### PR TITLE
Add gitignore whitelist on test/e2e/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ _tmp
 bin/*
 coverage.out
 junit-metering.xml
+/test/e2e/HDFS-OLM-Upgrade/pre-upgrade/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@ _tmp
 bin/*
 coverage.out
 junit-metering.xml
-/test/e2e/HDFS-OLM-Upgrade/pre-upgrade/logs/
+# this causes a whitelist on /test/e2e, add subdirs you want _in_ git
+/test/e2e/*
+# whitelist testdata subdir
+!test/e2e/testdata/


### PR DESCRIPTION
Generalized to a whitelist on test/e2e. Subdirectories appear after running e2e tests and it would be good to automatically ignore them.