### PR TITLE
Bug 1829836: Fix performance issues when deploying Metering on Ansible 2.9.6+ versions.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -28,8 +28,7 @@ RUN ln -f -s /tini /usr/bin/tini
 # 1. botocore and boto3 are used by the aws-related modules (aws_s3)
 # 2. netaddr is needed to use the ipv4/ipv6 jinja filter
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
-RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr
-RUN pip install --upgrade ansible==2.8
+RUN pip install --no-cache-dir --upgrade ansible~=2.9 openshift botocore boto3 cryptography netaddr
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -3,7 +3,7 @@ FROM openshift/ose-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/ose-cli:latest as cli
 # real base
-FROM openshift/ose-ansible-operator:latest
+FROM openshift/ose-ansible-operator:4.5
 
 USER root
 RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools tini python-netaddr python2-botocore python2-boto3 python2-openshift python2-cryptography openssl" \
@@ -16,7 +16,7 @@ COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 
-RUN yum -y update python2-openshift python2-cryptography
+RUN yum -y update python2-openshift python2-cryptography ansible~=2.9
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Hive TLS-related secrets
   block:
   - name: Check for the existence of the Hive Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.metastore.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: hive_metastore_tls_buf
 
   - name: Check for the existence of the Hive Server Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.metastoreTLS.secretName }}"
@@ -31,7 +31,7 @@
     register: hive_server_client_tls_buf
 
   - name: Check for the existence of the Hive Server TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
@@ -2,7 +2,7 @@
 
 # Get the Openshift cluster's networking config object
 - name: Check the IP version infrastructure provisioned
-  k8s_facts:
+  k8s_info:
     api_version: "config.openshift.io/v1"
     kind: Network
     name: cluster
@@ -31,7 +31,7 @@
 # Cluster Proxy Configuration
 #
 - name: Check if the cluster-wide Proxy configured
-  k8s_facts:
+  k8s_info:
     api_version: "config.openshift.io/v1"
     kind: Proxy
     name: cluster

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Presto TLS-related secrets
   block:
   - name: Check for the existence of the Presto TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: presto_secret_tls_buf
 
   - name: Check for the existence of the Presto Auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.auth.secretName }}"
@@ -31,7 +31,7 @@
     register: presto_secret_auth_buf
 
   - name: Check for the existence of the Presto-Hive client TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.connectors.hive.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -6,7 +6,7 @@
 - name: Check for the existence of the reporting-operator Presto TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Presto client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.auth.secretName }}"
@@ -52,7 +52,7 @@
 - name: Check for the existence of reporting-operator Hive TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Hive client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.hive.auth.secretName }}"
@@ -92,7 +92,7 @@
 - name: Check for the existence of reporting-operator authProxy-related secret data
   block:
   - name: Check for the existence of the reporting-operator authProxy cookie seed secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.authProxy.cookie.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -7,7 +7,7 @@
 - name: Check for the existence of the Metering Root CA secret
   block:
   - name: Check if Root CA secret already exists
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -28,7 +28,7 @@
       when: meteringconfig_storage_s3_create_bucket
 
     - name: Attempt to obtain the AWS credentials secret in the "{{ meta.namespace}}" namespace
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_storage_s3_aws_credentials_secret_name }}"
@@ -114,7 +114,7 @@
 - name: Get azure storage account name
   block:
     - name: Get Azure storage credentials secret
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_spec.storage.hive.azure.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Query for {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector }} to delete
-  k8s_facts:
+  k8s_info:
     api_version: "{{ to_delete_item.api_version | default(omit) }}"
     kind: "{{ to_delete_item.kind }}"
     namespace: "{{ namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Finalize the set of meteringconfig default values
+  set_fact:
+    meteringconfig_default_values: "{{ meteringconfig_default_values }}"
+
 - name: Validate Configurations
   include_tasks: validate.yml
 


### PR DESCRIPTION
In 2.9.6, changes were made to how the template caching mechanism works. In previous versions, all variables (i.e. jinja2 expressions) were being cached, instead of the intended behavior which is a single variable gets cached. This was obviously problematic, especially in the case where you're trying to generate a password a couple of times, which meant the first password result gets cached, and any subsequent calls to generating passwords would result in the value of the first, cached password being assigned to the corresponding variable. 

In the case of Metering, our Ansible role heavily relies on the notion of lazy evaluation - Ansible evaluates any variables at the last possible second. When this change to 2.9.6 was made, Metering saw a significant performance degradation, going from an average of 3-7 minutes to finish role execution, to 45+ minutes.

This was because we were relying on a buggy implementation of the templating caching mechanism. In our current implementation, we pass a variable to the name field of the `k8s_info` module. This meant that this module needed to make a filesystem lookup call many, many times for a particular value stored in this `meteringconfig_spec` variable, which is a large value dictionary and essentially serves as the single source of truth that Metering references.

A more concrete example:
```yaml
ASK [meteringconfig : Check for the existence of the Presto TLS secret] *******
task path: /opt/ansible/roles/meteringconfig/tasks/configure_presto_tls.yml:15
 
Wednesday 29 April 2020  21:43:56 +0000 (0:00:00.380)       0:00:38.695 *******
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
 
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
...
```

That variable in turn also relies on the value of the `meteringconfig_default_values`, which is a dictionary containing the default helm chart values. Previously, the result of that expression was cached. Now, due to how lazy evaluation works, the `meteringconfig_default_values` needed to be re-evaluated every time it's used, causing the aforementioned performance issues. The workaround is to cache or finalize, for a lack of a better phrase, the resultant of this `meteringconfig_default_values` expression.

This would help performance as we're no longer re-evaluating this variable every time we want to template something, and all changes made go through the meteringconfig_spec dictionary so there's no risk of creating this variable early in the role.

Also included in the changeset is the switch to the  [`k8s_info` module](https://docs.ansible.com/ansible/latest/modules/k8s_info_module.html), as the `k8s_facts` module was depreciated in 2.9, and the `k8s_info` has the same usage. 