### PR TITLE
Bug 1829833: Replace all instances of the depreciated k8s_facts module with k8s_info.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -3,7 +3,6 @@ FROM quay.io/openshift/origin-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli
 # the base image is the ansible-operator's origin images
-# TODO: stop using the latest tag for base images
 FROM quay.io/openshift/origin-ansible-operator:latest
 
 USER root
@@ -29,12 +28,8 @@ RUN ln -f -s /tini /usr/bin/tini
 # 1. botocore and boto3 are used by the aws-related modules (aws_s3)
 # 2. netaddr is needed to use the ipv4/ipv6 jinja filter
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
-# TODO: the ansible-operator base image uses setuptools >= 45.2.0 which needs python 3.5 so this is a temporary fix
 RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr "setuptools<=45.1.0"
-# In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
-# we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
-# TODO: revert this change once the issue mentioned above is resolved.
-RUN pip install --upgrade ansible==2.8
+RUN pip install --upgrade "ansible<2.9.6"
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -16,7 +16,7 @@ COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN ln -f -s /usr/bin/oc /usr/bin/kubectl
 
-RUN yum -y update python2-openshift python2-cryptography
+RUN yum -y update python2-openshift python2-cryptography "ansible<2.9.6"
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Hive TLS-related secrets
   block:
   - name: Check for the existence of the Hive Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.metastore.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: hive_metastore_tls_buf
 
   - name: Check for the existence of the Hive Server Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.metastoreTLS.secretName }}"
@@ -31,7 +31,7 @@
     register: hive_server_client_tls_buf
 
   - name: Check for the existence of the Hive Server TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
@@ -2,7 +2,7 @@
 
 # Get the Openshift cluster's networking config object
 - name: Check the IP version infrastructure provisioned
-  k8s_facts:
+  k8s_info:
     api_version: "config.openshift.io/v1"
     kind: Network
     name: cluster

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Presto TLS-related secrets
   block:
   - name: Check for the existence of the Presto TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: presto_secret_tls_buf
 
   - name: Check for the existence of the Presto Auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.auth.secretName }}"
@@ -31,7 +31,7 @@
     register: presto_secret_auth_buf
 
   - name: Check for the existence of the Presto-Hive client TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.connectors.hive.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -6,7 +6,7 @@
 - name: Check for the existence of the reporting-operator Presto TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Presto client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.auth.secretName }}"
@@ -52,7 +52,7 @@
 - name: Check for the existence of reporting-operator Hive TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Hive client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.hive.auth.secretName }}"
@@ -92,7 +92,7 @@
 - name: Check for the existence of reporting-operator authProxy-related secret data
   block:
   - name: Check for the existence of the reporting-operator authProxy cookie seed secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.authProxy.cookie.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -7,7 +7,7 @@
 - name: Check for the existence of the Metering Root CA secret
   block:
   - name: Check if Root CA secret already exists
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -24,7 +24,7 @@
         msg: "storage.hive.s3.secretName cannot be empty"
 
     - name: Obtaining AWS credentials to configure S3 bucket
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_storage_s3_aws_credentials_secret_name }}"
@@ -104,7 +104,7 @@
 - name: Get azure storage account name
   block:
     - name: Get Azure storage credentials secret
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_spec.storage.hive.azure.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Query for {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector }} to delete
-  k8s_facts:
+  k8s_info:
     api_version: "{{ to_delete_item.api_version | default(omit) }}"
     kind: "{{ to_delete_item.kind }}"
     namespace: "{{ namespace }}"


### PR DESCRIPTION
When using the 2.9.6 Ansible version, the time it takes for Metering to finish its role execution jumps from 3-5 minutes to ~35-40 minutes. If we increase the verbosity of the ansible logs for the Metering deployment, in 2.9.6, we see that the `k8s_facts` tasks are making a file lookup call orders of magnitude more often, whereas before, that file lookup call was made once or twice.

A more concrete example:
```yaml
ASK [meteringconfig : Check for the existence of the Presto TLS secret] *******
task path: /opt/ansible/roles/meteringconfig/tasks/configure_presto_tls.yml:15

Wednesday 29 April 2020  21:43:56 +0000 (0:00:00.380)       0:00:38.695 *******
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
...
```

If we pin the Ansible version in both the be less than 2.9.6 and update to the [`k8s_info` module](https://docs.ansible.com/ansible/latest/modules/k8s_info_module.html), the performance issues are resolved and that file lookup call is only made once or twice.
 