### PR TITLE
Makefile: Stop passing EXTRA_TEST_FLAGS to the e2e make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ unit-docker: metering-src-docker-build
 		make unit
 
 e2e: $(DEPLOY_METERING_BIN_OUT)
-	EXTRA_TEST_FLAGS="-run TestManualMeteringInstall" hack/e2e.sh
+	hack/e2e.sh
 
 # TODO: revert when https://bugzilla.redhat.com/show_bug.cgi?id=1825330 has been resolved
 e2e-upgrade: $(DEPLOY_METERING_BIN_OUT)


### PR DESCRIPTION
In the case where you only want to run the manual e2e tests and not the upgrade tests, you would need to specify `EXTRA_TEST_FLAGS="-run TestManualMeteringInstall"`.