### PR TITLE
Bug 1829072: Fix all of the k8s_event module instances.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/library/k8s_event.py
+++ b/images/metering-ansible-operator/roles/meteringconfig/library/k8s_event.py
@@ -228,7 +228,7 @@ EVENT_ARG_SPEC = {
     "merge_type": {"type": "list", "choices": ["json", "merge", "strategic-merge"]},
     "message": {"type": "str", "required": True},
     "reason": {"type": "str", "required": True},
-    "reportingComponent": {"type": "str", "required": True},
+    "reportingComponent": {"type": "str"},
     "type": {"choices": ["Normal", "Warning"]},
     "source": {
         "type": "dict",

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting.yml
@@ -1,38 +1,36 @@
 ---
 
-- name: Query Kubernetes for API version
-  command: kubectl version -o json
-  register: kube_version
-
-- name: Set default ReportDataSources to use based on Kubernetes version
-  block:
-    - name: Log Kubernetes version
-      debug:
-        msg: |
-          Kubernetes Minor Version: {{ kube_minor_version }}
-          Kubernetes version at least 1.14: {{ kube_version_at_least_1_14 }}
-
-    - name: Set default ReportDataSources to use based on Kubernetes version
-      set_fact:
-        meteringconfig_reporting_enable_post_kube_1_14_datasources: "{{ kube_version_at_least_1_14 }}"
-  vars:
-    kube_minor_version: "{{ (kube_version.stdout | from_json | json_query('serverVersion.minor')).rstrip('+') }}"
-    kube_version_at_least_1_14: "{{ ((kube_minor_version | int) >= 14) | bool }}"
-
-- name: Log Events for Configuring Reporting
+- name: Log event for starting the reporting configuration
   k8s_event:
     state: present
-    name: Configure Reporting resources
+    name: metering-operator-configuring-reporting
     namespace: "{{ meta.namespace }}"
-    message: Configure reporting
-    reason: Created
-    reportingComponent: Reporting components
+    message: Configuring reporting for the metering-ansible-operator
+    reason: Started
     type: Normal
     source:
-      component: Metering components
+      component: metering-ansible-operator
     involvedObject:
       apiVersion: metering.openshift.io
       kind: MeteringConfig
       name: "{{ meta.name }}"
       namespace: "{{ meta.namespace }}"
 
+- name: Query Kubernetes for API version
+  command: kubectl version -o json
+  register: kube_version
+
+- name: Set default ReportDataSources to use based on Kubernetes version
+  block:
+  - name: Log Kubernetes version
+    debug:
+      msg: |
+        Kubernetes Minor Version: {{ kube_minor_version }}
+        Kubernetes version at least 1.14: {{ kube_version_at_least_1_14 }}
+
+  - name: Set default ReportDataSources to use based on Kubernetes version
+    set_fact:
+      meteringconfig_reporting_enable_post_kube_1_14_datasources: "{{ kube_version_at_least_1_14 }}"
+  vars:
+    kube_minor_version: "{{ (kube_version.stdout | from_json | json_query('serverVersion.minor')).rstrip('+') }}"
+    kube_version_at_least_1_14: "{{ ((kube_minor_version | int) >= 14) | bool }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -8,6 +8,22 @@
       message: "Configuring Hive storage"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for configuring storage
+  k8s_event:
+    state: present
+    name: metering-operator-configuring-storage
+    namespace: "{{ meta.namespace }}"
+    message: Configuring storage for the metering-ansible-operator
+    reason: Started
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 #
 # Configure S3 section
 #
@@ -225,21 +241,3 @@
       status: "True"
       message: "Finished configuring Hive storage"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Configuring Storage
-  k8s_event:
-    state: present
-    name: Configuring Storage Event
-    namespace: "{{ meta.namespace }}"
-    message: Configure Storage
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -10,6 +10,22 @@
         message: "Configuring TLS"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+  - name: Log event for configuring the TLS-related tasks
+    k8s_event:
+      state: present
+      name: metering-operator-configuring-tls
+      namespace: "{{ meta.namespace }}"
+      message: Configuring TLS for the metering-ansible-operator
+      reason: Started
+      type: Normal
+      source:
+        component: metering-ansible-operator
+      involvedObject:
+        apiVersion: metering.openshift.io
+        kind: MeteringConfig
+        name: "{{ meta.name }}"
+        namespace: "{{ meta.namespace }}"
+
   - name: Create temporary directory to store all the necessary certificates/keys
     tempfile:
       suffix: certificates
@@ -53,21 +69,3 @@
       status: "True"
       message: "Finished configuring TLS"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for validating TLS
-  k8s_event:
-    state: present
-    name: Validate TLS
-    namespace: "{{ meta.namespace }}"
-    message: Validating TLS
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hdfs.yml
@@ -8,6 +8,22 @@
       message: "Reconciling HDFS resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling the hdfs resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-hdfs
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling HDFS resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy hdfs resources
   include_tasks: deploy_resources.yml
   vars:
@@ -66,20 +82,3 @@
       status: "True"
       message: "Finished reconciling HDFS resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling HDFS
-  k8s_event:
-    state: present
-    name: Reconcile Hdfs Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile HDFS
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_hive.yml
@@ -8,6 +8,22 @@
       message: "Reconciling Hive resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling the Hive resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-hive
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling Hive resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy hive resources
   include_tasks: deploy_resources.yml
   vars:
@@ -85,20 +101,3 @@
       status: "True"
       message: "Finished reconciling Hive resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Hive
-  k8s_event:
-    state: present
-    name: Reconcile Hive Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Hive
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
@@ -8,6 +8,22 @@
       message: "Reconciling Metering resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling the metering resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-metering
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling metering resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy metering resources
   include_tasks: deploy_resources.yml
   vars:
@@ -31,20 +47,3 @@
       status: "True"
       message: "Finished reconciling Metering resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Metering
-  k8s_event:
-    state: present
-    name: Reconcile Metering Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Metering
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_monitoring.yml
@@ -8,6 +8,22 @@
       message: "Reconciling monitoring resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling the monitoring resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-monitoring
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling monitoring resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy monitoring resources
   include_tasks: deploy_resources.yml
   vars:
@@ -41,20 +57,3 @@
       status: "True"
       message: "Finished reconciling monitoring resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Monitoring
-  k8s_event:
-    state: present
-    name: Reconcile Monitoring Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Monitoring
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_presto.yml
@@ -8,6 +8,22 @@
       message: "Reconciling Presto resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling the Presto resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-presto
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling Presto resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy presto resources
   include_tasks: deploy_resources.yml
   vars:
@@ -84,20 +100,3 @@
       status: "True"
       message: "Finished reconciling Presto resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Presto
-  k8s_event:
-    state: present
-    name: Reconcile Presto Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Presto
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting.yml
@@ -8,6 +8,22 @@
       message: "Reconciling reporting resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling the reporting resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-reporting
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling reporting resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy reporting resources
   include_tasks: deploy_resources.yml
   vars:
@@ -74,20 +90,3 @@
       status: "True"
       message: "Finished reconciling reporting resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reconciling Reporting
-  k8s_event:
-    state: present
-    name: Reconcile Reporting Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Reporting
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_reporting_operator.yml
@@ -8,6 +8,22 @@
       message: "Reconciling reporting-operator resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for reconciling reporting-operator resources
+  k8s_event:
+    state: present
+    name: metering-operator-reconciling-reporting-operator
+    namespace: "{{ meta.namespace }}"
+    message: Reconciling reporting-operator resources
+    reason: Reconciling
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 - name: Deploy reporting-operator resources
   include_tasks: deploy_resources.yml
   vars:
@@ -96,20 +112,3 @@
       status: "True"
       message: "Finished reconciling reporting-operator resources"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for Reporting Operator
-  k8s_event:
-    state: present
-    name: Reconcile Reporting Operator Event
-    namespace: "{{ meta.namespace }}"
-    message: Reconcile Reporting Operator
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/update_meteringconfig_status.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/update_meteringconfig_status.yml
@@ -9,6 +9,25 @@
     conditions: "{{ [ current_conditions ] }}"
   when: current_conditions is defined
 
-- fail:
-    msg: "Failing role execution after updating the MeteringConfig.Status"
+- block:
+  - name: Log event for role failure
+    k8s_event:
+      state: present
+      name: metering-operator-failing-role-event
+      namespace: "{{ meta.namespace }}"
+      message: "Error reconciling: {{ ansible_failed_result.msg }}"
+      reason: FailedRole
+      type: Warning
+      source:
+        component: metering-ansible-operator
+      involvedObject:
+        apiVersion: metering.openshift.io
+        kind: MeteringConfig
+        name: "{{ meta.name }}"
+        namespace: "{{ meta.namespace }}"
+    when: ansible_failed_result is defined and ansible_failed_result.msg | length > 0
+
+  - name: Fail role execution after encountering an error
+    fail:
+      msg: "Failing role execution after updating the MeteringConfig.Status"
   when: end_play_after_updating_status is defined and end_play_after_updating_status

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
@@ -8,6 +8,22 @@
       message: "Starting the validation process"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+- name: Log event for validating MeteringConfig configuration
+  k8s_event:
+    state: present
+    name: metering-operator-validating-configuration
+    namespace: "{{ meta.namespace }}"
+    message: Validating the user-provided configuration
+    reason: Validating
+    type: Normal
+    source:
+      component: metering-ansible-operator
+    involvedObject:
+      apiVersion: metering.openshift.io
+      kind: MeteringConfig
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+
 #
 # Validate OCP-only features were properly disabled
 #
@@ -91,20 +107,3 @@
       status: "True"
       message: "Finished the validation process"
       lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-
-- name: Log Events for validating configurations
-  k8s_event:
-    state: present
-    name: Validate Configuration
-    namespace: "{{ meta.namespace }}"
-    message: Validate Configurations
-    reason: Created
-    reportingComponent: Reporting components
-    type: Normal
-    source:
-      component: Metering components
-    involvedObject:
-      apiVersion: metering.openshift.io
-      kind: MeteringConfig
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"


### PR DESCRIPTION
Previously, all instances of the `k8s_event` module were using an invalid `k8s_event.name` configuration. This produced an error like the following:

```yaml
TASK [meteringconfig : Log Events for validating configurations] ***************
task path: /opt/ansible/roles/meteringconfig/tasks/validate.yml:91
Tuesday 28 April 2020  18:09:29 +0000 (0:00:00.365)       0:00:14.305 ********* 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: MaxRetryError: HTTPConnectionPool(host='localhost', port=8888): Max retries exceeded with url: /api/v1/namespaces/openshift-metering/events/Validate Configuration (Caused by ProtocolError('Connection aborted.', InvalidURL("URL can't contain control characters. '/api/v1/namespaces/openshift-metering/events/Validate Configuration' (found at least ' ')",)))
fatal: [localhost]: FAILED! => {"changed": false, "msg": "HTTPConnectionPool(host='localhost', port=8888): Max retries exceeded with url: /api/v1/namespaces/openshift-metering/events/Validate Configuration (Caused by ProtocolError('Connection aborted.', InvalidURL(\"URL can't contain control characters. '/api/v1/namespaces/openshift-metering/events/Validate Configuration' 
```

This `k8s_event.name` field directly corresponds to the [traditional `metadata.name`](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) for a k8s resource, which is how kubernetes refers to an object in a resource URL. This error is produced as the previous configuration(s) had invalid control characters being passed to the `k8s_event` module implementation.

On top of this, I changed the `k8s_event.reportingComponent` to be an optional field as it's not directly applicable to our use case in the metering-ansible-operator, and many of the core events often don't utilize this field.

Other changes that were made:
- Substituting the `source.component` to be the metering-ansible-operator, as "Metering Component" doesn't provide much value and it's difficult to interpret from that source what controller is responsible for firing off this event.
- Reorganizing the `k8s_event.reason`, `k8s_event.message`, and `k8s_event.state` to better reflect the current state of the metering-ansible-operator reconciliation effort.
- In the case of an error, i.e. a user-provided configuration was invalid, only the status field of the `MeteringConfig` custom resource was updated, and no event was fired off warning a user that they might need to take manually intervene.  

