### PR TITLE
Bug 1829836: Remove the ansible_failed_task variable from all block/rescue instances.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -4,7 +4,21 @@
 # Validate user-provided Hive TLS configuration when top-level spec.tls.enabled is set to false
 #
 - name: Validate the user-provided Hive TLS configuration
-  include_tasks: validate_hive_tls.yml
+  block:
+  - include_tasks: validate_hive_tls.yml
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not meteringconfig_tls_enabled
 
 #

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -4,7 +4,21 @@
 # Validate user-provided Presto TLS configuration when top-level spec.tls.enabled is set to false
 #
 - name: Validate the user-provided Presto TLS configuration
-  include_tasks: validate_presto_tls.yml
+  block:
+  - include_tasks: validate_presto_tls.yml
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not meteringconfig_tls_enabled
 
 #

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -86,7 +86,21 @@
 # Reporting Operator Openshift Auth-Proxy
 #
 - name: Validate the user-provided authProxy configuration
-  include_tasks: validate_reporting_operator_tls.yml
+  block:
+  - include_tasks: validate_reporting_operator_tls.yml
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not meteringconfig_tls_enabled
 
 - name: Check for the existence of reporting-operator authProxy-related secret data

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -57,10 +57,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   vars:
     s3_credentials_secret_exists: "{{ operator_s3_credentials_secret.resources and operator_s3_credentials_secret.resources | length > 0 }}"
     s3_use_dualstack_endpoint: "{{ _ocp_enabled_use_ipv6_networking }}"
@@ -102,10 +105,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 's3Compatible'
 
 #
@@ -135,10 +141,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 'azure' and not meteringconfig_storage_azure_create_secret
 
 - name: Configure Azure Storage
@@ -161,10 +170,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 'azure' and meteringconfig_storage_azure_create_secret
 
 #
@@ -197,10 +209,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 'gcs'
 
 - include_tasks: update_meteringconfig_status.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -30,14 +30,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   always:
   - name: Cleanup the temporary directory which held the certificates and keys
     file:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -11,18 +11,20 @@
     no_log: "{{ not meteringconfig_log_helm_template }}"
     register: template_results
   rescue:
-    - include_tasks: update_meteringconfig_status.yml
-      vars:
-        failed_result: "{{ ansible_failed_result.results | first }}"
-        end_play_after_updating_status: true
-        current_conditions:
-          type: "Invalid"
-          status: "True"
-          message: |
-            "Failed command: {{ failed_result.cmd | replace('...', '') | to_nice_yaml(indent=8, width=1337) }} "
-            "Error message: {{ failed_result.stderr_lines | to_nice_yaml }}"
-          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-      when: ansible_failed_result and ansible_failed_result.results and (ansible_failed_result.results | length > 0)
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      failed_result: "{{ ansible_failed_result.results | first }}"
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |-
+          "{{ failed_result.stderr | to_nice_yaml }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.results is defined
+    - ansible_failed_result.results | length > 0
 
 - name: Add prune label to resources
   vars:
@@ -62,19 +64,21 @@
       definition: "{{ updated_template_results | flatten }}"
       merge_type: ['merge', 'strategic-merge']
   rescue:
-      # Note for ansible_failed_return:
-      # there's no guarantee that more fields besides msg will be available
-      # as the return object varies depending on the type of error encountered
-    - include_tasks: update_meteringconfig_status.yml
-      vars:
-        end_play_after_updating_status: true
-        current_conditions:
-          type: "Invalid"
-          status: "True"
-          message: |
-            "{{ ansible_failed_result.msg }}"
-          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-      when: ansible_failed_result is defined and (ansible_failed_result.msg | length > 0)
+    # Note for ansible_failed_return:
+    # there's no guarantee that more fields besides msg will be available
+    # as the return object varies depending on the type of error encountered
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: template_results.changed and resource is not none
 
 - name: Prune resources
@@ -87,13 +91,16 @@
       loop_var: resource
       label: "{{ resource.template_file }}"
   rescue:
-    - include_tasks: update_meteringconfig_status.yml
-      vars:
-        end_play_after_updating_status: true
-        current_conditions:
-          type: "Invalid"
-          status: "True"
-          message: |
-            "{{ ansible_failed_result }}"
-          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not (resource.create | default(true))

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -20,6 +20,11 @@
 - name: Configure Reporting
   include_tasks: configure_reporting.yml
 
+- name: Finalize the set of overall meteringconfig values
+  set_fact:
+    meteringconfig_spec: "{{ meteringconfig_spec }}"
+  no_log: true
+
 - name: Store MeteringConfig spec into values file
   copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
@@ -39,14 +39,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: meteringconfig_ocp_disabled
 
 #
@@ -71,14 +73,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
 
 - include_tasks: update_meteringconfig_status.yml
   vars:
@@ -104,4 +108,3 @@
       kind: MeteringConfig
       name: "{{ meta.name }}"
       namespace: "{{ meta.namespace }}"
-

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
@@ -36,14 +36,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: hiveStorageType == 'gcs'
 
 #
@@ -66,14 +68,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: hiveStorageType == 'azure' and not meteringconfig_storage_azure_create_secret
 
 #
@@ -109,12 +113,14 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: hiveStorageType == 's3Compatible'

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
@@ -1,4 +1,7 @@
 ---
+#
+# Note: all of these tasks are wrapped in a block/rescue at the task file call site
+#
 
 #
 # Validate the user-provided cert/key/caCert fields are non-empty when top-level spec.tls.enabled is false
@@ -29,17 +32,6 @@
       that:
         - meteringconfig_spec.hive.spec.metastore.config.tls.enabled and meteringconfig_spec.hive.spec.metastore.config.auth.enabled
       msg: "Invalid configuration for hive.spec.metastore.config.tls: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_metastore_tls_secret
 
 - name: Validate user-provided Hive Server TLS fields are non-empty
@@ -67,17 +59,6 @@
       that:
         - meteringconfig_spec.hive.spec.server.config.tls.enabled and meteringconfig_spec.hive.spec.server.config.auth.enabled
       msg: "Invalid configuration for hive.spec.server.config.tls: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_server_tls_secret
 
 - name: Validate user-provided Hive Server Auth (metastoreTLS) fields are non-empty
@@ -99,15 +80,4 @@
       that:
         - meteringconfig_spec.hive.spec.server.config.metastoreTLS.key != ""
       msg: "hive.spec.server.config.metastoreTLS.key cannot be empty if createSecret: true and secretName != ''"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_server_auth_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
@@ -1,4 +1,7 @@
 ---
+#
+# Note: all of these tasks are wrapped in a block/rescue at the task file call site
+#
 
 #
 # Validate the user-provided cert/key/caCert fields are non-empty when top-level spec.tls.enabled is false
@@ -22,17 +25,6 @@
       that:
         - meteringconfig_spec.presto.spec.config.tls.key != ""
       msg: "presto.spec.config.tls.key cannot be empty if createSecret: true and secretName != ''"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
@@ -60,17 +52,6 @@
       that:
         - meteringconfig_spec.presto.spec.config.tls.enabled and meteringconfig_spec.presto.spec.config.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_auth_secret
 
 - name: Validate that the user provided Presto/Hive client TLS fields are not empty
@@ -92,15 +73,4 @@
       that:
         - meteringconfig_spec.presto.spec.config.connectors.hive.tls.caCertificate != ""
       msg: "spec.presto.spec.config.connectors.hive.tls.caCertificate cannot be empty when createSecret is set to true"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_hive_tls_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
@@ -1,4 +1,7 @@
 ---
+#
+# Note: all of these tasks are wrapped in a block/rescue at the task file call site
+#
 
 #
 # Validate that the user-provided reporting-operator Presto fields were properly configured
@@ -10,17 +13,6 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.caCertificate != ""
       msg: "reporting-operator.spec.config.presto.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
@@ -42,17 +34,6 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.presto.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_auth_secret
 
 #
@@ -83,17 +64,6 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.hive.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.hive.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_secrets
 
 #
@@ -121,14 +91,3 @@
         - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.data != ""
       msg: "spec.reporting-operator.spec.authProxy.authenticatedEmails: secretName and/or data key(s) cannot be empty when enabled and createSecret is set to true"
     when: meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.enabled and meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.createSecret
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"


### PR DESCRIPTION
# Overview

With the template caching changes made in 2.9.6, having to evaluate the result of the `ansible_failed_task` expression was greatly slowing down the role and doesn't provide much value for debuggability purposes.

# Changed:

- Removed all `ansible_failed_task` references
- Normalized most of the status updates
- Stored the result of the `meteringconfig_spec` variable locally.

## Storing the result of the `meteringconfig_spec` variable locally

At that point in the role, we've finished overriding any variables that reference this `meteringconfig_spec` variable, which is a giant dictionary containing all of the overridden MeteringConfig default values, and we can safely store this result locally.

Before this change, we copied this variable to a tmp file that the `reconcile_*` task files reference to deploy metering-related resources:

```yaml
- name: Store MeteringConfig spec into values file
  copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml

- include_tasks: "{{ item }}"
  loop:
    - reconcile_metering.yml
    - reconcile_monitoring.yml
    - reconcile_hdfs.yml
    - reconcile_hive.yml
    - reconcile_presto.yml
    - reconcile_reporting_operator.yml
    - reconcile_reporting.yml
```

The problem, however, is that we still use this `meteringconfig_spec` variable under-the-hood to determine whether or not to create a resource:

```yaml
- name: Deploy presto resources
  include_tasks: deploy_resources.yml
  vars:
    values_file: /tmp/metering-values.yaml
    resources:
    ...
      - template_file: templates/presto/presto-auth-secrets.yaml
        apis: [ {kind: secret} ]
        prune_label_value: presto-auth-secrets
        create: "{{ meteringconfig_create_presto_auth_secrets }}"
```

Here, the `meteringconfig_create_presto_auth_secrets` variable is defined in the role's defaults/main.yml as the following:

```yaml
meteringconfig_create_presto_auth_secrets: "{{ _presto_spec.config.auth.enabled and _presto_spec.config.auth.createSecret | default(false) }}"
```

Where the value of this `_presto_spec` dictionary is pulled out of the result of `meteringconfig_spec.presto.spec`.

If we instead store the value of this variable locally before reconciling resources, role execution is greatly improved as we no longer need to template these variables (due to lazy evaluation) every time we're looping over this list of resource definitions.