### PR TITLE
Bug 1829833: Fix performance issues when deploying Metering on Ansible 2.9.6+ versions.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -3,8 +3,7 @@ FROM quay.io/openshift/origin-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli
 # the base image is the ansible-operator's origin images
-# TODO: stop using the latest tag for base images
-FROM quay.io/openshift/origin-ansible-operator:latest
+FROM quay.io/openshift/origin-ansible-operator:4.4
 
 USER root
 RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools openssl" \
@@ -31,10 +30,7 @@ RUN ln -f -s /tini /usr/bin/tini
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
 # TODO: the ansible-operator base image uses setuptools >= 45.2.0 which needs python 3.5 so this is a temporary fix
 RUN pip install --no-cache-dir --upgrade openshift botocore boto3 cryptography netaddr "setuptools<=45.1.0"
-# In order to use the 'ansible_failed_result' and 'ansible_failed_task' variables in a block/rescue,
-# we need to ensure that the 2.8 version is being used while this is fixed in 2.9 upstream.
-# TODO: revert this change once the issue mentioned above is resolved.
-RUN pip install --upgrade ansible==2.8
+RUN pip install --upgrade ansible~=2.9
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -4,7 +4,21 @@
 # Validate user-provided Hive TLS configuration when top-level spec.tls.enabled is set to false
 #
 - name: Validate the user-provided Hive TLS configuration
-  include_tasks: validate_hive_tls.yml
+  block:
+  - include_tasks: validate_hive_tls.yml
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not meteringconfig_tls_enabled
 
 #

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Hive TLS-related secrets
   block:
   - name: Check for the existence of the Hive Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.metastore.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: hive_metastore_tls_buf
 
   - name: Check for the existence of the Hive Server Metastore TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.metastoreTLS.secretName }}"
@@ -31,7 +31,7 @@
     register: hive_server_client_tls_buf
 
   - name: Check for the existence of the Hive Server TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.hive.spec.server.config.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
@@ -2,7 +2,7 @@
 
 # Get the Openshift cluster's networking config object
 - name: Check the IP version infrastructure provisioned
-  k8s_facts:
+  k8s_info:
     api_version: "config.openshift.io/v1"
     kind: Network
     name: cluster

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -4,7 +4,21 @@
 # Validate user-provided Presto TLS configuration when top-level spec.tls.enabled is set to false
 #
 - name: Validate the user-provided Presto TLS configuration
-  include_tasks: validate_presto_tls.yml
+  block:
+  - include_tasks: validate_presto_tls.yml
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not meteringconfig_tls_enabled
 
 #

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_presto_tls.yml
@@ -13,7 +13,7 @@
 - name: Check for the existence of Presto TLS-related secrets
   block:
   - name: Check for the existence of the Presto TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.tls.secretName }}"
@@ -22,7 +22,7 @@
     register: presto_secret_tls_buf
 
   - name: Check for the existence of the Presto Auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.auth.secretName }}"
@@ -31,7 +31,7 @@
     register: presto_secret_auth_buf
 
   - name: Check for the existence of the Presto-Hive client TLS secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.presto.spec.config.connectors.hive.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -6,7 +6,7 @@
 - name: Check for the existence of the reporting-operator Presto TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Presto client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.presto.auth.secretName }}"
@@ -52,7 +52,7 @@
 - name: Check for the existence of reporting-operator Hive TLS-related secrets
   block:
   - name: Check for the existence of the reporting-operator Hive client auth secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.config.hive.auth.secretName }}"
@@ -92,7 +92,7 @@
 - name: Check for the existence of reporting-operator authProxy-related secret data
   block:
   - name: Check for the existence of the reporting-operator authProxy cookie seed secret
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec['reporting-operator'].spec.authProxy.cookie.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -86,7 +86,21 @@
 # Reporting Operator Openshift Auth-Proxy
 #
 - name: Validate the user-provided authProxy configuration
-  include_tasks: validate_reporting_operator_tls.yml
+  block:
+  - include_tasks: validate_reporting_operator_tls.yml
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not meteringconfig_tls_enabled
 
 - name: Check for the existence of reporting-operator authProxy-related secret data

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_root_ca.yml
@@ -7,7 +7,7 @@
 - name: Check for the existence of the Metering Root CA secret
   block:
   - name: Check if Root CA secret already exists
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Secret
       name: "{{ meteringconfig_spec.tls.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -24,7 +24,7 @@
         msg: "storage.hive.s3.secretName cannot be empty"
 
     - name: Obtaining AWS credentials to configure S3 bucket
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_storage_s3_aws_credentials_secret_name }}"
@@ -104,7 +104,7 @@
 - name: Get azure storage account name
   block:
     - name: Get Azure storage credentials secret
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Secret
         name: "{{ meteringconfig_spec.storage.hive.azure.secretName }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -90,7 +90,7 @@
       assert:
         that:
           - meteringconfig_storage_s3Compatible_credentials_secret_name != ""
-        msg: "storage.hive.s3Compatible.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+        msg: "storage.hive.s3Compatible.secretName is used to reference existing secrets and must not be empty if createSecret is set to false"
       when: not meteringconfig_storage_s3Compatible_create_secret
   rescue:
     - include_tasks: update_meteringconfig_status.yml
@@ -181,14 +181,14 @@
       assert:
         that:
           - meteringconfig_storage_gcs_credentials_secret_name == ""
-        msg: "storage.hive.gcs.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+        msg: "storage.hive.gcs.secretName is only used to reference existing secrets and must be empty if creating new secrets"
       when: meteringconfig_storage_gcs_create_secret
 
     - name: Validate Metering gcs credentials
       assert:
         that:
           - meteringconfig_storage_gcs_credentials_secret_name != ""
-        msg: "storage.hive.gcs.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+        msg: "storage.hive.gcs.secretName is used to reference existing secrets and must be non-empty if createSecret is set to false"
       when: not meteringconfig_storage_gcs_create_secret
   rescue:
     - include_tasks: update_meteringconfig_status.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_storage.yml
@@ -53,10 +53,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   vars:
     s3_credentials_secret_exists: "{{ operator_s3_credentials_secret.resources and operator_s3_credentials_secret.resources | length > 0 }}"
     s3_use_dualstack_endpoint: "{{ _ocp_enabled_use_ipv6_networking }}"
@@ -95,10 +98,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 's3Compatible'
 
 - name: Get azure storage account name
@@ -125,10 +131,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 'azure' and not meteringconfig_storage_azure_create_secret
 
 - name: Configure Azure Storage
@@ -151,10 +160,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 'azure' and meteringconfig_storage_azure_create_secret
 
 - name: Configure GCS Storage
@@ -184,10 +196,13 @@
         current_conditions:
           type: "Invalid"
           status: "True"
-          message: "The task \"{{ ansible_failed_task.name }}\" failed with the following message: {{ ansible_failed_result.msg }}"
+          message: |
+            "{{ ansible_failed_result.msg }}"
           lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
         end_play_after_updating_status: true
-      when: ansible_failed_result and (ansible_failed_result.msg | length > 0)
+      when:
+      - ansible_failed_result is defined
+      - ansible_failed_result.msg | length > 0
   when: meteringconfig_storage_hive_storage_type == 'gcs'
 
 - include_tasks: update_meteringconfig_status.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_tls.yml
@@ -30,14 +30,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   always:
   - name: Cleanup the temporary directory which held the certificates and keys
     file:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -11,19 +11,20 @@
     no_log: "{{ not meteringconfig_log_helm_template }}"
     register: template_results
   rescue:
-    - include_tasks: update_meteringconfig_status.yml
-      vars:
-        failed_result: "{{ ansible_failed_result.results | first }}"
-        end_play_after_updating_status: true
-        current_conditions:
-          type: "Invalid"
-          status: "True"
-          message: |
-            "Failed command: {{ failed_result.cmd | replace('...', '') | to_nice_yaml(indent=8, width=1337) }} "
-            "Error message: {{ failed_result.stderr_lines | to_nice_yaml }}"
-          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-      when: ansible_failed_result and ansible_failed_result.results and (ansible_failed_result.results | length > 0)
-
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |-
+          "{{ failed_result.stderr | to_nice_yaml }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      failed_result: "{{ ansible_failed_result.results | first }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.results is defined
+    - ansible_failed_result.results | length > 0
 - name: Add prune label to resources
   vars:
     # Index into the template_results.results array to get the result of
@@ -62,19 +63,21 @@
       definition: "{{ updated_template_results | flatten }}"
       merge_type: ['merge', 'strategic-merge']
   rescue:
-      # Note for ansible_failed_return:
-      # there's no guarantee that more fields besides msg will be available
-      # as the return object varies depending on the type of error encountered
-    - include_tasks: update_meteringconfig_status.yml
-      vars:
-        end_play_after_updating_status: true
-        current_conditions:
-          type: "Invalid"
-          status: "True"
-          message: |
-            "{{ ansible_failed_result.msg }}"
-          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
-      when: ansible_failed_result is defined and (ansible_failed_result.msg | length > 0)
+    # Note for ansible_failed_return:
+    # there's no guarantee that more fields besides msg will be available
+    # as the return object varies depending on the type of error encountered
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: template_results.changed and resource is not none
 
 - name: Prune resources
@@ -87,13 +90,16 @@
       loop_var: resource
       label: "{{ resource.template_file }}"
   rescue:
-    - include_tasks: update_meteringconfig_status.yml
-      vars:
-        end_play_after_updating_status: true
-        current_conditions:
-          type: "Invalid"
-          status: "True"
-          message: |
-            "{{ ansible_failed_result }}"
-          lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: not (resource.create | default(true))

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/prune_resources.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Query for {{ resource.apis | map(attribute='kind') | join(', ') }} resources with selector {{ label_selector }} to delete
-  k8s_facts:
+  k8s_info:
     api_version: "{{ to_delete_item.api_version | default(omit) }}"
     kind: "{{ to_delete_item.kind }}"
     namespace: "{{ namespace }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Finalize the set of meteringconfig default values
+  set_fact:
+    meteringconfig_default_values: "{{ meteringconfig_default_values }}"
+  no_log: true
+
 - name: Validate Configurations
   include_tasks: validate.yml
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -20,6 +20,11 @@
 - name: Configure Reporting
   include_tasks: configure_reporting.yml
 
+- name: Finalize the set of overall meteringconfig values
+  set_fact:
+    meteringconfig_spec: "{{ meteringconfig_spec }}"
+  no_log: true
+
 - name: Store MeteringConfig spec into values file
   copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml
 

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate.yml
@@ -39,14 +39,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: meteringconfig_ocp_disabled
 
 #
@@ -71,14 +73,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
 
 - include_tasks: update_meteringconfig_status.yml
   vars:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
@@ -4,10 +4,24 @@
 # Validate the Hive storage configuration
 #
 - name: Validate the user-provided hive storage type matches a supported storage
-  assert:
-    that:
-      - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure', 'gcs' , 's3Compatible']
-    msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of hdfs, s3, azure, gcs, s3Compatible or sharedPVC"
+  block:
+  - assert:
+      that:
+        - hiveStorageType is not undefined and hiveStorageType in ['s3', 'sharedPVC', 'hdfs', 'azure', 'gcs' , 's3Compatible']
+      msg: "Invalid spec.storage.hive.type: '{{ hiveStorageType }}', must be one of hdfs, s3, azure, gcs, s3Compatible or sharedPVC"
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
 
 #
 # Validate GCS storage configuration
@@ -36,14 +50,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: hiveStorageType == 'gcs'
 
 #
@@ -66,14 +82,16 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: hiveStorageType == 'azure' and not meteringconfig_storage_azure_create_secret
 
 #
@@ -109,12 +127,14 @@
   rescue:
   - include_tasks: update_meteringconfig_status.yml
     vars:
-      end_play_after_updating_status: true
       current_conditions:
         type: "Invalid"
         status: "True"
         message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
+          "{{ ansible_failed_result.msg }}"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+      end_play_after_updating_status: true
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when: hiveStorageType == 's3Compatible'

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_storage.yml
@@ -38,14 +38,14 @@
     assert:
       that:
         - meteringconfig_storage_gcs_credentials_secret_name == ""
-      msg: "storage.hive.gcs.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+      msg: "storage.hive.gcs.secretName is only used to reference existing secrets and must be empty if creating new secrets"
     when: meteringconfig_storage_gcs_create_secret
 
   - name: Validate that the GCS secretName is non-empty when createSecret is false
     assert:
       that:
         - meteringconfig_storage_gcs_credentials_secret_name != ""
-      msg: "storage.hive.gcs.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+      msg: "storage.hive.gcs.secretName is used to reference existing secrets and must be non-empty if createSecret is set to false"
     when: not meteringconfig_storage_gcs_create_secret
   rescue:
   - include_tasks: update_meteringconfig_status.yml
@@ -115,14 +115,14 @@
     assert:
       that:
         - meteringconfig_storage_s3Compatible_credentials_secret_name == ""
-      msg: "storage.hive.s3Compatible.secretName is only used to reference existing secrets, must be empty if creating new secrets"
+      msg: "storage.hive.s3Compatible.secretName is only used to reference existing secrets and must be empty if creating new secrets"
     when: meteringconfig_storage_s3Compatible_create_secret
 
   - name: Validate that createSecret is false when secretName is non-empty
     assert:
       that:
         - meteringconfig_storage_s3Compatible_credentials_secret_name != ""
-      msg: "storage.hive.s3Compatible.secretName is used to reference existing secrets, must not be empty if creatSecret is set to false"
+      msg: "storage.hive.s3Compatible.secretName is used to reference existing secrets and must be non-empty if createSecret is set to false"
     when: not meteringconfig_storage_s3Compatible_create_secret
   rescue:
   - include_tasks: update_meteringconfig_status.yml

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_hive_tls.yml
@@ -1,4 +1,7 @@
 ---
+#
+# Note: all of these tasks are wrapped in a block/rescue at the task file call site
+#
 
 #
 # Validate the user-provided cert/key/caCert fields are non-empty when top-level spec.tls.enabled is false
@@ -29,17 +32,6 @@
       that:
         - meteringconfig_spec.hive.spec.metastore.config.tls.enabled and meteringconfig_spec.hive.spec.metastore.config.auth.enabled
       msg: "Invalid configuration for hive.spec.metastore.config.tls: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_metastore_tls_secret
 
 - name: Validate user-provided Hive Server TLS fields are non-empty
@@ -67,17 +59,6 @@
       that:
         - meteringconfig_spec.hive.spec.server.config.tls.enabled and meteringconfig_spec.hive.spec.server.config.auth.enabled
       msg: "Invalid configuration for hive.spec.server.config.tls: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_server_tls_secret
 
 - name: Validate user-provided Hive Server Auth (metastoreTLS) fields are non-empty
@@ -99,15 +80,4 @@
       that:
         - meteringconfig_spec.hive.spec.server.config.metastoreTLS.key != ""
       msg: "hive.spec.server.config.metastoreTLS.key cannot be empty if createSecret: true and secretName != ''"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_server_auth_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_presto_tls.yml
@@ -1,4 +1,7 @@
 ---
+#
+# Note: all of these tasks are wrapped in a block/rescue at the task file call site
+#
 
 #
 # Validate the user-provided cert/key/caCert fields are non-empty when top-level spec.tls.enabled is false
@@ -22,17 +25,6 @@
       that:
         - meteringconfig_spec.presto.spec.config.tls.key != ""
       msg: "presto.spec.config.tls.key cannot be empty if createSecret: true and secretName != ''"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
@@ -60,17 +52,6 @@
       that:
         - meteringconfig_spec.presto.spec.config.tls.enabled and meteringconfig_spec.presto.spec.config.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_auth_secret
 
 - name: Validate that the user provided Presto/Hive client TLS fields are not empty
@@ -92,15 +73,4 @@
       that:
         - meteringconfig_spec.presto.spec.config.connectors.hive.tls.caCertificate != ""
       msg: "spec.presto.spec.config.connectors.hive.tls.caCertificate cannot be empty when createSecret is set to true"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_hive_tls_secret

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/validate_reporting_operator_tls.yml
@@ -1,4 +1,7 @@
 ---
+#
+# Note: all of these tasks are wrapped in a block/rescue at the task file call site
+#
 
 #
 # Validate that the user-provided reporting-operator Presto fields were properly configured
@@ -10,17 +13,6 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.caCertificate != ""
       msg: "reporting-operator.spec.config.presto.tls.caCertificate cannot be empty if createSecret: true and secretName != ''"
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_tls_secret
 
 - name: Validate that the user-provided Presto client Auth fields are not empty
@@ -42,17 +34,6 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.presto.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.presto.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_presto_auth_secret
 
 #
@@ -83,17 +64,6 @@
       that:
         - meteringconfig_spec['reporting-operator'].spec.config.hive.tls.enabled and meteringconfig_spec['reporting-operator'].spec.config.hive.auth.enabled
       msg: "Invalid configuration: you cannot enable auth but disable TLS."
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   when: meteringconfig_template_hive_secrets
 
 #
@@ -120,15 +90,6 @@
         - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.secretName != ""
         - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.data != ""
       msg: "spec.reporting-operator.spec.authProxy.authenticatedEmails: secretName and/or data key(s) cannot be empty when enabled and createSecret is set to true"
-    when: meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.enabled and meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.createSecret
-  rescue:
-  - include_tasks: update_meteringconfig_status.yml
-    vars:
-      end_play_after_updating_status: true
-      current_conditions:
-        type: "Invalid"
-        status: "True"
-        message: |
-          "Failed task name: {{ ansible_failed_task.name }}"
-          "Failed task message: {{ ansible_failed_result.msg }}"
-        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+    when:
+    - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.enabled
+    - meteringconfig_spec['reporting-operator'].spec.authProxy.authenticatedEmails.createSecret


### PR DESCRIPTION
# Overview

In 2.9.6, changes were made to how the template caching mechanism works. In previous versions, all variables (i.e. jinja2 expressions) were being cached, instead of the intended behavior which is a single variable gets cached. This was obviously problematic, especially in the case where you're trying to generate a password a couple of times, which meant the first password result gets cached, and any subsequent calls to generating passwords would result in the value of the first, cached password being assigned to the corresponding variable.

## Changes
- Replaced all instances of the depreciated `k8s_facts` module with the `k8s_info` module.
- Stored the result of the `meteringconfig_default_values` variable locally.
- Stored the result of the `meteringconfig_spec` variable locally.
- Removed all of the `ansible_failed_task` block/rescue references.
- Fixed misspelled`creatSecret` error messages.
- Updated the metering-ansible-operator's Dockerfile to stop pinning against the 2.8 Ansible release.

### Replacing `k8s_facts` module with `k8s_info`

In 2.9, the `k8s_facts` module was deprecated in favor of the [`k8s_info` module](https://docs.ansible.com/ansible/latest/modules/k8s_info_module.html). The usage was the same so this essentially just silences the Ansible warning message.

### Storing the result of the `meteringconfig_default_values` variable locally

In the case of Metering, our Ansible role heavily relies on the notion of lazy evaluation - Ansible evaluates any variables at the last possible second. When this change to 2.9.6 was made, Metering saw a significant performance degradation, going from an average of 3-7 minutes to finish role execution, to 45+ minutes.

This was because we were relying on a buggy implementation of the templating caching mechanism. In our current implementation, we pass a variable to the name field of the module. This meant that this module needed to make a filesystem lookup call many, many times for a particular value stored in this meteringconfig_spec variable, which is a large value dictionary and essentially serves as the single source of truth that Metering references.

A more concrete example:
```yaml
ASK [meteringconfig : Check for the existence of the Presto TLS secret] *******
task path: /opt/ansible/roles/meteringconfig/tasks/configure_presto_tls.yml:15

Wednesday 29 April 2020  21:43:56 +0000 (0:00:00.380)       0:00:38.695 *******
File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file

File lookup using /opt/ansible/charts/openshift-metering/values.yaml as file
...
```

That variable in turn also relies on the value of the `meteringconfig_default_values`, which is a dictionary containing the default helm chart values. Previously, the result of that expression was cached. Now, due to how lazy evaluation works, the `meteringconfig_default_values` needed to be re-evaluated every time it's used, causing the aforementioned performance issues. The workaround is to cache or finalize, for a lack of a better phrase, the resultant of this `meteringconfig_default_values` expression. This would help performance as we're no longer re-evaluating this variable every time we want to template something, and all changes made go through the meteringconfig_spec dictionary so there's no risk of creating this variable early in the role.

### Storing the result of the `meteringconfig` variable locally

At that point in the role, we've finished overriding any variables that reference this `meteringconfig_spec` variable, which is a giant dictionary containing all of the overridden MeteringConfig default values, and we can safely store this result locally.

Before this change, we copied this variable to a tmp file that the `reconcile_*` task files reference to deploy metering-related resources:

```yaml
- name: Store MeteringConfig spec into values file
  copy: content="{{ meteringconfig_spec }}" dest=/tmp/metering-values.yaml

- include_tasks: "{{ item }}"
  loop:
    - reconcile_metering.yml
    - reconcile_monitoring.yml
    - reconcile_hdfs.yml
    - reconcile_hive.yml
    - reconcile_presto.yml
    - reconcile_reporting_operator.yml
    - reconcile_reporting.yml
```

The problem, however, is that we still use this `meteringconfig_spec` variable under-the-hood to determine whether or not to create a resource:

```yaml
- name: Deploy presto resources
  include_tasks: deploy_resources.yml
  vars:
    values_file: /tmp/metering-values.yaml
    resources:
    ...
      - template_file: templates/presto/presto-auth-secrets.yaml
        apis: [ {kind: secret} ]
        prune_label_value: presto-auth-secrets
        create: "{{ meteringconfig_create_presto_auth_secrets }}"
```

Here, the `meteringconfig_create_presto_auth_secrets` variable is defined in the role's defaults/main.yml as the following:

```yaml
meteringconfig_create_presto_auth_secrets: "{{ _presto_spec.config.auth.enabled and _presto_spec.config.auth.createSecret | default(false) }}"
```

Where the value of this `_presto_spec` dictionary is pulled out of the result of `meteringconfig_spec.presto.spec`.

If we instead store the value of this variable locally before reconciling resources, role execution is greatly improved as we no longer need to template these variables (due to lazy evaluation) every time we're looping over this list of resource definitions.

### Removing all of the ansible_failed_task block/rescue references.

Like the other items mentioned above, this change has to do with the template caching changes. If a task wrapped in a block/rescue fails (e.g. a configuration failed our validation), then we attempt to update the `MeteringConfig` custom resource with this information. The problem, however, is that most of the failed tasks that get dropped to the rescue portion of the block use lazily evaluated variables, which means that it has to re-evaluate the contents of the task again and significantly slows down the role execution. That said, we use the `ansible_failed_task` solely for debuggability purposes, and that variable provides pretty low value in helping users or developers debug what went wrong with their Metering installation.

As long as we still have access to the `ansible_failed_result`, which is essentially the [registered](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#registering-variables) version of that failed task (and does not get affected by the template cache changes), we should have all the information we need to be able to produce better, more actionable errors.