### PR TITLE
pkg/deploy: Lower the initial CRD poll time.

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -30,7 +30,7 @@ const (
 	catalogSourceNamespace = "openshift-marketplace"
 
 	crdPollTimeout = 5 * time.Minute
-	crdInitialPoll = 3 * time.Second
+	crdInitialPoll = 1 * time.Second
 
 	hivetableFile         = "hive.crd.yaml"
 	prestotableFile       = "prestotable.crd.yaml"


### PR DESCRIPTION
For more installs, the MeteringConfig CRD should already be present so this is more of a quality of life change.