### PR TITLE
Bug 1831325: Stop returning an error when running the gather testing artifacts script.

### DIFF
--- a/test/deployframework/helpers.go
+++ b/test/deployframework/helpers.go
@@ -234,14 +234,10 @@ func runCleanupScript(logger logrus.FieldLogger, namespace, outputPath, scriptPa
 		errArr = append(errArr, fmt.Sprintf("failed to create a pipe from command output to stdout: %v", err))
 	}
 
+	scanner := bufio.NewScanner(cleanupStdout)
 	go func() {
-		scanner := bufio.NewScanner(cleanupStdout)
 		for scanner.Scan() {
-			line := scanner.Text()
-			logger.Infof(line)
-		}
-		if err := scanner.Err(); err != nil {
-			errArr = append(errArr, fmt.Sprintf("failed to read the command output: %v", err))
+			logger.Infof(scanner.Text())
 		}
 	}()
 


### PR DESCRIPTION
Occasionally, we get an error in the e2e suite that we're reading from a file that's already been closed. It appears there might be a race between reading from the stdout pipe and the cmd.Run() method. This would stop appending any read buffer errors to the overall function's error array and in most cases, capturing these errors provide very little value.