### PR TITLE
Bug 1837043: Mount the cluster's certificate authority bundle in the auth-proxy sidecar container.

### DIFF
--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -447,6 +447,11 @@ spec:
         resources:
 {{ toYaml $operatorValues.spec.authProxy.resources | indent 10 }}
         volumeMounts:
+{{- if and .Values.networking.useGlobalProxyNetworking .Values.networking.proxy.config.trusted_ca_bundle }}
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: reporting-operator-trusted-ca-bundle
+          readOnly: true
+{{- end }}
 {{- if $operatorValues.spec.config.tls.api.enabled }}
         - mountPath: /etc/tls
           name: api-tls


### PR DESCRIPTION
This CA bundle already gets mounted in the reporting-operator container when the cluster-wide proxy is enabled, but not in the sidecar container.