### PR TITLE
images: Finalize the meteringconfig_spec_overrides dictionary before running any top-level tasks.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile.yml
@@ -1,8 +1,9 @@
 ---
 
-- name: Finalize the set of meteringconfig default values
+- name: Finalize the set of meteringconfig static dictionaries
   set_fact:
     meteringconfig_default_values: "{{ meteringconfig_default_values }}"
+    meteringconfig_spec_overrides: "{{ meteringconfig_spec_overrides }}"
   no_log: true
 
 - name: Validate Configurations


### PR DESCRIPTION
This is another example of a static dictionary that we reference throughout the role where storing its result into a fact will shave off some overall role execution time, as Ansible no longer has to evaluate it every time its referenced.