### PR TITLE
[release-4.4] Bug 1847111: Add support for upgrading between Metering CSV versions.

### DIFF
--- a/charts/metering-ansible-operator/templates/olm/art.yaml
+++ b/charts/metering-ansible-operator/templates/olm/art.yaml
@@ -9,6 +9,8 @@ updates:
     # replace spec.version value
     - search: 'version: "{{ .Values.olm.csv.version }}"'
       replace: 'version: {FULL_VER}'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"

--- a/charts/metering-ansible-operator/templates/olm/clusterserviceversion.yaml
+++ b/charts/metering-ansible-operator/templates/olm/clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: placeholder
 {{- if .Values.olm.csv.annotations }}
   annotations:
+    olm.skipRange: {{ .Values.olm.csv.skipRange | quote }}
 {{ toYaml .Values.olm.csv.annotations | indent 4 }}
 {{- end }}
 {{- if .Values.olm.labels }}

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -208,6 +208,7 @@ olm:
   csv:
     name : metering-operator.v4.4.0
     version: "4.4.0"
+    skipRange: ">=4.2.0 <4.4.0"
     minKubeVersion: "1.11.0"
     displayName: Metering
     description: |
@@ -318,7 +319,7 @@ olm:
       operatorframework.io/cluster-monitoring: "true"
       categories: "OpenShift Optional, Monitoring"
       certified: "false"
-      capabilities: Basic Install
+      capabilities: Seamless Upgrades
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
       containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.4"

--- a/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: metering-operator-testing.v4.4.0
   namespace: placeholder
   annotations:
+    olm.skipRange: ">=4.2.0 <4.4.0"
     alm-examples: |-
       [
         {
@@ -202,7 +203,7 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.4

--- a/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: metering-operator.v4.4.0
   namespace: placeholder
   annotations:
+    olm.skipRange: ">=4.2.0 <4.4.0"
     alm-examples: |-
       [
         {
@@ -202,7 +203,7 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.4

--- a/manifests/deploy/openshift/olm/bundle/art.yaml
+++ b/manifests/deploy/openshift/olm/bundle/art.yaml
@@ -8,6 +8,8 @@ updates:
     # replace spec.version value
     - search: 'version: "4.4.0"'
       replace: 'version: {FULL_VER}'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"

--- a/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.4/meteringoperator.v4.4.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: metering-operator-upstream.v4.4.0
   namespace: placeholder
   annotations:
+    olm.skipRange: ">=4.2.0 <4.4.0"
     alm-examples: |-
       [
         {


### PR DESCRIPTION
# Overview

In the 4.5 release cycle, support was added to support upgrading between Metering CSV versions. We were asked to backport upgrade support to any release that made sense, which in this case would be 4.3/4.4 as 4.2 is marked as EOL once 4.5 GA is released.

# Changes

## charts,manifests[meteringoperator.v4.4.0.clusterserviceversion.yaml]

The [`olm.skipRange`](https://docs.openshift.com/container-platform/4.4/operators/understanding_olm/olm-understanding-olm.html#olm-upgrades-replacing-multiple_olm-understanding-olm) CSV annotation adds the ability to upgrade between Metering CSV versions in a single `package.yaml`, which ART populates.

## charts,manifests[art.yaml]

This file governs the substitution rules that ART is configured to read from. In this case, we're substituting the second x.y.z version from <4.4.0 reference, with the latest 4.4.z z-stream release.
