### PR TITLE
[release-4.5] Bug 1842977: Migrate to obtaining the service-serving CA bundle from a ConfigMap

### DIFF
--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -43,9 +43,9 @@ data:
       importCert /s3-compatible-ca/ca-bundle.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
     # always add the openshift service-ca.crt if it exists
-    if [ -a /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ]; then
-      echo "Adding /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
-      importCert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
+    if [ -a /var/run/configmaps/service-ca-bundle/service-ca.crt ]; then
+      echo "Adding /var/run/configmaps/service-ca-bundle/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
+      importCert /var/run/configmaps/service-ca-bundle/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
 
     export HADOOP_LOG_DIR="${HADOOP_HOME}/logs"

--- a/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-datanode-statefulset.yaml
@@ -260,6 +260,9 @@ spec:
           mountPath: /hadoop-scripts
         - name: hdfs-jmx-config
           mountPath: /opt/jmx_exporter/config
+        - name: hdfs-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if or .Values.hadoop.spec.config.s3Compatible.ca.secretName .Values.hadoop.spec.config.s3Compatible.ca.createSecret }}
         - name: s3-compatible-ca
           mountPath: /s3-compatible-ca
@@ -302,6 +305,10 @@ spec:
       - name: hdfs-jmx-config
         configMap:
           name: hdfs-jmx-config
+      - name: hdfs-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
       - name: namenode-empty
         emptyDir: {}
       - name: hadoop-logs

--- a/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
+++ b/charts/openshift-metering/templates/hadoop/hdfs-namenode-statefulset.yaml
@@ -222,6 +222,9 @@ spec:
           mountPath: /hadoop-scripts
         - name: hdfs-jmx-config
           mountPath: /opt/jmx_exporter/config
+        - name: hdfs-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if or .Values.hadoop.spec.config.s3Compatible.ca.secretName .Values.hadoop.spec.config.s3Compatible.ca.createSecret }}
         - name: s3-compatible-ca
           mountPath: /s3-compatible-ca
@@ -257,6 +260,10 @@ spec:
       - name: hdfs-jmx-config
         configMap:
           name: hdfs-jmx-config
+      - name: hdfs-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
       - name: datanode-empty
         emptyDir: {}
       - name: hadoop-logs

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -158,6 +158,9 @@ spec:
           mountPath: /hive-config
         - name: hive-scripts
           mountPath: /hive-scripts
+        - name: hive-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if .Values.hive.spec.config.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
@@ -261,6 +264,10 @@ spec:
         configMap:
           name: hive-scripts
           defaultMode: 0775
+      - name: hive-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
 {{- if .Values.hive.spec.config.useHadoopConfig }}
       - name: hadoop-config
         emptyDir: {}

--- a/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
@@ -43,9 +43,9 @@ data:
       importCert /s3-compatible-ca/ca-bundle.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
     # always add the openshift service-ca.crt if it exists
-    if [ -a /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ]; then
-      echo "Adding /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
-      importCert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
+    if [ -a /var/run/configmaps/service-ca-bundle/service-ca.crt ]; then
+      echo "Adding /var/run/configmaps/service-ca-bundle/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
+      importCert /var/run/configmaps/service-ca-bundle/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
 
     # add UID to /etc/passwd if missing

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -186,6 +186,9 @@ spec:
           mountPath: /hive-config
         - name: hive-scripts
           mountPath: /hive-scripts
+        - name: hive-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if .Values.hive.spec.config.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
@@ -315,6 +318,10 @@ spec:
         configMap:
           name: hive-scripts
           defaultMode: 0775
+      - name: hive-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
 {{- if .Values.hive.spec.config.useHadoopConfig }}
       - name: hadoop-config
         emptyDir: {}

--- a/charts/openshift-metering/templates/metering/metering-service-ca-crt.yaml
+++ b/charts/openshift-metering/templates/metering/metering-service-ca-crt.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-ca-bundle
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/charts/openshift-metering/templates/monitoring/reporting-operator-service-monitor.yaml
+++ b/charts/openshift-metering/templates/monitoring/reporting-operator-service-monitor.yaml
@@ -12,7 +12,7 @@ spec:
     scheme: "https"
     interval: 30s
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: reporting-operator.{{ .Release.Namespace }}.svc
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   selector:

--- a/charts/openshift-metering/templates/presto/presto-common-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-common-config.yaml
@@ -59,9 +59,9 @@ data:
       importCert /s3-compatible-ca/ca-bundle.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
     # always add the openshift service-ca.crt if it exists
-    if [ -a /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ]; then
-      echo "Adding /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
-      importCert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
+    if [ -a /var/run/configmaps/service-ca-bundle/service-ca.crt ]; then
+      echo "Adding /var/run/configmaps/service-ca-bundle/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
+      importCert /var/run/configmaps/service-ca-bundle/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
     fi
 
     # add node id to node config

--- a/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-statefulset.yaml
@@ -204,6 +204,9 @@ spec:
           mountPath: /var/presto/data
         - name: presto-logs
           mountPath: /var/presto/logs
+        - name: presto-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
@@ -260,6 +263,10 @@ spec:
         configMap:
           name: presto-common-config
           defaultMode: 0775
+      - name: presto-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
       - name: presto-catalog-config
         secret:
           secretName: presto-catalog-config

--- a/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-statefulset.yaml
@@ -190,6 +190,9 @@ spec:
           mountPath: /var/presto/data
         - name: presto-logs
           mountPath: /var/presto/logs
+        - name: presto-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if .Values.presto.spec.config.connectors.hive.useHadoopConfig }}
         - name: hadoop-config
           mountPath: /hadoop-config
@@ -246,6 +249,10 @@ spec:
         configMap:
           name: presto-common-config
           defaultMode: 0775
+      - name: presto-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
       - name: presto-catalog-config
         secret:
           secretName: presto-catalog-config

--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -202,7 +202,7 @@ spec:
     {{ fail "Cannot both use serviceAccount CA and CA from configMap" }}
   {{- end }}
         - name: REPORTING_OPERATOR_PROMETHEUS_CA_FILE
-          value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+          value: "/var/run/configmaps/service-ca-bundle/service-ca.crt"
 {{- end }}
 {{- if $operatorValues.spec.config.prometheus.certificateAuthority.configMap.enabled }}
         - name: REPORTING_OPERATOR_PROMETHEUS_CA_FILE
@@ -353,6 +353,9 @@ spec:
 {{ toYaml $operatorValues.spec.livenessProbe | indent 10 }}
 {{- end }}
         volumeMounts:
+        - name: reporting-operator-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if $operatorValues.spec.config.hive.tls.enabled }}
         - name: hive-tls
           mountPath: /var/run/secrets/hive-tls
@@ -447,6 +450,9 @@ spec:
         resources:
 {{ toYaml $operatorValues.spec.authProxy.resources | indent 10 }}
         volumeMounts:
+        - name: reporting-operator-service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
+          readOnly: true
 {{- if and .Values.networking.useGlobalProxyNetworking .Values.networking.proxy.config.trusted_ca_bundle }}
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: reporting-operator-trusted-ca-bundle
@@ -474,6 +480,10 @@ spec:
           - key: ca-bundle.crt
             path: ca-bundle.crt
 {{- end }}
+      - name: reporting-operator-service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
 {{- if $operatorValues.spec.config.hive.tls.enabled }}
       - name: hive-tls
         secret:

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml
@@ -32,6 +32,9 @@
       - template_file: templates/metering/metering-roles.yaml
         apis: [ {kind: role, api_version: 'rbac.authorization.k8s.io/v1'} ]
         prune_label_value: openshift-metering-roles
+      - template_file: templates/metering/metering-service-ca-crt.yaml
+        apis: [ {kind: ConfigMap} ]
+        prune_label_value: openshift-metering-service-ca-crt
       - template_file: templates/metering/metering-rolebindings.yaml
         apis: [ {kind: rolebindings, api_version: 'rbac.authorization.k8s.io/v1'} ]
         prune_label_value: openshift-metering-rolebindings


### PR DESCRIPTION
## Overview

In 4.1, the `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` field was depreciated, and in 4.5 it was removed entirely. Now, we need to migrate to reconciling an empty ConfigMap with the `service.beta.openshift.io/inject-cabundle="true"` annotation, which results in the service CA certificate bundle being automatically injected through one of the cluster's controllers. We can then mount that certificate into any of the Metering operand Pods that require access to that CA bundle.

### Changes

- charts/openshift-metering/templates/metering/metering-service-ca-crt.yaml adds an empty ConfigMap with the `service.beta.openshift.io/inject-cabundle="true"` annotation
- images/metering-ansible-operator/roles/meteringconfig/tasks/reconcile_metering.yml adds another reconciliation item to the reconcile_metering task file, and we always create this file.
- charts/openshift-metering/templates/monitoring/reporting-operator-service-monitor.yaml replaces the static/hardcoded /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt path with the ConfigMap that the Prometheus operator manages.
- charts/openshift-metering/*: updates the operand deployments/statefulsets/configmap scripts to mount the ConfigMap data into the applicable containers, which can then be consumed as a `volumeMount`. 
