### PR TITLE
[release-4.5] Bug 1843178: Reference the correct serviceaccount to allow Prometheus to scrape Metering endpoints properly.

### DIFF
--- a/charts/openshift-metering/templates/monitoring/monitoring-rbac.yaml
+++ b/charts/openshift-metering/templates/monitoring/monitoring-rbac.yaml
@@ -29,6 +29,6 @@ roleRef:
   name: metering-prometheus-k8s
 subjects:
 - kind: ServiceAccount
-  name: thanos-querier
+  name: prometheus-k8s
   namespace: {{ .Values.monitoring.namespace }}
 {{- end }}


### PR DESCRIPTION
## Overview

This was a regression when we updated our reporting-operator Prometheus URL configuration to point to the `thanos-querier` service, as we also updated the serviceaccount that grants Prometheus access to those resources, from the `prometheus-k8s` service account, to the `thanos-querier` one. 

### Result of Changing RoleBinding serviceaccount

When we updated our configuration to point to the thanos-querier service instead of the prometheus-k8s, we also updated the serviceaccount from prometheus-k8s to thanos-query, which results in the following errors:

```
level=error ts=2020-06-01T19:49:34.902Z caller=klog.go:94 component=k8s_client_runtime func=ErrorDepth msg="github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:263: Failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:openshift-monitoring:prometheus-k8s\" cannot list resource \"pods\" in API group \"\" in the namespace \"metering-emoss\""
level=error ts=2020-06-01T19:49:35.902Z caller=klog.go:94 component=k8s_client_runtime func=ErrorDepth msg="github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:261: Failed to list *v1.Endpoints: endpoints is forbidden: User \"system:serviceaccount:openshift-monitoring:prometheus-k8s\" cannot list resource \"endpoints\" in API group \"\" in the namespace \"metering-emoss\""
```

If we take a look at the available endpoints in that namespace:
```bash
hive-metastore                      10.131.0.28:8082,10.131.0.28:9083                      145m
hive-server                         10.131.0.27:10000,10.131.0.27:8082,10.131.0.27:10002   145m
metering-ansible-operator-metrics   <none>                                                 147m
mysql                               10.131.0.26:3306                                       169m
presto                              10.129.2.20:8082,10.129.2.20:8080                      144m
presto-nodes                        10.129.2.20:8080                                       144m
presto-worker                       <none>                                                 144m
reporting-operator                                                                         144m
```

We can see that the reporting-operator does not have an Endpoint listed despite having set up a ServiceMonitor while reconciling Metering.

### Result of Correcting RoleBinding

Once we update this rolebinding to point to the correct serviceaccount, that error is no longer present and the `prometheus-k8s` serviceaccount can correctly list off the endpoints present in a namespace (where the tflannag namespace contains the change and the metering-emoss namespace does not):

```
tflannag@localhost metering-operator [fix-prometheus-k8s-serviceaccount] ▶  oc auth can-i list endpoints -n metering-emoss --token $token
no
tflannag@localhost metering-operator [fix-prometheus-k8s-serviceaccount] ▶  oc auth can-i list endpoints -n tflannag --token $token
yes
tflannag@localhost metering-operator [fix-prometheus-k8s-serviceaccount] ▶
```
