### PR TITLE
charts,manifests: Update manifests to expose metering-ansible-operator metrics properly.

### DIFF
--- a/charts/metering-ansible-operator/templates/_helpers.tpl
+++ b/charts/metering-ansible-operator/templates/_helpers.tpl
@@ -12,6 +12,7 @@ template:
   metadata:
     labels:
       app: {{ .Values.operator.name }}
+      name: {{ .Values.operator.name }}
 {{- if .Values.operator.labels }}
 {{ toYaml .Values.operator.labels | indent 6 }}
 {{- end }}
@@ -39,7 +40,7 @@ template:
       imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
       env:
       - name: OPERATOR_NAME
-        value: "metering-ansible-operator"
+        value: "{{ .Values.operator.name }}"
       - name: DISABLE_OCP_FEATURES
         value: "{{ .Values.operator.disableOCPFeatures }}"
       - name: WATCH_NAMESPACE
@@ -62,6 +63,11 @@ template:
       - name: {{ $item.name | replace "-" "_" | upper | printf "%s_IMAGE" }}
         value: "{{ $item.from.name }}"
 {{- end }}
+      ports:
+      - name: http-metrics
+        containerPort: 8383
+      - name: cr-metrics
+        containerPort: 8686
       volumeMounts:
       - mountPath: /tmp/ansible-operator/runner
         name: runner

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -28,6 +28,13 @@ operator:
   rbac:
     clusterRoleName: metering-operator
     clusterRoleRules:
+    # grants access to the metering-ansible-operator to create a servicemonitor
+    - apiGroups: [""]
+      resources:
+      - services/finalizers
+      - deployments/finalizers
+      verbs:
+      - update
     # grants access to metrics data
     - apiGroups:
       - ""

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -6,6 +6,13 @@ rules:
   - apiGroups:
     - ""
     resources:
+    - services/finalizers
+    - deployments/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    resources:
     - namespaces
     verbs:
     - get

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: metering-operator
+        name: metering-operator
     spec:
       securityContext:
         runAsNonRoot: true
@@ -35,7 +36,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: OPERATOR_NAME
-          value: "metering-ansible-operator"
+          value: "metering-operator"
         - name: DISABLE_OCP_FEATURES
           value: "false"
         - name: WATCH_NAMESPACE
@@ -60,6 +61,11 @@ spec:
           value: "quay.io/openshift/origin-ghostunnel:4.6"
         - name: OAUTH_PROXY_IMAGE
           value: "quay.io/openshift/origin-oauth-proxy:4.6"
+        ports:
+        - name: http-metrics
+          containerPort: 8383
+        - name: cr-metrics
+          containerPort: 8686
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -457,6 +457,7 @@ spec:
               metadata:
                 labels:
                   app: metering-operator
+                  name: metering-operator
               spec:
                 securityContext:
                   runAsNonRoot: true
@@ -477,7 +478,7 @@ spec:
                   imagePullPolicy: Always
                   env:
                   - name: OPERATOR_NAME
-                    value: "metering-ansible-operator"
+                    value: "metering-operator"
                   - name: DISABLE_OCP_FEATURES
                     value: "false"
                   - name: WATCH_NAMESPACE
@@ -502,6 +503,11 @@ spec:
                     value: "quay.io/openshift/origin-ghostunnel:4.6"
                   - name: OAUTH_PROXY_IMAGE
                     value: "quay.io/openshift/origin-oauth-proxy:4.6"
+                  ports:
+                  - name: http-metrics
+                    containerPort: 8383
+                  - name: cr-metrics
+                    containerPort: 8686
                   volumeMounts:
                   - mountPath: /tmp/ansible-operator/runner
                     name: runner

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -296,6 +296,13 @@ spec:
           - apiGroups:
             - ""
             resources:
+            - services/finalizers
+            - deployments/finalizers
+            verbs:
+            - update
+          - apiGroups:
+            - ""
+            resources:
             - namespaces
             verbs:
             - get

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -6,6 +6,13 @@ rules:
   - apiGroups:
     - ""
     resources:
+    - services/finalizers
+    - deployments/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    resources:
     - namespaces
     verbs:
     - get

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: metering-operator
+        name: metering-operator
     spec:
       securityContext:
         runAsNonRoot: true
@@ -35,7 +36,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: OPERATOR_NAME
-          value: "metering-ansible-operator"
+          value: "metering-operator"
         - name: DISABLE_OCP_FEATURES
           value: "true"
         - name: WATCH_NAMESPACE
@@ -58,6 +59,11 @@ spec:
           value: "quay.io/coreos/hadoop:release-4.6"
         - name: GHOSTUNNEL_IMAGE
           value: "quay.io/coreos/metering-ghostunnel:release-4.6"
+        ports:
+        - name: http-metrics
+          containerPort: 8383
+        - name: cr-metrics
+          containerPort: 8686
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -455,6 +455,7 @@ spec:
               metadata:
                 labels:
                   app: metering-operator
+                  name: metering-operator
               spec:
                 securityContext:
                   runAsNonRoot: true
@@ -475,7 +476,7 @@ spec:
                   imagePullPolicy: Always
                   env:
                   - name: OPERATOR_NAME
-                    value: "metering-ansible-operator"
+                    value: "metering-operator"
                   - name: DISABLE_OCP_FEATURES
                     value: "true"
                   - name: WATCH_NAMESPACE
@@ -498,6 +499,11 @@ spec:
                     value: "quay.io/coreos/hadoop:release-4.6"
                   - name: GHOSTUNNEL_IMAGE
                     value: "quay.io/coreos/metering-ghostunnel:release-4.6"
+                  ports:
+                  - name: http-metrics
+                    containerPort: 8383
+                  - name: cr-metrics
+                    containerPort: 8686
                   volumeMounts:
                   - mountPath: /tmp/ansible-operator/runner
                     name: runner

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -294,6 +294,13 @@ spec:
           - apiGroups:
             - ""
             resources:
+            - services/finalizers
+            - deployments/finalizers
+            verbs:
+            - update
+          - apiGroups:
+            - ""
+            resources:
             - namespaces
             verbs:
             - get


### PR DESCRIPTION
## Overview

I started seeing the following error message in the metering-operator's, operator container logs:

```
{"level":"info","ts":1589913367.0101564,"logger":"cmd","msg":"Could not create ServiceMonitor object","Namespace":"tflannag","error":"servicemonitors.monitoring.coreos.com \"metering-ansible-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

After poking around the operator-sdk issues for a bit, the solution appears to be to allow 'updates' to the 'services/finalizers' and 'deployments/finalizers' resources for the metering-operator clusterrole.

Once the permissions were taken care of and the ServiceMonitor object was able to be created, I wasn't able to see an endpoint created for that metering-ansible-operator-metrics service, despite the service/servicemonitor resources be present in the namespace being watched.

If we take a look at the metering-ansible-operator-metrics service yaml, we see the following:

```yaml
...
spec:
  clusterIP: 172.30.31.205
  ports:
  - name: http-metrics
    port: 8383
    protocol: TCP
    targetPort: 8383
  - name: cr-metrics
    port: 8686
    protocol: TCP
    targetPort: 8686
  selector:
    name: metering-operator
  sessionAffinity: None
  type: ClusterIP
```

The problem here is that the service is targeting pods that match the `name: metering-operator` label and the metering-operator deployment creates pods with the `app: metering-operator` label.

This means we can simply add the `name: metering-operator` label to the deployment pod template, so any pods that get created can match that service label selector.

We also needed to expose the 8383 and 8686 container ports so Prometheus can properly scrap those metrics, such as `workqueue_work_duration_seconds_count`.