### PR TITLE
pkg/deploy: Delete all clusterroles/clusterrolebindings matching the 'app=reporting-operator' selector.

### DIFF
--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -257,6 +257,15 @@ func (deploy *Deployer) uninstallMeteringClusterRole() error {
 		return err
 	}
 
+	// attempt to delete any of the clusterroles the reporting-operator creates
+	err = deploy.client.RbacV1().ClusterRoles().DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: "app=reporting-operator",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list all the reporting-operator clusterroles in the %s namespace: %v", deploy.config.Namespace, err)
+	}
+	deploy.logger.Infof("Deleted the 'app=reporting-operator' cluster roles")
+
 	return nil
 }
 
@@ -278,6 +287,15 @@ func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
 	} else {
 		return err
 	}
+
+	// attempt to delete any of the clusterrolebindings the reporting-operator creates
+	err = deploy.client.RbacV1().ClusterRoleBindings().DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: "app=reporting-operator",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list all the reporting-operator clusterrolebindings in the %s namespace: %v", deploy.config.Namespace, err)
+	}
+	deploy.logger.Infof("Deleted the 'app=reporting-operator' cluster role bindings")
 
 	return nil
 }


### PR DESCRIPTION
It looks like we were properly cleaning up the metering-operator clusterrole and clusterrolebinding resources by encoding those YAML resources into Go objects and then deleting them, but the clusterroles/clusterrolebindings that metering was reconciling for the reporting-operator were being left over.

We always attach the [`app=reporting-operator` label](https://github.com/kube-reporting/metering-operator/blob/master/charts/openshift-metering/templates/reporting-operator/reporting-operator-rbac.yaml#L17) to any resource associated with the reporting-operator, so deleting all clusterroles/clusterrolebindings that match that label when the `--delete-crb` option is specified will properly clean up those resources.
