### PR TITLE
images: Ensure the randomly generated cookie seed string matches 32 characters in length.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_reporting_operator_tls.yml
@@ -120,12 +120,19 @@
     - name: Generate a 32-character random string
       command: openssl rand -base64 32
       register: cookie_seed_random_string
-      when: not reporting_operator_auth_proxy_cookie_secret_exists
 
     - name: Configure authProxy cookie seed secret
       set_fact:
         _meteringconfig_reporting_operator_auth_proxy_cookie_seed: "{{ cookie_seed_random_string.stdout }}"
       no_log: true
+      when: cookie_seed_random_string is defined
+
+    - name: Verify the randomly generated string is at least 32 characters in length
+      assert:
+        that:
+        - _meteringconfig_reporting_operator_auth_proxy_cookie_seed | length >= 32
+        msg: "Invalid cookie seed generated: the length of the string is less than 32 characters"
+      when: cookie_seed_random_string is defined
     when: not reporting_operator_auth_proxy_cookie_secret_exists
 
   - name: Configure authProxy cookie seed secret to use pre-existing secret data


### PR DESCRIPTION
When creating this cookie seed, we have validation in place for the reporting-operator auth-proxy secret helm charts.

Here is an error that we picked up while running the role:

```
tflannag@localhost metering-operator [ensure-cookie-seed-is-32-char-length] k get meteringconfig operator-metering -o json | jq '.status'
{
  "conditions": [
    {
      "lastTransitionTime": "2020-06-05T16:08:57.961574Z",
      "message": "\"'Error: render error in \"openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml\":\n    template: openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml:51:62:\n    executing \"openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml\"\n    at <include (print $.Template.BasePath \"/reporting-operator/reporting-operator-auth-proxy-cookie-secret.yaml\")\n    .>: error calling include: template: openshift-metering/templates/reporting-operator/reporting-operator-auth-proxy-cookie-secret.yaml:5:4:\n    executing \"openshift-metering/templates/reporting-operator/reporting-operator-auth-proxy-cookie-secret.yaml\"\n    at <fail \"reporting-operator.authProxy.cookie.seed should be a random string at\n    least 32 characters in length.\">: error calling fail: reporting-operator.authProxy.cookie.seed\n    should be a random string at least 32 characters in length.'\n\"",
      "status": "True",
      "type": "Invalid"
    },
    {
      "lastTransitionTime": "2020-06-05T16:09:05.533009Z",
      "message": "Starting the reconciliation process",
      "status": "True",
      "type": "Running"
    }
  ]
}
tflannag@localhost metering-operator [ensure-cookie-seed-is-32-char-length]
```

In some cases, I was seeing that the string generated from that `openssl rand ...` command did not match the 32 character limit we have in place, so we need to explicitly truncate any characters that exceed 32 characters.

Also, the 'command' module in Ansible does not support piping output between shell commands, and I wasn't able to find an Ansible filter that accomplishes something like this, so we need to switch to using the 'shell' module here.

On top of that, I added a validation check in Ansible that ensures the string generated matches 32 characters in length before we start reconciling any metering-related tasks. This makes it quicker and easier to validate than the reporting-operator auth-proxy helm chart check.