### PR TITLE
Bug 1838652: Ensure the MeteringConfig CRD exists and has a populated Status field.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -811,6 +811,7 @@ k8s.io/kube-proxy v0.0.0-20191114110717-50a77e50d7d9/go.mod h1:HTBohWmrysPQ20NEC
 k8s.io/kube-scheduler v0.0.0-20191114111229-2e90afcb56c7/go.mod h1:GGBuzn2uP9d8InjDSXHKMRB19MToTafRo+BnMLF2QWk=
 k8s.io/kubectl v0.0.0-20191114113550-6123e1c827f7/go.mod h1:MYrMrU6JgEeGVz2sFggJizAfyoRjwsP4iTQcP8iQS00=
 k8s.io/kubelet v0.0.0-20191114110954-d67a8e7e2200/go.mod h1:BJl+6D6pGeUm+/uJfOWrPouIq05g/TCiKXc/Bxw+ZYw=
+k8s.io/kubernetes v1.16.0 h1:WPaqle2JWogVzLxhN6IK67u62IHKKrtYF7MS4FVR4/E=
 k8s.io/kubernetes v1.16.0/go.mod h1:nlP2zevWKRGKuaaVbKIwozU0Rjg9leVDXkL4YTtjmVs=
 k8s.io/legacy-cloud-providers v0.0.0-20191114112655-db9be3e678bb/go.mod h1:LwtW+cUPHdurdbed4pXQiAWcjYg9XkwxPO8NOX0qeQA=
 k8s.io/metrics v0.0.0-20191114105837-a4a2842dc51b/go.mod h1:+OP14I2yuLAiYCsEB4pC2101W6tZ2rC9uSZFvR3DEJg=


### PR DESCRIPTION
We're currently running into a problem in the upgrade e2e suite where we ensure the MeteringConfig CRD exists before creating the MeteringConfig custom resource.
This has proven to be an inadequate check, as seen in the following error:

```bash
FATA[06-08-2020 11:24:41] Failed to deploy metering: failed to install metering through OLM: failed to create the MeteringConfig resource: the server could not find the requested resource (post meteringconfigs.metering.openshift.io)  error="failed to install metering through OLM: failed to create the MeteringConfig resource: the server could not find the requested resource (post meteringconfigs.metering.openshift.io)"
```

Despite verifying the MeteringConfig CRD exists, we can still see that the apiserver is failing to find the plural name version of that resource.

If we instead modified the logic to ensure that the `.Status.AcceptedNames.Plural` matches the 'meteringconfigs' string, we can safely assume that the MeteringConfig CRD exists and it's "ready".