### PR TITLE
test/e2e: Replace the MeteringConfig Golang objects with decoded YAML manifests.

### DIFF
--- a/test/e2e/testdata/meteringconfigs/missing-storage.yaml
+++ b/test/e2e/testdata/meteringconfigs/missing-storage.yaml
@@ -1,0 +1,5 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+spec: {}

--- a/test/e2e/testdata/meteringconfigs/prometheus-metrics-importer-disabled.yaml
+++ b/test/e2e/testdata/meteringconfigs/prometheus-metrics-importer-disabled.yaml
@@ -1,0 +1,76 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+spec:
+  logHelmTemplate: true
+
+  unsupportedFeatures:
+    enableHDFS: true
+
+  storage:
+    type: hive
+    hive:
+      type: hdfs
+      hdfs:
+        namenode: hdfs-namenode-0.hdfs-namenode:9820
+
+  reporting-operator:
+    spec:
+      resources:
+        requests:
+          cpu: 1
+          memory: 250Mi
+      config:
+        logLevel: debug
+        prometheus:
+          metricsImporter:
+            enabled: false
+
+  presto:
+    spec:
+      coordinator:
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+      config:
+        connectors:
+          prometheus:
+            enabled: true
+            config:
+              uri: "https://thanos-querier.openshift-monitoring.svc:9091/"
+            auth:
+              bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  hive:
+    spec:
+      metastore:
+        resources:
+          requests:
+            cpu: 1
+            memory: 650Mi
+        storage:
+          size: 5Gi
+      server:
+        resources:
+          requests:
+            cpu: 500m
+            memory: 650Mi
+
+  hadoop:
+    spec:
+      hdfs:
+        enabled: true
+        datanode:
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi
+        namenode:
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi

--- a/test/e2e/testdata/meteringconfigs/prometheus-metrics-importer-enabled.yaml
+++ b/test/e2e/testdata/meteringconfigs/prometheus-metrics-importer-enabled.yaml
@@ -1,0 +1,73 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+spec:
+  logHelmTemplate: true
+
+  unsupportedFeatures:
+    enableHDFS: true
+
+  storage:
+    type: hive
+    hive:
+      type: hdfs
+      hdfs:
+        namenode: hdfs-namenode-0.hdfs-namenode:9820
+
+  reporting-operator:
+    spec:
+      resources:
+        requests:
+          cpu: 1
+          memory: 250Mi
+      config:
+        logLevel: debug
+        prometheus:
+          metricsImporter:
+            config:
+              chunkSize: 5m
+              pollInterval: 30s
+              stepSize: 60s
+              maxImportBackfillDuration: 15m
+              maxQueryRangeDuration: 5m
+
+  presto:
+    spec:
+      coordinator:
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+
+  hive:
+    spec:
+      metastore:
+        resources:
+          requests:
+            cpu: 1
+            memory: 650Mi
+        storage:
+          size: 5Gi
+      server:
+        resources:
+          requests:
+            cpu: 500m
+            memory: 650Mi
+
+  hadoop:
+    spec:
+      hdfs:
+        enabled: true
+        datanode:
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi
+        namenode:
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi


### PR DESCRIPTION
This would add a set of MeteringConfig custom resource YAML manifests in the test/e2e/testdata directory. We can decode those manifests into Go object which is what the rest of the e2e deployframework suite currently expects. This way, we reduce the size of the main_test.go significantly, and it's much easier to follow the configuration listed in the YAML manifest, as compared to a giant Go object.
