### PR TITLE
Documentation,images: Generalize and update the configuring_hive_metastore task file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1214](https://github.com/kube-reporting/metering-operator/pull/1214) Add initial support for configuring the Hive Metastore database to reference a secret containing the base64 encrypted username and password credentials.
 - [#1224](https://github.com/kube-reporting/metering-operator/pull/1224) Improve performance of the metering-ansible-operator by "finalizing" the `meteringconfig_spec_overrides` dictionary.
 - [#1226](https://github.com/kube-reporting/metering-operator/pull/1226) Re-generate assets and YAML manifests to point to the 4.6 images.
+- [#1245](https://github.com/kube-reporting/metering-operator/pull/1245) Consolidate Hive Metastore configurable fields. You no longer need to specify `spec.hive.spec.metastore.storage.create: false` when using a non-default database for Hive Metastore.
 
 ### Bug Fixes
 

--- a/Documentation/configuring-hive-metastore.md
+++ b/Documentation/configuring-hive-metastore.md
@@ -16,7 +16,7 @@ In practice, it is possible to remove this requirement by using [MySQL](#use-mys
 
 To install, Hive metastore requires that dynamic volume provisioning be enabled via a Storage Class, a persistent volume of the correct size must be manually pre-created, or that you use a pre-existing MySQL or PostgreSQL database.
 
-### Configuring the Storage Class for Hive Metastore
+## Configuring the Storage Class for Hive Metastore
 
 To configure and specify a `StorageClass` for the hive-metastore-db-data PVC, specify the `StorageClass` in your MeteringConfig.
 A example `StorageClass` section is included in [metastore-storage.yaml][metastore-storage-config].
@@ -24,27 +24,37 @@ A example `StorageClass` section is included in [metastore-storage.yaml][metasto
 Uncomment the `spec.hive.spec.metastore.storage.class` sections and replace the `null` in `class: null` value with the name of the StorageClass to use.
 Leaving the value `null` will cause Metering to use the default StorageClass for the cluster.
 
-### Configuring the volume sizes for Hive Metastore
+## Configuring the Volume Sizes for Hive Metastore
 
 Use [metastore-storage.yaml][metastore-storage-config] as a template and adjust the `size: "5Gi"` value to the desired capacity for the following sections:
 
 - `spec.hive.spec.metastore.storage.size`
 
-## Use MySQL for the Hive Metastore database
+## Configuring the Database for Hive Metastore
 
-By default to make installation easier Metering configures Hive to use an embedded Java database called [Derby](https://db.apache.org/derby/#What+is+Apache+Derby%3F), however this is unsuited for larger environments or metering installations with a lot of reports and metrics being collected.
+By default, to make the installation easier, Metering configures Hive to use an embedded Java database called [Derby](https://db.apache.org/derby/#What+is+Apache+Derby%3F), however this is unsuitable for larger environments or metering installations where a lot of reports and metrics are being collected.
+
 Currently two alternative options are available, MySQL and PostgreSQL, both of which have been tested with the metering-operator.
 
-There are three configuration options you can use to control the database used by Hive metastore: `url` , `driver` , and `secretName` .
-The `url` is the url of the MySQL instance, port followed by the database name.
-The `driver` configures the javax.jdo.option.ConnectionDriverName, which is the class name for the jdbc driver that will be used to store hive metadata.
-The `secretName` is the name assigned to the secret which contains the base64 encrypted username and password for the database.
+There are three configuration options you can use to control the database used by Hive metastore: `url` , `driver` , and `secretName`.
 
-### Using MySQL
+- `url`: the url of the MySQL or PostgreSQL instance. Examples are shown below.
+- `driver`: configures the class name for the JDBC driver that will be used to store the hive metadata.
+- `secretName`: the name of the secret which contains the base64 encrypted username and password for the database instance.
 
-To use MySQL create a secret in your namespace and then add the following to your Metering CR under the top level `spec`:
+Before proceeding to following examples, you need to create a secret in the `$METERING_NAMESPACE` containing the base64 encrypted username and password combination to the database instance.
 
+Through the command-line, you can replace the following commands wrapped in the `<...>` markers:
+
+```bash
+kubectl -n $METERING_NAMESPACE create secret generic <name of the secret> --from-literal=username=<database username> --from-literal=password=<database password>
 ```
+
+### Using MySQL for the Hive Metastore database
+
+**Note**: Metering cannot work with more recent versions of MySQL, which is being tracking in [BZ #1838802](https://bugzilla.redhat.com/show_bug.cgi?id=1838802). Instead, use the 5.7 version which has been tested.
+
+```yaml
 spec:
   hive:
     spec:
@@ -57,9 +67,11 @@ spec:
 
 You can pass additional JDBC parameters using the `spec.hive.spec.config.db.url`, for more details see [the MySQL Connector/J documentation](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html).
 
-## Use PostgreSQL for the Hive Metastore database
+## Using PostgreSQL for the Hive Metastore database
 
-```
+**Note**:  Metering cannot work with more recent versions of PostgreSQL, which is being tracking in [BZ #1838845](https://bugzilla.redhat.com/show_bug.cgi?id=1838845).
+
+```yaml
 spec:
   hive:
     spec:

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -616,7 +616,7 @@ meteringconfig_reporting_overrides:
           enabled: "{{ meteringconfig_reporting_enable_post_kube_1_14_datasources }}"
 
 # combine the _meteringconfig_tls_overrides dictionary last to enforce when spec.tls.enabled is specified and set to true
-meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, meteringconfig_reporting_overrides, _meteringconfig_root_ca_overrides, _meteringconfig_tls_overrides, _meteringconfig_ocp_disabled_overrides, meteringconfig_spec_overrides, recursive=True) }}"
+meteringconfig_spec: "{{ meteringconfig_default_values | combine(meteringconfig_default_image_overrides, meteringconfig_storage_overrides, _hive_metastore_db_overrides, meteringconfig_reporting_overrides, _meteringconfig_root_ca_overrides, _meteringconfig_tls_overrides, _meteringconfig_ocp_disabled_overrides, meteringconfig_spec_overrides, recursive=True) }}"
 
 meteringconfig_storage_s3_create_bucket: "{{ meteringconfig_spec | json_query('storage.hive.s3.createBucket') }}"
 meteringconfig_storage_s3_bucket_name: "{{ (meteringconfig_spec | json_query('storage.hive.s3.bucket') | default('', true)).split('/')[0] }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -414,6 +414,9 @@ _hive_metastore_db_overrides:
         db:
           username: "{{ _hive_metastore_db_username | default('') }}"
           password: "{{ _hive_metastore_db_password | default('') }}"
+      metastore:
+        storage:
+          create: "{{ _hive_metastore_create_default_storage | default(true) }}"
 
 #
 # Networking Configuration

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_metastore.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_metastore.yml
@@ -15,10 +15,6 @@
     when:
     - hive_metastore_db_secret_buf is defined
     - _hive_metastore_db_secret_buf_resources_first_index | length > 0
-
-  - name: Merge the two dictionaries together
-    set_fact:
-      meteringconfig_spec: "{{ meteringconfig_spec | combine(_hive_metastore_db_overrides, recursive=True) }}"
   vars:
     _hive_metastore_db_secret_buf_resources_first_index: "{{ hive_metastore_db_secret_buf.resources | first }}"
     _hive_metastore_db_secretName: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.secretName') }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_metastore.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_metastore.yml
@@ -1,24 +1,90 @@
-- name: Get metastore secret
+#
+# Configure the Hive Metastore
+#
+# Note: in the case where any of the username/password/secretName
+# configurations have been provided, set hive.spec.metastore.storage.create
+# to false as we can make a relatively safe assumption they're providing a
+# non-default database configuration.
+#
+# Note: for the top-level condition for this block, because json_query will
+# return an empty string when an object is defined, we need to ensure that
+# object is defined and non-empty before we can check if the database dictionary
+# contains any keys.
+- name: Configure and validate the user-provided Hive metastore configuration
   block:
-  - name: Get Metastore storage credentials secret
-    k8s_info:
-      api_version: v1
-      kind: Secret
-      name: "{{ _hive_metastore_db_secretName }}"
-      namespace: "{{ meta.namespace }}"
-    register: hive_metastore_db_secret_buf
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Running"
+        status: "True"
+        message: "Configuring hive metastore"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
-  - name: Create variables for the decoded username and password data
+  - name: Override the default hive.spec.metastore.storage.create option to false
     set_fact:
-      _hive_metastore_db_username: "{{ _hive_metastore_db_secret_buf_resources_first_index.data.username | b64decode }}"
-      _hive_metastore_db_password: "{{ _hive_metastore_db_secret_buf_resources_first_index.data.password | b64decode }}"
+      _hive_metastore_create_default_storage: false
     when:
-    - hive_metastore_db_secret_buf is defined
-    - _hive_metastore_db_secret_buf_resources_first_index | length > 0
+    - _meteringconfig_hive_metastore_db_username is defined and _meteringconfig_hive_metastore_db_username | length > 0
+    - _meteringconfig_hive_metastore_db_password is defined and _meteringconfig_hive_metastore_db_password | length > 0
+
+  - name: Manage username and password data when secretName is not empty
+    block:
+    - name: Validate the username and password fields are undefined when secretName is not empty
+      assert:
+        that:
+        - _meteringconfig_hive_metastore_db_username is not defined or _meteringconfig_hive_metastore_db_username | length == 0
+        - _meteringconfig_hive_metastore_db_password is not defined or _meteringconfig_hive_metastore_db_password | length == 0
+        msg: "Invalid configuration for hive.spec.config.db: the username and password fields must be empty when secretName has been specified"
+
+    - name: Query k8s for the user-provided secretName object
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ _meteringconfig_hive_metastore_db_secretName }}"
+        namespace: "{{ meta.namespace }}"
+      register: hive_metastore_db_secret_buf
+
+    - name: Create variables from the decoded username and password data
+      set_fact:
+        _hive_metastore_db_username: "{{ _hive_metastore_db_secret_buf_resources_first_index.data.username | b64decode }}"
+        _hive_metastore_db_password: "{{ _hive_metastore_db_secret_buf_resources_first_index.data.password | b64decode }}"
+        _hive_metastore_create_default_storage: false
+      when:
+      - hive_metastore_db_secret_buf is defined
+      - _hive_metastore_db_secret_buf_resources_first_index | length > 0
+    vars:
+      _hive_metastore_db_secret_buf_resources_first_index: "{{ hive_metastore_db_secret_buf.resources | first }}"
+    when:
+    - _meteringconfig_hive_metastore_db_secretName is defined
+    - _meteringconfig_hive_metastore_db_secretName | length > 0
+
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      current_conditions:
+        type: "Running"
+        status: "True"
+        message: "Finished configuring the hive metastore"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
   vars:
-    _hive_metastore_db_secret_buf_resources_first_index: "{{ hive_metastore_db_secret_buf.resources | first }}"
-    _hive_metastore_db_secretName: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.secretName') }}"
-  no_log: true
+    _meteringconfig_hive_metastore_db_secretName: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.secretName') }}"
+    _meteringconfig_hive_metastore_db_username: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.username') }}"
+    _meteringconfig_hive_metastore_db_password: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.password') }}"
+    _meteringconfig_hive_metastore_db_configuration: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db') }}"
+  no_log: false
+  rescue:
+  - include_tasks: update_meteringconfig_status.yml
+    vars:
+      end_play_after_updating_status: true
+      current_conditions:
+        type: "Invalid"
+        status: "True"
+        message: |
+          "{{ ansible_failed_result.msg }}"
+        lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
+    when:
+    - ansible_failed_result is defined
+    - ansible_failed_result.msg | length > 0
   when:
-  - _hive_metastore_db_secretName is defined
-  - _hive_metastore_db_secretName | length > 0
+  - _meteringconfig_hive_metastore_db_configuration is defined
+  - _meteringconfig_hive_metastore_db_configuration | length > 0
+  - _meteringconfig_hive_metastore_db_configuration.keys() | length > 0


### PR DESCRIPTION
We need to avoid using `set_fact` on the `meteringconfig_spec` dictionary before we're finished processing any non-reconciliation tasks. If we added an additional task file that we include after the `configure_hive_metastore.yml` task file, override a variable in the `meteringconfig_spec` dictionary, we won't see that propagate to the rest of the role as we ran `set_fact` on this dictionary in a previous task file.

The main change here is consolidating the need to set `hive.spec.metastore.storage.create` to false when a non-default database configuration has been specified. Also, we add MeteringConfig status updates and some light validation centered around asserting that the user didn't provide a username/password/secretName configuration in the `MeteringConfig` custom resource. This is important to check as the username and password fields will override what gets pulled out in the `secretName` object, as the `meteringconfig_spec_overrides` (e.g. what the user has provided as a configuration) has precedence over the hive metastore overrides dictionary.
