### PR TITLE
[release-4.3] Add support for upgrading between Metering CSV versions.

### DIFF
--- a/charts/metering-ansible-operator/templates/olm/art.yaml
+++ b/charts/metering-ansible-operator/templates/olm/art.yaml
@@ -9,6 +9,8 @@ updates:
     # replace spec.version value
     - search: 'version: "{{ .Values.olm.csv.version }}"'
       replace: 'version: {FULL_VER}'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -308,12 +308,13 @@ olm:
     annotations:
       categories: "OpenShift Optional, Monitoring"
       certified: "false"
-      capabilities: Basic Install
+      capabilities: Seamless Upgrades
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
       containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.3"
       description: 'Chargeback and reporting tool to provide accountability for how resources are used across a cluster'
       repository: https://github.com/operator-framework/operator-metering
+      olm.skipRange: ">=4.2.0 <4.3.0"
       alm-examples: |-
         [
           {

--- a/manifests/deploy/ocp-testing/olm/bundle/4.3/meteringoperator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/deploy/ocp-testing/olm/bundle/4.3/meteringoperator.v4.3.0.clusterserviceversion.yaml
@@ -202,13 +202,14 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.3
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.3.0'
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 

--- a/manifests/deploy/openshift/olm/bundle/4.3/meteringoperator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.3/meteringoperator.v4.3.0.clusterserviceversion.yaml
@@ -202,13 +202,14 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.3
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.3.0'
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 

--- a/manifests/deploy/openshift/olm/bundle/art.yaml
+++ b/manifests/deploy/openshift/olm/bundle/art.yaml
@@ -8,6 +8,8 @@ updates:
     # replace spec.version value
     - search: 'version: "4.3.0"'
       replace: 'version: {FULL_VER}'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "metering.package.yaml"
     update_list:
     - search: "currentCSV: metering-operator.v{MAJOR}.{MINOR}.0"

--- a/manifests/deploy/upstream/olm/bundle/4.3/meteringoperator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.3/meteringoperator.v4.3.0.clusterserviceversion.yaml
@@ -209,6 +209,7 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.3.0'
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 


### PR DESCRIPTION
In the 4.5 release cycle, support was added to support upgrading between Metering CSV versions. We were asked to backport upgrade support to any release that made sense, which in this case would be 4.3/4.4 as 4.2 is marked as EOL once 4.5 GA is released.

The [`olm.skipRange`](https://docs.openshift.com/container-platform/4.4/operators/understanding_olm/olm-understanding-olm.html#olm-upgrades-replacing-multiple_olm-understanding-olm) CSV annotation adds the ability to upgrade between Metering CSV versions in a single `package.yaml`, which ART populates.

This file governs the substitution rules that ART is configured to read from. In this case, we're substituting the second x.y.z version from <4.3.0 reference, with the latest 4.4.z z-stream release.