### PR TITLE
hack,test: Prepend the namespace prefix to the testing namespace label we apply for multi-tenancy.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -12,8 +12,8 @@ function cleanup() {
     exit_status=$?
 
     if [[ "${METERING_RUN_DEV_TEST_SETUP}" = false ]]; then
-        echo "Removing namespaces with the 'name=metering-testing-ns' label"
-        kubectl delete ns -l "name=metering-testing-ns" || true
+        echo "Removing namespaces with the 'name=${METERING_NAMESPACE}-metering-testing-ns' label"
+        kubectl delete ns -l "name=${METERING_NAMESPACE}-metering-testing-ns" --wait=false || true
     else
         echo "Skipping the namespace deletion"
     fi

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -51,6 +51,7 @@ type DeployFramework struct {
 	RunLocal          bool
 	RunDevSetup       bool
 	KubeConfigPath    string
+	NamespacePrefix   string
 	RepoDir           string
 	RepoVersion       string
 	OperatorResources *deploy.OperatorResources
@@ -114,6 +115,7 @@ func New(logger logrus.FieldLogger, runLocal, runDevSetup bool, nsPrefix, repoDi
 		KubeConfigPath:    kubeconfig,
 		RepoDir:           repoDir,
 		RepoVersion:       repoVersion,
+		NamespacePrefix:   nsPrefix,
 		RunLocal:          runLocal,
 		RunDevSetup:       runDevSetup,
 		Logger:            logger,

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -189,7 +189,7 @@ func (df *DeployFramework) NewDeployerConfig(
 		SubscriptionName: defaultSubscriptionName,
 		Channel:          defaultSubscriptionChannel,
 		ExtraNamespaceLabels: map[string]string{
-			"name": testNamespaceLabel,
+			"name": df.NamespacePrefix + "-" + testNamespaceLabel,
 		},
 		OperatorResources:        df.OperatorResources,
 		RunMeteringOperatorLocal: df.RunLocal,


### PR DESCRIPTION
It the current iteration of the e2e suite, we always add a `metering-testing-ns` namespace label to any namespace that gets created. This is problematic in the case where multiple people are running the e2e suite locally, where all namespaces matching the `metering-testing-ns` get deleted as of a result of finishing (or exiting the e2e.sh script early) e2e suite.

This updates the `deployframework` structure to include the `--namespace-prefix` that gets passed to the e2e package. For whatever reason, this field was never added, despite being passed to the `deployframework` constructor. Once we add this field, we can prepend that field when we're constructing a label to pass to the `deploy` metering package. Now, in the trap function for the e2e.sh script we can target only the labels that belong to the correct user.