### PR TITLE
[release-4.5] Bug 1847154: Fix the olm.skipRange CSV annotation being rendered incorrectly.

### DIFF
--- a/charts/metering-ansible-operator/templates/olm/clusterserviceversion.yaml
+++ b/charts/metering-ansible-operator/templates/olm/clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: placeholder
 {{- if .Values.olm.csv.annotations }}
   annotations:
+    olm.skipRange: {{ .Values.olm.csv.skipRange | quote }}
 {{ toYaml .Values.olm.csv.annotations | indent 4 }}
 {{- end }}
 {{- if .Values.olm.labels }}

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -216,6 +216,7 @@ olm:
   csv:
     name : metering-operator.v4.5.0
     version: "4.5.0"
+    skipRange: ">=4.2.0 <4.5.0"
     minKubeVersion: "1.11.0"
     displayName: Metering
     description: |
@@ -333,7 +334,6 @@ olm:
       containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.5"
       description: 'Chargeback and reporting tool to provide accountability for how resources are used across a cluster'
       repository: https://github.com/kube-reporting/metering-operator
-      olm.skipRange: ">=4.2.0 <4.5.0"
       alm-examples: |-
         [
           {

--- a/manifests/deploy/openshift/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: metering-operator.v4.5.0
   namespace: placeholder
   annotations:
+    olm.skipRange: ">=4.2.0 <4.5.0"
     alm-examples: |-
       [
         {
@@ -209,7 +210,6 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
-    olm.skipRange: '>=4.2.0 <4.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'

--- a/manifests/deploy/upstream/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.5/meteringoperator.v4.5.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: metering-operator-upstream.v4.5.0
   namespace: placeholder
   annotations:
+    olm.skipRange: ">=4.2.0 <4.5.0"
     alm-examples: |-
       [
         {
@@ -209,7 +210,6 @@ metadata:
     createdAt: 2019-01-01T11:59:59Z
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
-    olm.skipRange: '>=4.2.0 <4.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'


### PR DESCRIPTION
In the art.yaml, which defines the substitution rules for ART, we search for this olm.skipRange annotation in the Metering CSV file:

```yaml
    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
```

What's problematic here is that we're searching for strings that start with double-quotes, but helm renders all of the chart's annotations as single quotes, instead of quote, so the search for that string fails and the end result is ART cannot properly substitute the 4.5 version.