### PR TITLE
Bug 1844240: Fix many-to-many occasional e2e errors by adding `label_replace()` to handle missing `volumename`

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -197,7 +197,7 @@ openshift-reporting:
             spec:
               prometheusMetricsImporter:
                 query: |
-                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(label_replace(kube_persistentvolumeclaim_info, "volumename", "$1", "volumename", "(.+)")) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(label_replace(kube_persistentvolumeclaim_info, "volumename", "$1", "volumename", "(.*)")) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
           - name: persistentvolumeclaim-usage-bytes
             spec:
               prometheusMetricsImporter:

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -197,7 +197,7 @@ openshift-reporting:
             spec:
               prometheusMetricsImporter:
                 query: |
-                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(label_replace(kube_persistentvolumeclaim_info, "volumename", "$1", "volumename", "(.+)")) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
           - name: persistentvolumeclaim-usage-bytes
             spec:
               prometheusMetricsImporter:

--- a/pkg/operator/prestostore/query.go
+++ b/pkg/operator/prestostore/query.go
@@ -78,6 +78,7 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 		})
 
 		promLogger.Debugf("querying Prometheus using range %s to %s", timeRange.Start, timeRange.End)
+		promLogger.Debugf("Prometheus query is: %s", cfg.PrometheusQuery)
 
 		queryStart := clock.Now()
 		pVal, err := promConn.QueryRange(ctx, cfg.PrometheusQuery, timeRange)


### PR DESCRIPTION
We occasionally see errors of the type:

```bash
errored: failed to perform Prometheus query: execution: found duplicate series for the match group {namespace=\"metering-validhdfs-reportdynamicinputdata\", persistentvolumeclaim=\"hive-metastore-db-data\"} on the right hand-side of the operation: [{namespace=\"metering-validhdfs-reportdynamicinputdata\", persistentvolumeclaim=\"hive-metastore-db-data\", storageclass=\"gp2\", volumename=\"pvc-e7ea4ab5-b8e6-4f87-8f16-c4cfc84d19db\"}, {namespace=\"metering-validhdfs-reportdynamicinputdata\", persistentvolumeclaim=\"hive-metastore-db-data\", storageclass=\"gp2\"}];many-to-many matching not allowed: matching labels must be unique on one side"
```

Checking the Prometheus code we see:

```go
ev.errorf("found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]"+";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, rs.Metric.String(), duplSample.Metric.String())
```

Matching that up with the specific error above we get:

```
matchedLabels.String: {namespace=\"metering-validhdfs-reportdynamicinputdata\", persistentvolumeclaim=\"hive-metastore-db-data\"}
oneSide: right
rs.Metric:      {namespace=\"metering-validhdfs-reportdynamicinputdata\", persistentvolumeclaim=\"hive-metastore-db-data\", storageclass=\"gp2\", volumename=\"pvc-e7ea4ab5-b8e6-4f87-8f16-c4cfc84d19db\"}
duplSample: {namespace=\"metering-validhdfs-reportdynamicinputdata\", persistentvolumeclaim=\"hive-metastore-db-data\", storageclass=\"gp2\"}
```
So it appears we lack the `volumename` sometimes on the right hand side. Adding `label_replace` with a regex matching on anything, or nothing, should mean that we always have at least an empty `volumename` label and avoid the error.

This SO was helpful: https://stackoverflow.com/questions/54235797/how-to-rename-label-within-a-metric-in-prometheus

This SO makes sense after you read it about 5 times: https://stackoverflow.com/questions/52625815/prometheus-many-to-many-matching-not-allowed