### PR TITLE
First pass jq faq without hack/faq.repo copy

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -7,14 +7,13 @@ FROM openshift/origin-cli:latest as cli
 FROM openshift/origin-release:golang-1.13
 
 # our copy of faq and jq
-COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo
+#COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo
 
 # ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
-RUN INSTALL_PKGS="curl jq-1.6-2.el7 faq rh-python36" && \
+RUN INSTALL_PKGS="curl jq faq rh-python36" && \
     yum clean all && rm -rf /var/cache/yum/* && \
     yum -y install centos-release-scl && \
-    yum -y remove jq && \
     yum install --setopt=skip_missing_names_on_install=False -y $INSTALL_PKGS && \
     yum clean all && \
     rm -rf /var/cache/yum


### PR DESCRIPTION
WIP
We are encountering a build error, likely due to a dependency being removed:

```
Error: Package: jq-1.6-2.el7.x86_64 (ecnahc515-faq)
           Requires: libonig.so.2()(64bit)
Error: Package: faq-0.0.6-1.el7.x86_64 (ecnahc515-faq)
           Requires: libonig.so.2()(64bit) 
```