### PR TITLE
Revert "Bug 1844240: Fix many-to-many occasional e2e errors by adding `label_replace()` to handle missing `volumename`"

### DIFF
--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -197,7 +197,7 @@ openshift-reporting:
             spec:
               prometheusMetricsImporter:
                 query: |
-                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(label_replace(kube_persistentvolumeclaim_info, "volumename", "$1", "volumename", "(.*)")) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
           - name: persistentvolumeclaim-usage-bytes
             spec:
               prometheusMetricsImporter:

--- a/pkg/operator/prestostore/query.go
+++ b/pkg/operator/prestostore/query.go
@@ -78,7 +78,6 @@ func ImportFromTimeRange(logger logrus.FieldLogger, clock clock.Clock, promConn 
 		})
 
 		promLogger.Debugf("querying Prometheus using range %s to %s", timeRange.Start, timeRange.End)
-		promLogger.Debugf("Prometheus query is: %s", cfg.PrometheusQuery)
 
 		queryStart := clock.Now()
 		pVal, err := promConn.QueryRange(ctx, cfg.PrometheusQuery, timeRange)


### PR DESCRIPTION
Reverts kube-reporting/metering-operator#1257