### PR TITLE
hack: Add the '-mod=vendor' go test option.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -59,6 +59,7 @@ set -x
 echo "Running E2E Tests"
 
 go test \
+    -mod=vendor \
     -test.short="${METERING_SHORT_TESTS}" \
     -test.v \
     -parallel 10 \


### PR DESCRIPTION
This is a nice to have, especially when the repository structure is still using the old $GOPATH style.