### PR TITLE
images: Fix conditional when checking if the cluster-wide proxy has been configured.

### DIFF
--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_networking.yml
@@ -71,7 +71,7 @@
     _ocp_enabled_global_proxy_https_proxy: "{{ _cluster_proxy_config.status.httpsProxy }}"
   no_log: true
   when:
-  - cluster_proxy_config is defined
+  - cluster_proxy.config.resources is defined
   - cluster_proxy_config.resources | length > 0
   - _cluster_proxy_config.status is defined
   - _cluster_proxy_config.status | length > 0


### PR DESCRIPTION

The first conditional check was configured to check if the `cluster_proxy_config` variable was defined. This is problematic check as that variable is the registered output of querying for the OCP cluster-wide proxy object, and in the case of Ansible, a registered variable will always be defined even if a task has been skipped. If we, instead, check if the `.resources` dictionary key is defined instead of the top-level object, that's sufficient as a baseline check.