### PR TITLE
pkg/deploy: Update the label selector used to delete the metering clusterroles/clusterrolebindings.

### DIFF
--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -246,7 +246,6 @@ func (deploy *Deployer) uninstallMeteringRole() error {
 
 func (deploy *Deployer) uninstallMeteringClusterRole() error {
 	res := deploy.config.OperatorResources.ClusterRole
-
 	res.Name = deploy.config.Namespace + "-" + res.Name
 
 	err := deploy.client.RbacV1().ClusterRoles().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
@@ -258,9 +257,10 @@ func (deploy *Deployer) uninstallMeteringClusterRole() error {
 		return err
 	}
 
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
 	// attempt to delete any of the clusterroles the reporting-operator creates
 	err = deploy.client.RbacV1().ClusterRoles().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
-		LabelSelector: "app=reporting-operator",
+		LabelSelector: labelSelector,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list all the reporting-operator clusterroles in the %s namespace: %v", deploy.config.Namespace, err)
@@ -289,9 +289,10 @@ func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
 		return err
 	}
 
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
 	// attempt to delete any of the clusterrolebindings the reporting-operator creates
 	err = deploy.client.RbacV1().ClusterRoleBindings().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
-		LabelSelector: "app=reporting-operator",
+		LabelSelector: labelSelector,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list all the reporting-operator clusterrolebindings in the %s namespace: %v", deploy.config.Namespace, err)


### PR DESCRIPTION
When we're reconciling the clusterrole and clusterrolebinding resources for the reporting-operator, we add a pruning label for those resources:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    operator-sdk/primary-resource: tflannag/operator-metering
    operator-sdk/primary-resource-type: MeteringConfig.metering.openshift.io
  creationTimestamp: "2020-06-23T16:29:24Z"
  labels:
    app: reporting-operator
    metering.openshift.io/ns-prune: tflannag
    metering.openshift.io/prune: cluster-monitoring-view-rbac
```

These are namely hacks to ensure we clean up all resources properly, but you can see that we tag the watched namespace and the resource with a `metering.openshift.io/*prune*` label to track these resources.

In the past implementation, we only searched for clusterroles and clusterrolebindings that met the `app=reporting-operator` label selector, but we should also be searching for that namespace pruning label to avoid deleting other tenant's resources.