### PR TITLE
Dockerfile.src: Get the faq dependency via a static Linux binary.

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -1,17 +1,19 @@
 # need helm CLI for final image
-FROM quay.io/openshift/origin-metering-helm:latest as helm
+FROM quay.io/openshift/origin-metering-helm:4.4 as helm
 
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli as cli
 
 FROM openshift/origin-release:golang-1.13
 
-# our copy of faq and jq
-COPY hack/faq.repo /etc/yum.repos.d/ecnahc515-faq-epel-7.repo
+# go get faq via static Linux binary approach
+ARG LATEST_RELEASE=0.0.6
+RUN curl -Lo /usr/local/bin/faq https://github.com/jzelinskie/faq/releases/download/$LATEST_RELEASE/faq-linux-amd64
+RUN chmod +x /usr/local/bin/faq
 
 # ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
-RUN INSTALL_PKGS="curl jq-1.6-2.el7 faq rh-python36" && \
+RUN INSTALL_PKGS="rh-python36" && \
     yum clean all && rm -rf /var/cache/yum/* && \
     yum -y install centos-release-scl && \
     yum -y remove jq && \


### PR DESCRIPTION
Our CI is configured to use this Dockerfile as the build root - it essentially just adds things like `operator-courier`, `faq`, `helm`, etc. that get used throughout our testing configuration.