### PR TITLE
cmd,pkg/deploy: Support passing a list of configurable OLM flagsets/environment variables.

### DIFF
--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -89,8 +89,14 @@ func init() {
 	uninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")
 
+	// TODO: probably need to refactor this structure as the uninstallCmd and olmUninstallCmd
+	// are both using the same flagset. We could switch to an installCmd and uninstallCmd, and
+	// have a --olm sub-command configuration so we could share flags between install/uninstall.
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
+	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
+	olmUninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
+	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")
 
 	installCmd.Flags().StringVar(&cfg.Repo, "repo", "", "The name of the metering-ansible-operator image repository. This can also be specified through the METERING_OPERATOR_IMAGE_REPO ENV var.")
 	installCmd.Flags().StringVar(&cfg.Tag, "tag", "", "The name of the metering-ansible-operator image tag. This can also be specified through the METERING_OPERATOR_IMAGE_TAG ENV var.")
@@ -98,6 +104,9 @@ func init() {
 	installCmd.Flags().BoolVar(&cfg.RunMeteringOperatorLocal, "run-metering-operator-local", false, "If true, skip installing the metering deployment. This can also be specified through the $SKIP_METERING_OPERATOR_DEPLOYMENT ENV var.")
 
 	olmInstallCmd.Flags().StringVar(&cfg.SubscriptionName, "subscription", "metering-ocp", "The name of the metering subscription that gets created.")
+	olmInstallCmd.Flags().StringVar(&cfg.CatalogSourceName, "catalog-source", "redhat-operators", "The name of the metering subscription that gets created.")
+	olmInstallCmd.Flags().StringVar(&cfg.CatalogSourceNamespace, "catalog-source-namespace", "openshift-marketplace", "The name of the metering subscription that gets created.")
+	olmInstallCmd.Flags().StringVar(&cfg.PackageName, "package", "metering-ocp", "The name of an existing package manifest from a CatalogSource.")
 	olmInstallCmd.Flags().StringVar(&cfg.Channel, "channel", "4.4", "The metering channel to subscribe to. Examples: 4.2, 4.3, 4.4, etc.")
 
 	if err := initFlagsFromEnv(); err != nil {
@@ -256,12 +265,32 @@ func initFlagsFromEnv() error {
 			},
 		},
 		{
+			cmd: olmUninstallCmd,
+			env: map[string]string{
+				"METERING_DELETE_CRB":       "delete-crb",
+				"METERING_DELETE_CRDS":      "delete-crd",
+				"METERING_DELETE_PVCS":      "delete-pvc",
+				"METERING_DELETE_NAMESPACE": "delete-namespace",
+				"METERING_DELETE_ALL":       "delete-all",
+			},
+		},
+		{
 			cmd: installCmd,
 			env: map[string]string{
 				"SKIP_METERING_OPERATOR_DEPLOYMENT": "skip-metering-operator-deployment",
 				"METERING_OPERATOR_IMAGE_REPO":      "repo",
 				"METERING_OPERATOR_IMAGE_TAG":       "tag",
 				"DEPLOY_METERING_OPERATOR_LOCAL":    "run-metering-operator-local",
+			},
+		},
+		{
+			cmd: olmInstallCmd,
+			env: map[string]string{
+				"METERING_OLM_SUBSCRIPTION":             "subscription",
+				"METERING_OLM_CATALOG_SOURCE":           "catalog-source",
+				"METERING_OLM_CATALOG_SOURCE_NAMESPACE": "catalog-source-namespace",
+				"METERING_OLM_PACKAGE":                  "package",
+				"METERING_OLM_CHANNEL":                  "channel",
 			},
 		},
 	}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -75,6 +75,9 @@ type Config struct {
 	Repo                     string
 	Tag                      string
 	Channel                  string
+	PackageName              string
+	CatalogSourceName        string
+	CatalogSourceNamespace   string
 	SubscriptionName         string
 	ExtraNamespaceLabels     map[string]string
 	OperatorResources        *OperatorResources
@@ -228,6 +231,12 @@ func (deploy *Deployer) UninstallOLM() error {
 		return fmt.Errorf("failed to uninstall the metering OperatorGroup: %v", err)
 	}
 
+	if deploy.config.DeletePVCs {
+		err = deploy.uninstallMeteringPVCs()
+		if err != nil {
+			return fmt.Errorf("failed to uninstall the Metering PVCs: %v", err)
+		}
+	}
 	if deploy.config.DeleteCRDs {
 		err = deploy.uninstallMeteringCRDs()
 		if err != nil {
@@ -238,6 +247,17 @@ func (deploy *Deployer) UninstallOLM() error {
 		err = deploy.uninstallNamespace()
 		if err != nil {
 			return fmt.Errorf("failed to uninstall the %s metering namespace: %v", deploy.config.Namespace, err)
+		}
+	}
+	if deploy.config.DeleteCRB {
+		err = deploy.uninstallReportingOperatorClusterRole()
+		if err != nil {
+			return fmt.Errorf("failed to delete the reporting-operator ClusterRole resources: %v", err)
+		}
+
+		err = deploy.uninstallReportingOperatorClusterRoleBinding()
+		if err != nil {
+			return fmt.Errorf("failed to delete the reporting-operator ClusterRoleBinding resources: %v", err)
 		}
 	}
 

--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,6 +135,15 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 		if err != nil {
 			return fmt.Errorf("failed to delete the metering cluster role binding: %v", err)
 		}
+		err = deploy.uninstallReportingOperatorClusterRole()
+		if err != nil {
+			return fmt.Errorf("failed to delete the reporting-operator ClusterRole resources: %v", err)
+		}
+
+		err = deploy.uninstallReportingOperatorClusterRoleBinding()
+		if err != nil {
+			return fmt.Errorf("failed to delete the reporting-operator ClusterRoleBinding resources: %v", err)
+		}
 	} else {
 		deploy.logger.Infof("Skipped deleting the metering cluster role resources")
 	}
@@ -264,15 +274,37 @@ func (deploy *Deployer) uninstallMeteringClusterRole() error {
 	}
 	deploy.logger.Infof("Deleted the metering cluster role")
 
+	return nil
+}
+
+func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
 	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
+
 	// attempt to delete any of the clusterroles the reporting-operator creates
-	err = deploy.client.RbacV1().ClusterRoles().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+	crs, err := deploy.client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list all the reporting-operator clusterroles in the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to list all the reporting-operator ClusterRoles resources: %v", err)
 	}
-	deploy.logger.Infof("Deleted the 'app=reporting-operator' cluster roles")
+
+	if len(crs.Items) == 0 {
+		deploy.logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRole resources")
+		return nil
+	}
+
+	var errArr []string
+	for _, cr := range crs.Items {
+		err = deploy.client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
+		if err != nil {
+			errArr = append(errArr, fmt.Sprintf("failed to delete the %s ClusterRole resource: %v", cr.Name, err))
+		}
+		deploy.logger.Infof("Deleted the %s ClusterRole resource", cr.Name)
+	}
+
+	if len(errArr) != 0 {
+		return fmt.Errorf(strings.Join(errArr, "\n"))
+	}
 
 	return nil
 }
@@ -305,6 +337,37 @@ func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
 		return fmt.Errorf("failed to list all the reporting-operator clusterrolebindings in the %s namespace: %v", deploy.config.Namespace, err)
 	}
 	deploy.logger.Infof("Deleted the 'app=reporting-operator' cluster role bindings")
+
+	return nil
+}
+
+func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
+
+	// attempt to delete any of the clusterroles the reporting-operator creates
+	crbs, err := deploy.client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list all the 'app=reporting-operator' ClusterRoleBindings: %v", err)
+	}
+
+	if len(crbs.Items) == 0 {
+		deploy.logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRoleBinding resources")
+		return nil
+	}
+
+	var errArr []string
+	for _, crb := range crbs.Items {
+		err = deploy.client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{})
+		if err != nil {
+			errArr = append(errArr, fmt.Sprintf("failed to delete the %s ClusterRoleBinding resource: %v", crb.Name, err))
+		}
+		deploy.logger.Infof("Deleted the %s ClusterRoleBinding resource", crb.Name)
+	}
+	if len(errArr) != 0 {
+		return fmt.Errorf(strings.Join(errArr, "\n"))
+	}
 
 	return nil
 }

--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -52,16 +52,20 @@ func (deploy *Deployer) uninstallMeteringOperatorGroup() error {
 }
 
 func (deploy *Deployer) uninstallMeteringSubscription() error {
-	// TODO: add configuration flag for setting the subscription name instead of hardcoding the openshift package name
-	err := deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Delete(context.TODO(), "metering-ocp", metav1.DeleteOptions{})
+	_, err := deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Get(context.TODO(), deploy.config.SubscriptionName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering Subscription resource does not exist")
+		deploy.logger.Warnf("The %s metering Subscription in the %s namespace does not exist", deploy.config.SubscriptionName, deploy.config.Namespace)
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("failed to delete the metering Subscription: %v", err)
+		return err
 	}
-	deploy.logger.Infof("Deleted the metering Subscription resource")
+
+	err = deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Delete(context.TODO(), deploy.config.SubscriptionName, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete the %s metering Subscription in the %s namespace: %v", deploy.config.SubscriptionName, deploy.config.Namespace, err)
+	}
+	deploy.logger.Infof("Deleted the %s metering Subscription resource in the %s namespace", deploy.config.SubscriptionName, deploy.config.Namespace)
 
 	return nil
 }
@@ -81,14 +85,15 @@ func (deploy *Deployer) uninstallMeteringCSV() error {
 	}
 
 	if sub.Status.CurrentCSV == "" {
-		return fmt.Errorf("failed to get the currentCSV stored in the %s metering Subscription", deploy.config.SubscriptionName)
+		return fmt.Errorf("failed to get the 'status.currentCSV' stored in the %s metering Subscription resource", deploy.config.SubscriptionName)
 	}
+
 	csvName := sub.Status.CurrentCSV
-	deploy.logger.Infof("Found existing metering subscription, attempting to delete the %s CSV", csvName)
+	deploy.logger.Infof("Found an existing metering subscription, attempting to delete the %s CSV", csvName)
 
 	csv, err := deploy.olmV1Alpha1Client.ClusterServiceVersions(deploy.config.Namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering CSV does not exist")
+		deploy.logger.Warnf("The %s metering CSV resource does not exist", csvName)
 		return nil
 	}
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -97,9 +102,9 @@ func (deploy *Deployer) uninstallMeteringCSV() error {
 
 	err = deploy.olmV1Alpha1Client.ClusterServiceVersions(deploy.config.Namespace).Delete(context.TODO(), csv.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete the metering Subscription: %v", err)
+		return fmt.Errorf("failed to delete the %s metering CSV resource: %v", csvName, err)
 	}
-	deploy.logger.Infof("Deleted the metering Subscription resource")
+	deploy.logger.Infof("Deleted the %s metering CSV resource in the %s namespace", csvName, deploy.config.Namespace)
 
 	return nil
 }


### PR DESCRIPTION
This functionality was mainly only used for upgrade testing in our e2e suite, so the creating and deletion of OLM resources like a Subscription were configured to use several constants/hardcoded values, like using the redhat-operators CatalogSource and the `metering-ocp` package name.

Now, you can specify the subscription name, the name, and namespace of an existing CatalogSource resource, etc. This will be mainly used for updating the e2e suite to deploy Metering using OLM, instead of manually creating the requisite objects, so this work is intended to be iterative.