### PR TITLE
hack,olm_deploy: Add an additional set of manifests used to build a local bundle registry.

### DIFF
--- a/hack/push-olm-manifests.sh
+++ b/hack/push-olm-manifests.sh
@@ -5,11 +5,10 @@ set -o pipefail
 ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
 source "${ROOT_DIR}/hack/common.sh"
 
-OLM_PACKAGE_ORG="${1:?}"
-OLM_PACKAGE_NAME="${2:?}"
-MANIFEST_BUNDLE="${3:-$OCP_OLM_MANIFESTS_DIR/bundle}"
-OLM_PACKAGE_VERSION="${OLM_PACKAGE_VERSION:-"4.4.0-$(date +'%Y%m%d%H%M%S')"}"
-: "${QUAY_AUTH_TOKEN:?}"
+IMAGE_METERING_ANSIBLE_OPERATOR_REGISTRY="${1:?}"
+MANIFEST_BUNDLE="${2:-manifests/deploy/openshift/olm/bundle}"
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
 
-echo "operator-courier push $MANIFEST_BUNDLE ${OLM_PACKAGE_ORG} ${OLM_PACKAGE_NAME} ${OLM_PACKAGE_VERSION} <ommited>"
-operator-courier push "$MANIFEST_BUNDLE" "${OLM_PACKAGE_ORG}" "${OLM_PACKAGE_NAME}" "${OLM_PACKAGE_VERSION}" "${QUAY_AUTH_TOKEN}"
+echo "Building and pushing the operator manifest bundle to ${IMAGE_METERING_ANSIBLE_OPERATOR_REGISTRY}"
+${CONTAINER_RUNTIME} build -f ${ROOT_DIR}/olm_deploy/Dockerfile.registry -t ${IMAGE_METERING_ANSIBLE_OPERATOR_REGISTRY} --build-arg MANIFEST_BUNDLE=${MANIFEST_BUNDLE} .
+${CONTAINER_RUNTIME} push ${IMAGE_METERING_ANSIBLE_OPERATOR_REGISTRY}

--- a/olm_deploy/Dockerfile.registry
+++ b/olm_deploy/Dockerfile.registry
@@ -1,0 +1,17 @@
+FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+
+WORKDIR /
+ARG MANIFEST_BUNDLE
+COPY ${MANIFEST_BUNDLE} /manifests
+
+# Need to remove the art.yaml and image-references files from the list of OLM
+# manifests as those are invalid in a manifest bundle
+RUN chmod -R g+w /manifests && rm /manifests/art.yaml /manifests/*/image-references
+COPY olm_deploy/scripts/ /scripts/
+
+COPY --from=builder /bin/initializer /usr/bin/initializer
+COPY --from=builder /bin/registry-server /usr/bin/registry-server
+COPY --from=builder /bin/grpc_health_probe /usr/bin/grpc_health_probe
+
+WORKDIR /bundle

--- a/olm_deploy/manifests/deployment.yaml
+++ b/olm_deploy/manifests/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metering-ansible-operator-registry
+  labels:
+    registry.operator.metering-ansible: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      registry.operator.metering-ansible: "true"
+  template:
+    metadata:
+      labels:
+        registry.operator.metering-ansible: "true"
+      name: metering-ansible-operator-registry
+    spec:
+      initContainers:
+      - name: mutate-csv-and-generate-sqlite-db
+        image: ${IMAGE_METERING_ANSIBLE_OPERATOR_REGISTRY}
+        imagePullPolicy: Always
+        command:
+        - sh
+        args:
+        - /scripts/init-bundle-registry.sh
+        volumeMounts:
+        - name: workdir
+          mountPath: /bundle
+        env:
+        - name: IMAGE_METERING_ANSIBLE_OPERATOR
+          value: registry.svc.ci.openshift.org/ocp/4.6:metering-ansible-operator
+        - name: IMAGE_METERING_REPORTING_OPERATOR
+          value: registry.svc.ci.openshift.org/ocp/4.6:metering-reporting-operator
+        - name: IMAGE_METERING_PRESTO
+          value: registry.svc.ci.openshift.org/ocp/4.6:metering-presto
+        - name: IMAGE_METERING_HIVE
+          value: registry.svc.ci.openshift.org/ocp/4.6:metering-hive
+        - name: IMAGE_METERING_HADOOP
+          value: registry.svc.ci.openshift.org/ocp/4.6:metering-hadoop
+        - name: IMAGE_GHOSTUNNEL
+          value: registry.svc.ci.openshift.org/ocp/4.6:ghostunnel
+        - name: IMAGE_OAUTH_PROXY
+          value: registry.svc.ci.openshift.org/ocp/4.6:oauth-proxy
+
+      containers:
+      - name: metering-ansible-operator-registry
+        image: ${IMAGE_METERING_ANSIBLE_OPERATOR_REGISTRY}
+        imagePullPolicy: Always
+        command:
+        - /usr/bin/registry-server
+        - --database=/bundle/bundles.db
+        volumeMounts:
+        - name: workdir
+          mountPath: /bundle
+        ports:
+        - containerPort: 50051
+          name: grpc
+          protocol: TCP
+        livenessProbe:
+          exec:
+            command:
+            - grpc_health_probe
+            - -addr=localhost:50051
+        readinessProbe:
+          exec:
+            command:
+            - grpc_health_probe
+            - -addr=localhost:50051
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      volumes:
+      - name: workdir
+        emptyDir: {}

--- a/olm_deploy/manifests/service.yaml
+++ b/olm_deploy/manifests/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metering-ansible-operator-registry
+  labels:
+    registry.operator.metering-ansible: "true"
+spec:
+  type: ClusterIP
+  selector:
+    registry.operator.metering-ansible: "true"
+  ports:
+  - name: grpc
+    port: 50051
+    protocol: TCP
+    targetPort: 50051
+  sessionAffinity: None

--- a/olm_deploy/scripts/init-bundle-registry.sh
+++ b/olm_deploy/scripts/init-bundle-registry.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eou pipefail
+
+echo -e "Dumping IMAGE env vars\n"
+env | grep IMAGE
+echo -e "\n\n"
+
+# Need to handle the case where the metering and reporting operator images have already been set
+# Right now, we're depending on the METERING_OPERATOR_IMAGE_REPO and METERING_OPERATOR_IMAGE_TAG
+# (and the same for the reporting-operator) so we need to remain consistent with that approach
+IMAGE_METERING_ANSIBLE_OPERATOR=${IMAGE_METERING_ANSIBLE_OPERATOR:-registry.svc.ci.openshift.org/ocp/4.6:metering-ansible-operator}
+IMAGE_METERING_REPORTING_OPERATOR=${IMAGE_METERING_REPORTING_OPERATOR:-registry.svc.ci.openshift.org/ocp/4.6:metering-reporting-operator}
+IMAGE_METERING_PRESTO=${IMAGE_METERING_PRESTO:-registry.svc.ci.openshift.org/ocp/4.6:metering-presto}
+IMAGE_METERING_HIVE=${IMAGE_METERING_HIVE:-registry.svc.ci.openshift.org/ocp/4.6:metering-hive}
+IMAGE_METERING_HADOOP=${IMAGE_METERING_HADOOP:-registry.svc.ci.openshift.org/ocp/4.6:metering-hadoop}
+IMAGE_GHOSTUNNEL=${IMAGE_GHOSTUNNEL:-registry.svc.ci.openshift.org/ocp/4.6:ghostunnel}
+IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.svc.ci.openshift.org/ocp/4.6:oauth-proxy}
+
+# update the manifest with the image built by ci
+sed -i "s,quay.io/openshift/origin-metering-ansible-operator:4.6,${IMAGE_METERING_ANSIBLE_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-metering-reporting-operator:4.6,${IMAGE_METERING_REPORTING_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-metering-presto:4.6,${IMAGE_METERING_PRESTO}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-metering-hive:4.6,${IMAGE_METERING_HIVE}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-metering-hadoop:4.6,${IMAGE_METERING_HADOOP}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-ghostunnel:4.6,${IMAGE_GHOSTUNNEL}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-oauth-proxy:4.6,${IMAGE_OAUTH_PROXY}," /manifests/*/*clusterserviceversion.yaml
+
+echo -e "substitution complete, dumping new csv\n\n"
+cat /manifests/*/*clusterserviceversion.yaml
+
+echo "Generating the sqlite database"
+/usr/bin/initializer --manifests=/manifests --output=/bundle/bundles.db --permissive=true


### PR DESCRIPTION
In order to deploy the most up-to-date operator bundle, we need to be able to create a CatalogSource custom resource that references an existing image.

We have a couple of different options for doing this:
- Create ConfigMap containing the package.yaml, CRDs, and CSV manifests.
- Build and push an image containing the manifest bundle and an initialized registry server to an image registry.
- Build and push an image containing the manifest bundle and serve the registry server locally.

In the case of CI, we need to take the third approach as they expose a series of environment variables pointing to the newly built metering/reporting operator images.

In the Dockerfile.registry, we copy over the current openshift manifest bundle to a known destination path in the container and copy over a script responsible for manipulating the CSV manifest with the images that get built by CI or provided by devs through the METERING_OPERATOR_IMAGE_*/REPORTING_OPERATOR_IMAGE_* variables.

In the manifest directory, we have a registry deployment, which is responsible for calling that CSV manipulation script we copied over in the Dockerfile.registry in an initContainer, and serving that updated manifest bundle in a local registry server. We also have a registry service, which is responsible for exposing this local registry and can be consumed by a CatalogSource custom resource using the ClusterIP of that service and the grpc port we defined.

This mainly mirrors the setup that cluster-logging and the cluster-resource-override-admission operators have already configured. The only main differences with those implementations are that we are going to instantiate and configure the CatalogSource and registry manifests in Go, instead of manipulating and applying those manifests using a client.

Other changes include updating the hack/push-olm-manifests.sh script to build a manifest bundle using this Dockerfile.registry that was introduced instead of the `operator-courier` tool, which we can't use anyways as it doesn't support v1 CRDs in an operator's bundle.
