### PR TITLE
Changes needed to accomodate the move of our forked Presto to  v328

### DIFF
--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -21,6 +21,7 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
+    http-server.https.keystore.key=notnull
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem
     node.internal-address-source=FQDN

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -22,6 +22,7 @@ data:
     http-server.https.enabled=true
     http-server.https.port=8080
 #   TODO revisit this once we move our forked Presto past v330 as there are security changes there that may effect this
+#    Presto as of v228 requires a non-null keystore password
     http-server.https.keystore.key=changeit
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -21,8 +21,6 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
-#   TODO revisit this once we move our forked Presto past v330 as there are security changes there that may effect this
-#    Presto as of v228 requires a non-null keystore password
     http-server.https.keystore.key=changeit
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem

--- a/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-coordinator-config.yaml
@@ -21,7 +21,8 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
-    http-server.https.keystore.key=notnull
+#   TODO revisit this once we move our forked Presto past v330 as there are security changes there that may effect this
+    http-server.https.keystore.key=changeit
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem
     node.internal-address-source=FQDN

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -20,7 +20,9 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
-    http-server.https.keystore.key=notnull
+#   TODO revisit this once we move our forked Presto past v330 as there are security changes there that may effect this
+#    Presto as of v228 requires a non-null keystore password
+    http-server.https.keystore.key=changeit
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem
     node.internal-address-source=FQDN

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -20,8 +20,6 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
-#   TODO revisit this once we move our forked Presto past v330 as there are security changes there that may effect this
-#    Presto as of v228 requires a non-null keystore password
     http-server.https.keystore.key=changeit
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem

--- a/charts/openshift-metering/templates/presto/presto-worker-config.yaml
+++ b/charts/openshift-metering/templates/presto/presto-worker-config.yaml
@@ -20,6 +20,7 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port=8080
+    http-server.https.keystore.key=notnull
     http-server.https.keystore.path=/opt/presto/tls/keystore.pem
     http-server.https.truststore.path=/opt/presto/tls/truststore.pem
     node.internal-address-source=FQDN


### PR DESCRIPTION
Will likely revisit these changes once our forked Presto version => 330 when more complete security changes were made to upstream.

Presto as of v228 requires a non-null keystore password