### PR TITLE
chart,manifests: Fix issue where configuring resource requirements for Metering gets purged.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -784,8 +784,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           subjectAccessReview:
                             type: object
                             required:
@@ -1254,8 +1256,10 @@ spec:
                         properties:
                           limits:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           requests:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       route:
                         type: object
                         required:
@@ -1767,8 +1771,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -1921,8 +1927,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -2199,8 +2207,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           storage:
                             type: object
                             properties:
@@ -2454,8 +2464,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           tolerations:
                             type: array
                             items:
@@ -2637,8 +2649,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:
@@ -2727,8 +2741,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -783,8 +783,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           subjectAccessReview:
                             type: object
                             required:
@@ -1253,8 +1255,10 @@ spec:
                         properties:
                           limits:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           requests:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       route:
                         type: object
                         required:
@@ -1766,8 +1770,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -1920,8 +1926,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -2198,8 +2206,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           storage:
                             type: object
                             properties:
@@ -2453,8 +2463,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           tolerations:
                             type: array
                             items:
@@ -2636,8 +2648,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:
@@ -2726,8 +2740,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringconfig.crd.yaml
@@ -783,8 +783,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           subjectAccessReview:
                             type: object
                             required:
@@ -1253,8 +1255,10 @@ spec:
                         properties:
                           limits:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           requests:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       route:
                         type: object
                         required:
@@ -1766,8 +1770,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -1920,8 +1926,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -2198,8 +2206,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           storage:
                             type: object
                             properties:
@@ -2453,8 +2463,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           tolerations:
                             type: array
                             items:
@@ -2636,8 +2648,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:
@@ -2726,8 +2740,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:

--- a/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
@@ -783,8 +783,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           subjectAccessReview:
                             type: object
                             required:
@@ -1253,8 +1255,10 @@ spec:
                         properties:
                           limits:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           requests:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       route:
                         type: object
                         required:
@@ -1766,8 +1770,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -1920,8 +1926,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -2198,8 +2206,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           storage:
                             type: object
                             properties:
@@ -2453,8 +2463,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           tolerations:
                             type: array
                             items:
@@ -2636,8 +2648,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:
@@ -2726,8 +2740,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringconfig.crd.yaml
@@ -783,8 +783,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           subjectAccessReview:
                             type: object
                             required:
@@ -1253,8 +1255,10 @@ spec:
                         properties:
                           limits:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           requests:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       route:
                         type: object
                         required:
@@ -1766,8 +1770,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -1920,8 +1926,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           terminationGracePeriodSeconds:
                             type: integer
                           tolerations:
@@ -2198,8 +2206,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           storage:
                             type: object
                             properties:
@@ -2453,8 +2463,10 @@ spec:
                             properties:
                               limits:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               requests:
                                 type: object
+                                x-kubernetes-preserve-unknown-fields: true
                           tolerations:
                             type: array
                             items:
@@ -2636,8 +2648,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:
@@ -2726,8 +2740,10 @@ spec:
                                 properties:
                                   limits:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   requests:
                                     type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                               storage:
                                 type: object
                                 properties:


### PR DESCRIPTION
I was seeing this pop up in the e2e test runs where the resource limits and request configurations in the MeteringConfig manifests weren't being rendered properly:

```yaml
...
  spec:
    hadoop:
      spec:
        hdfs:
          datanode:
            resources:
              requests: {}
            storage:
              size: 5Gi
          enabled: true
          namenode:
            resources:
              requests: {}
            storage:
              size: 5Gi
...
```

This is a result of moving from v1beta1 to v1 CRDs, which auto-purges any CRD schemas that aren't defined.

If we instead explicitly specify that we don't want these fields pruned by the apiserver, we get the following:

```yaml
...
  spec:
    hadoop:
      spec:
        hdfs:
          datanode:
            resources:
              requests:
                memory: 500Mi
            storage:
              size: 5Gi
          enabled: true
          namenode:
            resources:
              requests:
                memory: 500Mi
            storage:
              size: 5Gi
...
```