### PR TITLE
charts,manifests: Update the Report CRD to add a schema for 'spec.overwriteExistingData'.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/report.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/report.crd.yaml
@@ -54,6 +54,8 @@ spec:
                 format: date-time
               runImmediately:
                 type: boolean
+              overwriteExistingData:
+                type: boolean
               inputs:
                 type: array
                 minItems: 1

--- a/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
@@ -54,6 +54,8 @@ spec:
                 format: date-time
               runImmediately:
                 type: boolean
+              overwriteExistingData:
+                type: boolean
               inputs:
                 type: array
                 minItems: 1

--- a/manifests/deploy/openshift/olm/bundle/4.6/report.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/report.crd.yaml
@@ -54,6 +54,8 @@ spec:
                 format: date-time
               runImmediately:
                 type: boolean
+              overwriteExistingData:
+                type: boolean
               inputs:
                 type: array
                 minItems: 1

--- a/manifests/deploy/upstream/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/report.crd.yaml
@@ -54,6 +54,8 @@ spec:
                 format: date-time
               runImmediately:
                 type: boolean
+              overwriteExistingData:
+                type: boolean
               inputs:
                 type: array
                 minItems: 1

--- a/manifests/deploy/upstream/olm/bundle/4.6/report.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/report.crd.yaml
@@ -54,6 +54,8 @@ spec:
                 format: date-time
               runImmediately:
                 type: boolean
+              overwriteExistingData:
+                type: boolean
               inputs:
                 type: array
                 minItems: 1


### PR DESCRIPTION
It looks like this is a valid API field for the Report CRD, but wasn't added when we were initially adding the schema validation for this object. Before, when we were using apiextensions.k8s.io/v1beta1 CRDs, this was fine as the pruning of unknown fields defaulting to false, but now that we transitioned to v1 CRDs, we need to add this field as a valid schema property.