### PR TITLE
test/e2e: Add support for running any pre-installation tests.

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -47,12 +47,6 @@ var (
 	testMeteringConfigManifestsPath = "/test/e2e/testdata/meteringconfigs/"
 )
 
-type InstallTestCase struct {
-	Name         string
-	ExtraEnvVars []string
-	TestFunc     func(t *testing.T, testReportingFramework *reportingframework.ReportingFramework)
-}
-
 func init() {
 	runAWSBillingTests = os.Getenv("ENABLE_AWS_BILLING_TESTS") == "true"
 
@@ -140,6 +134,14 @@ func testMainWrapper(m *testing.M) int {
 	return m.Run()
 }
 
+type InstallTestCase struct {
+	Name         string
+	ExtraEnvVars []string
+	TestFunc     func(t *testing.T, testReportingFramework *reportingframework.ReportingFramework)
+}
+
+type PreInstallFunc func(ctx *deployframework.DeployerCtx) error
+
 func TestManualMeteringInstall(t *testing.T) {
 	testInstallConfigs := []struct {
 		Name                           string
@@ -149,6 +151,7 @@ func TestManualMeteringInstall(t *testing.T) {
 		ExpectInstallErr               bool
 		ExpectInstallErrMsg            []string
 		InstallSubTests                []InstallTestCase
+		PreInstallFunc                 PreInstallFunc
 		MeteringConfigManifestFilename string
 	}{
 		{
@@ -244,6 +247,7 @@ func TestManualMeteringInstall(t *testing.T) {
 				testOutputPath,
 				testCase.ExpectInstallErrMsg,
 				testCase.ExpectInstallErr,
+				testCase.PreInstallFunc,
 				testCase.InstallSubTests,
 			)
 		})

--- a/test/e2e/metering_manual_install_tests.go
+++ b/test/e2e/metering_manual_install_tests.go
@@ -28,6 +28,7 @@ func testManualMeteringInstall(
 	testOutputPath string,
 	expectInstallErrMsg []string,
 	expectInstallErr bool,
+	preInstallFunc PreInstallFunc,
 	testInstallFunctions []InstallTestCase,
 ) {
 	// create a directory used to store the @testCaseName container and resource logs
@@ -65,6 +66,11 @@ func testManualMeteringInstall(
 	)
 	require.NoError(t, err, "creating a new deployer context should produce no error")
 	defer deployerCtx.LoggerOutFile.Close()
+
+	if preInstallFunc != nil {
+		err = preInstallFunc(deployerCtx)
+		require.NoError(t, err, "expected no error while running any pre-install functions")
+	}
 
 	rf, err := deployerCtx.Setup(deployerCtx.Deployer.InstallOLM, expectInstallErr)
 


### PR DESCRIPTION
In order to add more flexibility to the e2e suite, we need to support creating any pre-installation resources before punting the current test context to the deploy-metering Go package. In order to do this we can create a function type that takes a deployframework.DeployerCtx object, with the assumption that when we run the preInstallFunc, that state has been initialized. This is useful in the case where we want to create things like an NFS provisioner, or create a secret containing the AWS credentials that will be used throughout the testing suite.