### PR TITLE
Additions for Report expiration

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/report.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/report.crd.yaml
@@ -52,6 +52,9 @@ spec:
               reportingEnd:
                 type: string
                 format: date-time
+              expiration:
+                type: string
+                format: duration
               runImmediately:
                 type: boolean
               overwriteExistingData:

--- a/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
@@ -52,6 +52,9 @@ spec:
               reportingEnd:
                 type: string
                 format: date-time
+              expiration:
+                type: string
+                format: duration
               runImmediately:
                 type: boolean
               overwriteExistingData:

--- a/manifests/deploy/openshift/olm/bundle/4.6/report.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/report.crd.yaml
@@ -52,6 +52,9 @@ spec:
               reportingEnd:
                 type: string
                 format: date-time
+              expiration:
+                type: string
+                format: duration
               runImmediately:
                 type: boolean
               overwriteExistingData:

--- a/manifests/deploy/upstream/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/report.crd.yaml
@@ -52,6 +52,9 @@ spec:
               reportingEnd:
                 type: string
                 format: date-time
+              expiration:
+                type: string
+                format: duration
               runImmediately:
                 type: boolean
               overwriteExistingData:

--- a/manifests/deploy/upstream/olm/bundle/4.6/report.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/report.crd.yaml
@@ -52,6 +52,9 @@ spec:
               reportingEnd:
                 type: string
                 format: date-time
+              expiration:
+                type: string
+                format: duration
               runImmediately:
                 type: boolean
               overwriteExistingData:

--- a/pkg/apis/metering/v1/report.go
+++ b/pkg/apis/metering/v1/report.go
@@ -34,6 +34,9 @@ type ReportSpec struct {
 	// Schedule configures when the report runs.
 	Schedule *ReportSchedule `json:"schedule,omitempty"`
 
+	// Expiration of the report. Report will be deleted once Report creation time + this retention period is reached, if no deps found
+	Expiration *meta.Duration `json:"expiration,omitempty"`
+
 	// ReportingStart specifies the time this Report should start from
 	// instead of the current time.
 	// This is intended for allowing a Report to start from the past

--- a/pkg/apis/metering/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/metering/v1/zz_generated.deepcopy.go
@@ -3057,6 +3057,11 @@ func (in *ReportSpec) DeepCopyInto(out *ReportSpec) {
 		*out = new(ReportSchedule)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Expiration != nil {
+		in, out := &in.Expiration, &out.Expiration
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.ReportingStart != nil {
 		in, out := &in.ReportingStart, &out.ReportingStart
 		*out = (*in).DeepCopy()

--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -118,7 +118,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 	}{
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -146,7 +146,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -187,7 +187,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -232,7 +232,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -394,7 +394,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -444,7 +444,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -475,7 +475,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -524,7 +524,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLFull(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -533,7 +533,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLFull(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -542,7 +542,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -682,7 +682,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -734,7 +734,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -765,7 +765,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -814,7 +814,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLTable(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -823,7 +823,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLTable(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -832,7 +832,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{

--- a/pkg/operator/reporting/templates_test.go
+++ b/pkg/operator/reporting/templates_test.go
@@ -180,7 +180,7 @@ func TestRenderQuery(t *testing.T) {
 				Query:          "SELECT * FROM {| reportTableName .Report.Inputs.MissingReportNameInReportsField |}",
 				RequiredInputs: []string{"MissingReportNameInReportsField"},
 				Reports: []*metering.Report{
-					testhelpers.NewReport("", testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+					testhelpers.NewReport("", testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 				},
 				PrestoTables: []*metering.PrestoTable{
 					newTestPrestoTable(ds1.Status.TableRef.Name, testNamespace, testCatalogName, testCatalogName, nil),
@@ -198,7 +198,7 @@ func TestRenderQuery(t *testing.T) {
 			name: "Report dependency was not found (due to Report.Name not matching name) returns error",
 			reportTemplate: &ReportQueryTemplateContext{
 				Reports: []*metering.Report{
-					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 				},
 				Query:             "SELECT * FROM {| reportTableName .Report.Inputs.ReportNameDoesNotMatchInputName |}",
 				RequiredInputs:    []string{"ReportNameDoesNotMatchInputName"},
@@ -223,7 +223,7 @@ func TestRenderQuery(t *testing.T) {
 				Reports: []*metering.Report{
 					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: ""},
-					}, nil, false),
+					}, nil, false, nil),
 				},
 			},
 			templateContext: TemplateContext{
@@ -242,7 +242,7 @@ func TestRenderQuery(t *testing.T) {
 				Reports: []*metering.Report{
 					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: testReportName},
-					}, nil, false),
+					}, nil, false, nil),
 				},
 				PrestoTables: []*metering.PrestoTable{
 					newTestPrestoTable(ds1.Status.TableRef.Name, testNamespace, testSchemaName, testCatalogName, nil),
@@ -264,7 +264,7 @@ func TestRenderQuery(t *testing.T) {
 				Reports: []*metering.Report{
 					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: testReportName},
-					}, nil, false),
+					}, nil, false, nil),
 				},
 				PrestoTables: []*metering.PrestoTable{
 					newTestPrestoTable(testReportName, testNamespace, testSchemaName, testCatalogName, nil),
@@ -532,7 +532,7 @@ func TestRenderQuery(t *testing.T) {
 				Reports: []*metering.Report{
 					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: ds1.Status.TableRef.Name},
-					}, nil, false),
+					}, nil, false, nil),
 				},
 				PrestoTables: []*metering.PrestoTable{
 					newTestPrestoTable(ds1.Status.TableRef.Name, testNamespace, testCatalogName, testCatalogName, nil),

--- a/pkg/operator/reporting/validate_test.go
+++ b/pkg/operator/reporting/validate_test.go
@@ -17,10 +17,10 @@ func TestValidateQueryDependencies(t *testing.T) {
 	dataSourceTableSet := testhelpers.NewReportDataSource("initialized-datasource", "default")
 	dataSourceTableSet.Status.TableRef.Name = reportingutil.DataSourceTableName("test-ns", "initialized-datasource")
 
-	reportTableUnset := testhelpers.NewReport("uninitialized-report", "default", "some-query", nil, nil, metering.ReportStatus{}, nil, false)
+	reportTableUnset := testhelpers.NewReport("uninitialized-report", "default", "some-query", nil, nil, metering.ReportStatus{}, nil, false, nil)
 	reportTableSet := testhelpers.NewReport("initialized-report", "default", "some-query", nil, nil, metering.ReportStatus{
 		TableRef: v1.LocalObjectReference{Name: reportingutil.ReportTableName("test-ns", "initialized-report")},
-	}, nil, false)
+	}, nil, false, nil)
 
 	uninitializedDataSources := []*metering.ReportDataSource{
 		dataSourceTableUnset,

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -91,7 +91,13 @@ func (op *Reporting) syncReport(logger log.FieldLogger, key string) error {
 		}
 		return err
 	}
+
 	sr := report.DeepCopy()
+
+	err = op.handleExpiredReport(sr, time.Now())
+	if err != nil {
+		return err
+	}
 
 	if report.DeletionTimestamp != nil {
 		_, err = op.removeReportFinalizer(sr)
@@ -347,6 +353,11 @@ func getReportPeriod(now time.Time, logger log.FieldLogger, report *metering.Rep
 func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) error {
 	// check if the report was previously finished; store result in bool
 	if reportFinished := isReportFinished(logger, report); reportFinished {
+		return nil
+	}
+
+	// check if report is expired (CreationTime + expiration). If true, stop processing and exit early.
+	if reportExpired := isReportExpired(logger, report, time.Now()); reportExpired {
 		return nil
 	}
 
@@ -742,6 +753,60 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) 
 	return nil
 }
 
+// We check first for Reports depending on this Report, return if any, and then check ReportQueries depending on Report
+func isReportNotUsedAsInput(report *metering.Report, op *Reporting) bool {
+	// Consider Reports referencing this report in the namespace of this report
+	reports, err := op.reportLister.Reports(report.Namespace).List(labels.Everything())
+	if err != nil {
+		op.logger.Errorf("unable to determine list of reports that might be input for report: %s", report.Name)
+		return false
+	}
+	for _, report := range reports {
+		// If Report has no spec.inputs it can't be depending on this report.
+		if report.Spec.Inputs == nil {
+			continue
+		}
+		if does, depReport := op.reportsDependOnThisReport(report, reports); does {
+			op.logger.Infof(
+				"report %s exists that uses report %s as input, "+
+					"will not delete though retention period has expired", depReport, report.Name)
+			return false
+		}
+	}
+	// Consider ReportQueries referencing this report in the namespace of this report
+	reportQueries, err := op.reportQueryLister.ReportQueries(report.Namespace).List(labels.Everything())
+	if err != nil {
+		op.logger.Errorf("unable to determine list of ReportQueries that might be input for report: %s", report.Name)
+		return false
+	}
+	for _, reportQuery := range reportQueries {
+		// If ReportQuery has no spec.inputs it can't be depending on this report.
+		if reportQuery.Spec.Inputs == nil {
+			continue
+		}
+
+		if does, depQuery := op.reportQueriesDependOnThisReport(report, reportQueries); does {
+			op.logger.Infof("ReportQuery, %s exists that uses report %s as input, " +
+				"will not delete though retention period has expired", depQuery, report.Name)
+			return false
+		}
+	}
+	return true
+}
+
+func isReportExpired(logger log.FieldLogger, report *metering.Report, currentTime time.Time) bool {
+	if report.Spec.Expiration != nil {
+		currentTimeNano := currentTime.UTC().Truncate(time.Millisecond).UnixNano()
+		reportCreationNano := report.ObjectMeta.CreationTimestamp.UTC().Truncate(time.Millisecond).UnixNano()
+		retentionAmountNano := report.Spec.Expiration.Nanoseconds()
+		if currentTimeNano > (reportCreationNano + retentionAmountNano) {
+			return true
+		}
+		logger.Infof("curr: %d, creat: %d, retain: %d", currentTimeNano, reportCreationNano, retentionAmountNano)
+	}
+	return false
+}
+
 func getRunOnceReportPeriod(report *metering.Report) (*reportPeriod, error) {
 	if report.Spec.ReportingEnd == nil || report.Spec.ReportingStart == nil {
 		return nil, fmt.Errorf("run-once reports must have both ReportingEnd and ReportingStart")
@@ -867,6 +932,47 @@ func (op *Reporting) queueDependentReportsForReport(report *metering.Report) err
 		}
 	}
 	return nil
+}
+
+// for each report in the namespace, find ones that depend on the report passed into the function
+func (op *Reporting) reportsDependOnThisReport(report *metering.Report, reports []*metering.Report) (bool, string) {
+	var depReportName = ""
+	for _, otherReport := range reports {
+		deps, err := op.getReportDependencies(otherReport)
+		if err != nil {
+			op.logger.Errorf("was unable to get dependencies for report: %s, while looking for dependent reports", report.Name)
+			return true, depReportName
+		}
+		// If a Report has a dependency on the passed in report, we're done
+		for _, dep := range deps.Reports {
+			if dep.Name == report.Name {
+				depReportName = dep.Name
+				return true, depReportName
+			}
+		}
+	}
+	return false, depReportName
+}
+
+// Look for all ReportQueries in the namespace
+func (op *Reporting) reportQueriesDependOnThisReport(report *metering.Report, reportQueries []*metering.ReportQuery) (bool, string) {
+	var depQueryName = ""
+	// for each report in the namespace, find queries that depend on the report passed into the function.
+	for _, reportQuery := range reportQueries {
+		deps, err := op.getQueryDependencies(reportQuery.Namespace, reportQuery.Name, nil)
+		if err != nil {
+			op.logger.Errorf("was unable to get dependencies for report: %s, while looking for dependent queries")
+			return true, ""
+		}
+		// If this ReportQuery has a dependency on the passed in report, we're done
+		for _, dep := range deps.Reports {
+			if dep.Name == report.Name {
+				depQueryName = dep.Name
+				return true, depQueryName
+			}
+		}
+	}
+	return false, depQueryName
 }
 
 // queueDependentReportQueriesForReport will queue all

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -936,7 +936,7 @@ func (op *Reporting) queueDependentReportsForReport(report *metering.Report) err
 
 // for each report in the namespace, find ones that depend on the report passed into the function
 func (op *Reporting) reportsDependOnThisReport(report *metering.Report, reports []*metering.Report) (bool, string) {
-	var depReportName = ""
+	var depReportName string
 	for _, otherReport := range reports {
 		deps, err := op.getReportDependencies(otherReport)
 		if err != nil {
@@ -946,17 +946,16 @@ func (op *Reporting) reportsDependOnThisReport(report *metering.Report, reports 
 		// If a Report has a dependency on the passed in report, we're done
 		for _, dep := range deps.Reports {
 			if dep.Name == report.Name {
-				depReportName = dep.Name
-				return true, depReportName
+				return true, dep.Name
 			}
 		}
 	}
 	return false, depReportName
 }
 
-// Look for all ReportQueries in the namespace
+// for each ReportQuery in the namespace, find ones that depend on the report passed into the function
 func (op *Reporting) reportQueriesDependOnThisReport(report *metering.Report, reportQueries []*metering.ReportQuery) (bool, string) {
-	var depQueryName = ""
+	var depQueryName string
 	// for each report in the namespace, find queries that depend on the report passed into the function.
 	for _, reportQuery := range reportQueries {
 		deps, err := op.getQueryDependencies(reportQuery.Namespace, reportQuery.Name, nil)
@@ -967,8 +966,7 @@ func (op *Reporting) reportQueriesDependOnThisReport(report *metering.Report, re
 		// If this ReportQuery has a dependency on the passed in report, we're done
 		for _, dep := range deps.Reports {
 			if dep.Name == report.Name {
-				depQueryName = dep.Name
-				return true, depQueryName
+				return true, dep.Name
 			}
 		}
 	}

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -126,7 +126,7 @@ func TestIsReportFinished(t *testing.T) {
 	}{
 		{
 			name:           "new report returns false",
-			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -135,7 +135,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
-			}, nil, false),
+			}, nil, false, nil),
 			expectFinished: true,
 		},
 		{
@@ -144,7 +144,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -154,7 +154,7 @@ func TestIsReportFinished(t *testing.T) {
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
 				LastReportTime: &metav1.Time{Time: reportStart.AddDate(0, 0, 0)},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -164,7 +164,7 @@ func TestIsReportFinished(t *testing.T) {
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
 				LastReportTime: &metav1.Time{Time: reportStart.AddDate(0, 2, 0)},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: true,
 		},
 		{
@@ -173,7 +173,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ScheduledReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -182,7 +182,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.ScheduledReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -191,7 +191,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.InvalidReportReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -200,7 +200,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.InvalidReportReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -209,7 +209,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 		{
@@ -218,7 +218,7 @@ func TestIsReportFinished(t *testing.T) {
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
-			}, schedule, false),
+			}, schedule, false, nil),
 			expectFinished: false,
 		},
 	}
@@ -322,43 +322,43 @@ func TestValidateReport(t *testing.T) {
 	}{
 		{
 			name:         "empty spec.query returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, "", reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:       testhelpers.NewReport(testReportName, testNamespace, "", reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectErr:    true,
 			expectErrMsg: "must set spec.query",
 		},
 		{
 			name:         "spec.ReportingStart > spec.ReportingEnd returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportEnd, reportStart, metering.ReportStatus{}, nil, false),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportEnd, reportStart, metering.ReportStatus{}, nil, false, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("spec.reportingEnd (%s) must be after spec.reportingStart (%s)", reportStart.String(), reportEnd.String()),
 		},
 		{
 			name:         "spec.ReportingEnd is unset and spec.RunImmediately is set returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, nil, metering.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, nil, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    true,
 			expectErrMsg: "spec.reportingEnd must be set if report.spec.runImmediately is true",
 		},
 		{
 			name:         "spec.QueryName does not exist returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("ReportQuery (%s) does not exist", testNonExistentQueryName),
 		},
 		{
 			name:         "valid report with missing DataSource returns error",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("failed to resolve ReportQuery dependencies %s: %s", testInvalidQueryName, "ReportDataSource.metering.openshift.io \"this-does-not-exist\" not found"),
 		},
 		{
 			name:         "valid report with uninitalized DataSource returns error",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName2, reportStart, reportEnd, metering.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName2, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("failed to validate ReportQuery dependencies %s: ReportQueryDependencyValidationError: uninitialized ReportDataSource dependencies: %s", testInvalidQueryName2, ds2.Name),
 		},
 		{
 			name:         "valid report with valid DataSource returns nil",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    false,
 			expectErrMsg: "",
 		},
@@ -411,47 +411,47 @@ func TestGetReportPeriod(t *testing.T) {
 	}{
 		{
 			name:      "invalid report with an unset spec.Schedule field returns an error",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false, nil),
 			expectErr: true,
 		},
 		{
 			name:      "valid report with an unset spec.Schedule field returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "invalid schedule with a set spec.Schedule field returns error",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, invalidSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, invalidSchedule, false, nil),
 			expectErr: true,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and a set Spec.Status.LastReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.ReportingStart returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and an unset Spec.ReportingStart returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.NextReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:        "unset Spec.Schedule with reportPeriod.periodStart > reportPeriod.periodEnd returns panic",
-			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportEnd, reportStart, metering.ReportStatus{NextReportTime: nextReportTime}, nil, false),
+			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportEnd, reportStart, metering.ReportStatus{NextReportTime: nextReportTime}, nil, false, nil),
 			expectErr:   false,
 			expectPanic: true,
 		},
@@ -472,6 +472,41 @@ func TestGetReportPeriod(t *testing.T) {
 					assert.Nil(t, err, "expected that getting the report period would return a nil error")
 				}
 			}
+		})
+	}
+}
+
+func TestReportsExpireAsExpected(t *testing.T) {
+	const (
+		testNamespace  = "default"
+		testReportName = "test-report"
+		testQueryName  = "test-query"
+	)
+
+	testTable := []struct {
+		name     string
+		nowAdder int
+		report   *metering.Report
+	}{
+		{
+			name:     "expired report should be deleted",
+			report:   testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false, &metav1.Duration{Duration: 1 * time.Minute}),
+			nowAdder: 1,
+		},
+		{
+			name:     "not expired report should not be deleted",
+			report:   testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false, &metav1.Duration{Duration: 1 * time.Minute}),
+			nowAdder: -1,
+		},
+	}
+
+	for _, testCase := range testTable {
+		var mockLogger = logrus.New()
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			result := isReportExpired(mockLogger, testCase.report, time.Now().Add(time.Minute*1).Add(time.Second*time.Duration(testCase.nowAdder)))
+			assert.True(t, result, "report should expire as expected")
 		})
 	}
 }

--- a/test/testhelpers/helpers.go
+++ b/test/testhelpers/helpers.go
@@ -24,7 +24,7 @@ import (
 )
 
 // NewReport creates a mock report used for testing purposes.
-func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status metering.ReportStatus, schedule *metering.ReportSchedule, runImmediately bool) *metering.Report {
+func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status metering.ReportStatus, schedule *metering.ReportSchedule, runImmediately bool, expiration *meta.Duration) *metering.Report {
 	var start, end *meta.Time
 	if reportStart != nil {
 		start = &meta.Time{Time: *reportStart}
@@ -43,6 +43,7 @@ func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *ti
 			ReportingEnd:   end,
 			Schedule:       schedule,
 			RunImmediately: runImmediately,
+			Expiration:     expiration,
 		},
 		Status: status,
 	}


### PR DESCRIPTION
Less WIP:

- Does have any required manifest changes;
- Does not have validation on the retention value provided;
- Does have consideration of `spec.input` dependencies (please check that seem complete and correct way to go about doing them though)

Note: Do we think the new `report.Spec.Expiration` on the Report CRD should just be a duration to be added to Report create timestamp?