### PR TITLE
hack: Bump the default channel in the get-metering-package-images script.

### DIFF
--- a/hack/get-metering-package-images.sh
+++ b/hack/get-metering-package-images.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# kubectl -n openshift-marketplace port-forward svc/art-applications 50051
+# Note: before running, ensure that the correct registry service is exposed
+# The following would expose the redhat-operators CatalogSource service:
+# kubectl -n openshift-marketplace port-forward svc/redhat-operators 50051
 
-CHANNEL="${CHANNEL:-"4.4"}"
+CHANNEL="${CHANNEL:-"4.6"}"
 
 read -r -d '' JQ_PROGRAM << EOM
  .spec.install.spec.deployments[0].spec.template.spec.containers[]


### PR DESCRIPTION
This script is useful for interacting with CatalogSource bundles locally, ensuring that the images listed in the bundle matches what you expect before creating a Subscription object.

The following will output the contents of the 4.5 metering-ocp package in the qe-app-registry CatalogSource:

```bash
$ kubectl -n openshift-marketplace port-forward svc/qe-app-registry 50051 &
...
$ ./hack/get-metering-package-images.sh 
export METERING_ANSIBLE_OPERATOR_IMAGE=quay.io/openshift-qe-optional-operators/ose-metering-ansible-operator@sha256:0d3766d650504a00bfe552a64c7d17f8ae905dfc1f3629a49d6d72f722cfee1b
export METERING_REPORTING_OPERATOR_IMAGE=quay.io/openshift-qe-optional-operators/ose-metering-reporting-operator@sha256:3f701a5539ac347e9bca2da31bc771384abe32560d7a7671e6962b2e5d9d8a87
export METERING_PRESTO_IMAGE=quay.io/openshift-qe-optional-operators/ose-metering-presto@sha256:cf16a5142b7203dafb99b2b29bdb8170db4d41876600f75de2b164e58a267473
export METERING_HIVE_IMAGE=quay.io/openshift-qe-optional-operators/ose-metering-hive@sha256:852c152f3c8bf3cf73a4e6e23f44edfa8b88bdde4a867644c91243772acceb2e
export METERING_HADOOP_IMAGE=quay.io/openshift-qe-optional-operators/ose-metering-hadoop@sha256:7447d640f311910752e4b7066c8afee835b7f0d1f75d747ab445a26ae0d89cb7
export GHOSTUNNEL_IMAGE=quay.io/openshift-qe-optional-operators/ose-ghostunnel@sha256:8c22e865bce5bc62d9172d119c470fdbbfe2b83c14bbd7bf425362fba61c2231
export OAUTH_PROXY_IMAGE=quay.io/openshift-qe-optional-operators/ose-oauth-proxy@sha256:628adc340d830f99e048bcaafe7b6d1536ff9f07326900b49058e2d4c9f1484c
...
$ fg
```
