### PR TITLE
Add an e2e test for validating a custom node selector configuration.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -15,6 +15,14 @@ function cleanup() {
         echo "Removing namespaces with the 'name=${METERING_NAMESPACE}-metering-testing-ns' label"
         kubectl delete ns -l "name=${METERING_NAMESPACE}-metering-testing-ns" --wait=false || true
 
+        # Remove any testing labels that may have been added during tests
+        echo "Removing any testing labels that were added to the cluster's nodes"
+        nodes=( $(kubectl get nodes -l metering-node-testing-label="true" --no-headers | awk '{ print $1 }') )
+        for i in "${nodes[@]}"
+        do
+            kubectl label node "$i" metering-node-testing-label- 2>/dev/null
+        done
+
         # Note: the `openshift-marketplace` namespace is hardcoded for now until we have the need
         # to create the registry-related resources in another namespace (e.g. testing upstream manifests).
         echo "Removing the local registry resources with the 'name=${METERING_NAMESPACE}-metering-testing-ns' label"

--- a/test/e2e/custom_node_selector_tests.go
+++ b/test/e2e/custom_node_selector_tests.go
@@ -1,0 +1,80 @@
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kube-reporting/metering-operator/test/reportingframework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testNodeSelectorConfigurationWorks(t *testing.T, rf *reportingframework.ReportingFramework) {
+	// note: we already know the node selector configuration that
+	// was specified in the MeteringConfig YAML manifest.
+	expectedNodeSelector := map[string]string{
+		"node-role.kubernetes.io/worker": "",
+		"metering-node-testing-label":    "true",
+	}
+
+	tt := []struct {
+		Name                 string
+		PodNameContains      string
+		ExpectedNodeSelector map[string]string
+	}{
+		{
+			Name:                 "valid-presto-coordinator-node-selector",
+			PodNameContains:      "presto-coordinator-0",
+			ExpectedNodeSelector: expectedNodeSelector,
+		},
+		{
+			Name:                 "valid-hive-server-node-selector",
+			PodNameContains:      "hive-server-0",
+			ExpectedNodeSelector: expectedNodeSelector,
+		},
+		{
+			Name:                 "valid-hive-metastore-node-selector",
+			PodNameContains:      "hive-metastore-0",
+			ExpectedNodeSelector: expectedNodeSelector,
+		},
+		{
+			Name:                 "valid-hdfs-datanode-node-selector",
+			PodNameContains:      "hdfs-datanode-0",
+			ExpectedNodeSelector: expectedNodeSelector,
+		},
+		{
+			Name:                 "valid-hdfs-namenode-node-selector",
+			PodNameContains:      "hdfs-namenode-0",
+			ExpectedNodeSelector: expectedNodeSelector,
+		},
+		{
+			Name:                 "valid-reporting-operator-node-selector",
+			PodNameContains:      "reporting-operator",
+			ExpectedNodeSelector: expectedNodeSelector,
+		},
+	}
+
+	pods, err := rf.KubeClient.CoreV1().Pods(rf.Namespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err, "expected querying the %s namespace for the list of pods would produce no error", rf.Namespace)
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			var matched bool
+			for _, pod := range pods.Items {
+				// in the case where a pod was spun up by a deployment
+				// controller, check if the current pod were handling
+				// in this loop iteration contains a subset of the test
+				// case pod name.
+				if !strings.Contains(pod.Name, tc.PodNameContains) {
+					continue
+				}
+
+				assert.Equal(t, tc.ExpectedNodeSelector, pod.Spec.NodeSelector, "expected that the actual node selectors for the Pod would matched the test case expected value")
+				matched = true
+			}
+			assert.True(t, matched, "expected to find the pod listed in the test case")
+		})
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -223,6 +223,37 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-disabled.yaml",
 		},
 		{
+			Name:                      "ValidHDFS-ValidNodeSelector",
+			MeteringOperatorImageRepo: meteringOperatorImageRepo,
+			MeteringOperatorImageTag:  meteringOperatorImageTag,
+			// TODO: transistion this to a periodic test and
+			// update the `Skip` condition to !runAllInstallTests
+			Skip:           false,
+			PreInstallFunc: customNodeSelectorFunc,
+			InstallSubTests: []InstallTestCase{
+				{
+					Name:     "testNodeSelectorConfigurationWorks",
+					TestFunc: testNodeSelectorConfigurationWorks,
+				},
+				{
+					Name:     "testReportingProducesCorrectDataForInput",
+					TestFunc: testReportingProducesCorrectDataForInput,
+					ExtraEnvVars: []string{
+						"REPORTING_OPERATOR_DISABLE_PROMETHEUS_METRICS_IMPORTER=true",
+					},
+				},
+				{
+					Name:     "testPrometheusConnectorWorks",
+					TestFunc: testPrometheusConnectorWorks,
+				},
+				{
+					Name:     "testReportingOperatorServiceCABundleExists",
+					TestFunc: testReportingOperatorServiceCABundleExists,
+				},
+			},
+			MeteringConfigManifestFilename: "node-selector-prometheus-importer-disabled.yaml",
+		},
+		{
 			Name:                      "S3-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,

--- a/test/e2e/testdata/meteringconfigs/node-selector-prometheus-importer-disabled.yaml
+++ b/test/e2e/testdata/meteringconfigs/node-selector-prometheus-importer-disabled.yaml
@@ -1,0 +1,94 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+spec:
+  logHelmTemplate: true
+
+  unsupportedFeatures:
+    enableHDFS: true
+
+  storage:
+    type: hive
+    hive:
+      type: hdfs
+      hdfs:
+        namenode: hdfs-namenode-0.hdfs-namenode:9820
+
+  reporting-operator:
+    spec:
+      resources:
+        requests:
+          cpu: 1
+          memory: 250Mi
+      config:
+        logLevel: debug
+        prometheus:
+          metricsImporter:
+            enabled: false
+      nodeSelector:
+        "node-role.kubernetes.io/worker": ""
+        "metering-node-testing-label": "true"
+
+  presto:
+    spec:
+      coordinator:
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+        nodeSelector:
+          "node-role.kubernetes.io/worker": ""
+          "metering-node-testing-label": "true"
+      config:
+        connectors:
+          prometheus:
+            enabled: true
+            config:
+              uri: "https://thanos-querier.openshift-monitoring.svc:9091/"
+            auth:
+              bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  hive:
+    spec:
+      metastore:
+        nodeSelector:
+          "node-role.kubernetes.io/worker": ""
+          "metering-node-testing-label": "true"
+        resources:
+          requests:
+            cpu: 1
+            memory: 650Mi
+        storage:
+          size: 5Gi
+      server:
+        nodeSelector:
+          "node-role.kubernetes.io/worker": ""
+          "metering-node-testing-label": "true"
+        resources:
+          requests:
+            cpu: 500m
+            memory: 650Mi
+
+  hadoop:
+    spec:
+      hdfs:
+        enabled: true
+        datanode:
+          nodeSelector:
+            "node-role.kubernetes.io/worker": ""
+            "metering-node-testing-label": "true"
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi
+        namenode:
+          nodeSelector:
+            "node-role.kubernetes.io/worker": ""
+            "metering-node-testing-label": "true"
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi


### PR DESCRIPTION
This is a common MeteringConfig custom resource configuration we document downstream and following the updates in #1310, we should be testing this configuration regularly to ensure it's still working. At the moment, we can make this a required test with the intention of offloading it eventually as a periodic test that's not run as part of the regular dev PR e2e.