### PR TITLE
charts,manifests: Fix missing schema definitions for map[string]string API fields.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -620,6 +620,8 @@ spec:
                         type: object
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       apiService:
                         type: object
                         properties:
@@ -1239,8 +1241,12 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       nodeSelector:
                         type: object
+                        additionalProperties:
+                          type: string
                       rbac:
                         type: object
                         required:
@@ -1317,6 +1323,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       terminationGracePeriodSeconds:
                         type: integer
                       config:
@@ -1766,6 +1774,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -1804,6 +1814,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       securityContext:
                         type: object
                         properties:
@@ -1919,6 +1931,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           replicas:
                             type: integer
                             format: int32
@@ -1960,6 +1974,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       config:
                         type: object
                         properties:
@@ -2074,6 +2090,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       metastore:
                         type: object
                         properties:
@@ -2202,6 +2220,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2459,6 +2479,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2619,6 +2641,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2639,8 +2663,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               replicas:
                                 type: integer
                                 format: int32
@@ -2714,6 +2742,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2734,8 +2764,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               resources:
                                 type: object
                                 properties:

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -619,6 +619,8 @@ spec:
                         type: object
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       apiService:
                         type: object
                         properties:
@@ -1238,8 +1240,12 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       nodeSelector:
                         type: object
+                        additionalProperties:
+                          type: string
                       rbac:
                         type: object
                         required:
@@ -1316,6 +1322,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       terminationGracePeriodSeconds:
                         type: integer
                       config:
@@ -1765,6 +1773,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -1803,6 +1813,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       securityContext:
                         type: object
                         properties:
@@ -1918,6 +1930,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           replicas:
                             type: integer
                             format: int32
@@ -1959,6 +1973,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       config:
                         type: object
                         properties:
@@ -2073,6 +2089,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       metastore:
                         type: object
                         properties:
@@ -2201,6 +2219,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2458,6 +2478,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2618,6 +2640,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2638,8 +2662,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               replicas:
                                 type: integer
                                 format: int32
@@ -2713,6 +2741,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2733,8 +2763,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               resources:
                                 type: object
                                 properties:

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringconfig.crd.yaml
@@ -619,6 +619,8 @@ spec:
                         type: object
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       apiService:
                         type: object
                         properties:
@@ -1238,8 +1240,12 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       nodeSelector:
                         type: object
+                        additionalProperties:
+                          type: string
                       rbac:
                         type: object
                         required:
@@ -1316,6 +1322,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       terminationGracePeriodSeconds:
                         type: integer
                       config:
@@ -1765,6 +1773,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -1803,6 +1813,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       securityContext:
                         type: object
                         properties:
@@ -1918,6 +1930,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           replicas:
                             type: integer
                             format: int32
@@ -1959,6 +1973,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       config:
                         type: object
                         properties:
@@ -2073,6 +2089,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       metastore:
                         type: object
                         properties:
@@ -2201,6 +2219,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2458,6 +2478,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2618,6 +2640,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2638,8 +2662,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               replicas:
                                 type: integer
                                 format: int32
@@ -2713,6 +2741,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2733,8 +2763,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               resources:
                                 type: object
                                 properties:

--- a/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
@@ -619,6 +619,8 @@ spec:
                         type: object
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       apiService:
                         type: object
                         properties:
@@ -1238,8 +1240,12 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       nodeSelector:
                         type: object
+                        additionalProperties:
+                          type: string
                       rbac:
                         type: object
                         required:
@@ -1316,6 +1322,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       terminationGracePeriodSeconds:
                         type: integer
                       config:
@@ -1765,6 +1773,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -1803,6 +1813,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       securityContext:
                         type: object
                         properties:
@@ -1918,6 +1930,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           replicas:
                             type: integer
                             format: int32
@@ -1959,6 +1973,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       config:
                         type: object
                         properties:
@@ -2073,6 +2089,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       metastore:
                         type: object
                         properties:
@@ -2201,6 +2219,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2458,6 +2478,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2618,6 +2640,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2638,8 +2662,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               replicas:
                                 type: integer
                                 format: int32
@@ -2713,6 +2741,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2733,8 +2763,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               resources:
                                 type: object
                                 properties:

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringconfig.crd.yaml
@@ -619,6 +619,8 @@ spec:
                         type: object
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       apiService:
                         type: object
                         properties:
@@ -1238,8 +1240,12 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       nodeSelector:
                         type: object
+                        additionalProperties:
+                          type: string
                       rbac:
                         type: object
                         required:
@@ -1316,6 +1322,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       terminationGracePeriodSeconds:
                         type: integer
                       config:
@@ -1765,6 +1773,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -1803,6 +1813,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       securityContext:
                         type: object
                         properties:
@@ -1918,6 +1930,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           replicas:
                             type: integer
                             format: int32
@@ -1959,6 +1973,8 @@ spec:
                     properties:
                       annotations:
                         type: object
+                        additionalProperties:
+                          type: string
                       config:
                         type: object
                         properties:
@@ -2073,6 +2089,8 @@ spec:
                             type: string
                       labels:
                         type: object
+                        additionalProperties:
+                          type: string
                       metastore:
                         type: object
                         properties:
@@ -2201,6 +2219,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2458,6 +2478,8 @@ spec:
                                 type: integer
                           nodeSelector:
                             type: object
+                            additionalProperties:
+                              type: string
                           resources:
                             type: object
                             properties:
@@ -2618,6 +2640,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2638,8 +2662,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               replicas:
                                 type: integer
                                 format: int32
@@ -2713,6 +2741,8 @@ spec:
                                               type: string
                               annotations:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               config:
                                 type: object
                                 properties:
@@ -2733,8 +2763,12 @@ spec:
                                         maximum: 100
                               labels:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               nodeSelector:
                                 type: object
+                                additionalProperties:
+                                  type: string
                               resources:
                                 type: object
                                 properties:


### PR DESCRIPTION
When we bumped the apiextensions.k8s.io versioning to v1, all unknown CRD schema definitions get purged automatically, which is problematic in the case of specifying labels, annotations, and node selector configurations for the Metering operands, as those schema definitions are missing a properties definition. The end result was them being rendered as an empty dictionary (e.g. `nodeSelector: {}`) and the user-provided configuration was not respected.

If we instead add this `additionalProperties` field for those fields, those contents are rendered correctly assuming they're in the correct form.