### PR TITLE
Add a Dockerfile for building the deploy-metering CLI utility.

### DIFF
--- a/Dockerfile.deploy-metering
+++ b/Dockerfile.deploy-metering
@@ -1,0 +1,19 @@
+FROM golang:1.13-alpine as build
+WORKDIR /deploy-metering
+
+COPY build ./build
+COPY hack/codegen_source_files.sh hack/codegen_output_files.sh ./hack/
+COPY Makefile ./Makefile
+COPY cmd/deploy-metering ./cmd/deploy-metering
+COPY pkg ./pkg
+COPY manifests/deploy ./manifests/deploy
+COPY go.mod go.sum ./
+RUN apk --no-cache add make bash && make bin/deploy-metering GO_BUILD_ARGS=""
+
+FROM alpine:3
+
+RUN mkdir /manifests
+COPY --from=build /deploy-metering/bin/deploy-metering /bin/deploy-metering
+COPY --from=build /deploy-metering/manifests/deploy /manifests/deploy
+
+ENTRYPOINT ["/bin/deploy-metering", "--deploy-manifests-dir", "/manifests/deploy"]


### PR DESCRIPTION
This builds an alpine container image containing the deploy-metering utility that we use to provision Metering installations in for the dev and testing environments.

For simple usage, you could alias running the container locally:
```bash
$ alias dm="podman run --rm -v "$KUBECONFIG:/kubeconfig" -v "$METERING_CR_FILE:/mc.yaml -e KUBECONFIG=/kubeconfig -e METERING_CR_FILE=/mc.yaml quay.io/tflannag/deploy-metering:latest
```

And interacting with that command could look something like this:
```bash
$ dm install --namespace metering --deploy-manifest-dir /manifests
time="07-16-2020 18:20:50" level=info msg="Setting the log level to info" app=deploy
time="07-16-2020 18:20:50" level=info msg="Metering Deploy Namespace: tflannag-test" app=deploy
time="07-16-2020 18:20:50" level=info msg="Metering Deploy Platform: openshift" app=deploy
time="07-16-2020 18:20:50" level=info msg="Labeling the tflannag-test namespace with 'openshift.io/cluster-monitoring=true'" app=deploy
time="07-16-2020 18:20:50" level=info msg="Annotating the tflannag-test namespace with 'openshift.io/node-selector=''" app=deploy
time="07-16-2020 18:20:50" level=info msg="Created the tflannag-test namespace" app=deploy
time="07-16-2020 18:20:50" level=info msg="Updated the hivetables.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:50" level=info msg="Updated the prestotables.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:50" level=info msg="Updated the storagelocations.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:50" level=info msg="Updated the reports.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:51" level=info msg="Updated the reportqueries.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:51" level=info msg="Updated the reportdatasources.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:51" level=info msg="Updated the meteringconfigs.metering.openshift.io CRD" app=deploy
time="07-16-2020 18:20:51" level=info msg="Created the metering deployment" app=deploy
time="07-16-2020 18:20:51" level=info msg="Created the metering serviceaccount" app=deploy
time="07-16-2020 18:20:52" level=info msg="Created the metering role" app=deploy
time="07-16-2020 18:20:52" level=info msg="Created the metering role binding" app=deploy
time="07-16-2020 18:20:52" level=info msg="Created the metering cluster role" app=deploy
time="07-16-2020 18:20:52" level=info msg="Created the metering cluster role binding" app=deploy
time="07-16-2020 18:20:53" level=info msg="The MeteringConfig CRD exists" app=deploy
time="07-16-2020 18:20:53" level=info msg="Created the MeteringConfig resource" app=deploy
time="07-16-2020 18:20:53" level=info msg="Finished installing metering" app=deploy
```

Note: this binary essentially only requires a valid kubeconfig being passed, but you should always pass the custom meteringconfig CR file as it will fail validation defaulting to the invalid meteringconfig manifest.