### PR TITLE
test/e2e: Add an e2e test for configuring a MySQL instance for Hive metastore.

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -254,6 +254,27 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "node-selector-prometheus-importer-disabled.yaml",
 		},
 		{
+			Name:                      "ValidHDFS-MySQLDatabase",
+			MeteringOperatorImageRepo: meteringOperatorImageRepo,
+			MeteringOperatorImageTag:  meteringOperatorImageTag,
+			Skip:                      false,
+			PreInstallFunc:            createMySQLDatabase,
+			InstallSubTests: []InstallTestCase{
+				{
+					Name:     "testReportingProducesData",
+					TestFunc: testReportingProducesData,
+					ExtraEnvVars: []string{
+						"REPORTING_OPERATOR_PROMETHEUS_DATASOURCE_MAX_IMPORT_BACKFILL_DURATION=15m",
+						"REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_INTERVAL=30s",
+						"REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_CHUNK_SIZE=5m",
+						"REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_INTERVAL=5m",
+						"REPORTING_OPERATOR_PROMETHEUS_METRICS_IMPORTER_STEP_SIZE=60s",
+					},
+				},
+			},
+			MeteringConfigManifestFilename: "mysql.yaml",
+		},
+		{
 			Name:                      "S3-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,

--- a/test/e2e/manifests/meteringconfigs/mysql.yaml
+++ b/test/e2e/manifests/meteringconfigs/mysql.yaml
@@ -1,0 +1,78 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+spec:
+  logHelmTemplate: true
+
+  unsupportedFeatures:
+    enableHDFS: true
+
+  storage:
+    type: hive
+    hive:
+      type: hdfs
+      hdfs:
+        namenode: hdfs-namenode-0.hdfs-namenode:9820
+
+  reporting-operator:
+    spec:
+      resources:
+        requests:
+          cpu: 1
+          memory: 250Mi
+      config:
+        logLevel: debug
+        prometheus:
+          metricsImporter:
+            config:
+              chunkSize: 5m
+              pollInterval: 30s
+              stepSize: 60s
+              maxImportBackfillDuration: 15m
+              maxQueryRangeDuration: 5m
+
+  presto:
+    spec:
+      coordinator:
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+
+  hive:
+    spec:
+      metastore:
+        resources:
+          requests:
+            cpu: 1
+            memory: 650Mi
+        storage:
+          size: 5Gi
+      server:
+        resources:
+          requests:
+            cpu: 500m
+            memory: 650Mi
+      config:
+        db:
+          driver: com.mysql.jdbc.Driver
+          username: testuser
+          password: testpass
+          url: jdbc:mysql://mysql.mysql.svc.cluster.local:3306/metastore
+  hadoop:
+    spec:
+      hdfs:
+        enabled: true
+        datanode:
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi
+        namenode:
+          resources:
+            requests:
+              memory: 500Mi
+          storage:
+            size: 5Gi


### PR DESCRIPTION
In our OCP documentation, we recommend overriding the default, local embedded Derby database that Hive metastore is configured to use, with either a MySQL or PostgreSQL instance.
    
This would add a fairly straight-forward MeteringConfig YAML manifest that is configured to reference to a MySQL database instance in the `mysql` namespace. We create that namespace and the database instance using the `oc new-app ...` mysql 5.7 imagestream before firing off the metering installation responsible for using MySQL as an underlying hive metastore database.
