### PR TITLE
charts,manifests: Bump the minimum kubernetes server version to 1.18.3

### DIFF
--- a/charts/metering-ansible-operator/upstream-values.yaml
+++ b/charts/metering-ansible-operator/upstream-values.yaml
@@ -47,7 +47,7 @@ olm:
   csv:
     name : metering-operator-upstream.v4.6.0
     version: "4.6.0"
-    minKubeVersion: "1.18.0"
+    minKubeVersion: 1.18.3
 
     description: |
       The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -224,10 +224,7 @@ olm:
     name : metering-operator.v4.6.0
     version: "4.6.0"
     skipRange: ">=4.3.0 <4.6.0"
-    # FIXME: revert once the apiserver issues have been resolved on 4.6.
-    # This is needed as a 4.6 cluster's server version is being interpreted
-    # as 1.17.0 instead of 1.18.3.
-    minKubeVersion: "1.17.0"
+    minKubeVersion: 1.18.3
     displayName: Metering
     description: |
       The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ spec:
 
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.6.0"
-  minKubeVersion: "1.17.0"
+  minKubeVersion: "1.18.3"
   maturity: stable
   maintainers:
     - email: sd-operator-metering@redhat.com

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ spec:
 
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.6.0"
-  minKubeVersion: "1.18.0"
+  minKubeVersion: "1.18.3"
   maturity: stable
   maintainers:
     - email: sd-operator-metering@redhat.com


### PR DESCRIPTION
This is a follow-up PR to #1322 which lowered the `minKubeVersion` in our CSV's to unblock CI as the server was reporting a kube version of 1.17.0 instead of 1.18.3 at the time. It appears this is now fixed, so this reverts back to 1.18.3, which is the version our kube dependencies are currently pinned to now.