### PR TITLE
charts,manifests: Lower the minKubeVersion to 1.17.0 to unblock CI.

### DIFF
--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -224,7 +224,10 @@ olm:
     name : metering-operator.v4.6.0
     version: "4.6.0"
     skipRange: ">=4.3.0 <4.6.0"
-    minKubeVersion: "1.18.0"
+    # FIXME: revert once the apiserver issues have been resolved on 4.6.
+    # This is needed as a 4.6 cluster's server version is being interpreted
+    # as 1.17.0 instead of 1.18.3.
+    minKubeVersion: "1.17.0"
     displayName: Metering
     description: |
       The Metering Operator is a chargeback and reporting tool to provide accountability for how resources are used across a cluster. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster wide. The Metering Operator is a part of the [Kubernetes Reporting organization](https://coreos.com/blog/introducing-operator-framework-metering).

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -253,7 +253,7 @@ spec:
 
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.6.0"
-  minKubeVersion: "1.18.0"
+  minKubeVersion: "1.17.0"
   maturity: stable
   maintainers:
     - email: sd-operator-metering@redhat.com


### PR DESCRIPTION
Right now, every PR is failing e2e as the minKubeVersion specified in our CSV resource is 1.18.3, which is greater than the server version (1.17.0) that the apiserver is advertising. In order to unblock CI, we can lower this value to 1.17.0 with the intention of reverting it once this issue is resolved.