### PR TITLE
update to non-deprecated informer factory method

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -274,7 +274,7 @@ func newReportingOperator(
 	meteringClient cbClientset.Interface,
 	informerNamespace string,
 ) *Reporting {
-	informerFactory := factory.NewFilteredSharedInformerFactory(meteringClient, defaultResyncPeriod, informerNamespace, nil)
+	informerFactory := factory.NewSharedInformerFactoryWithOptions(meteringClient, defaultResyncPeriod, factory.WithNamespace(informerNamespace), factory.WithTweakListOptions(nil))
 
 	prestoTableInformer := informerFactory.Metering().V1().PrestoTables()
 	hiveTableInformer := informerFactory.Metering().V1().HiveTables()


### PR DESCRIPTION
`NewFilteredSharedInformerFactory` is deprecated in favor of `NewSharedInformerFactoryWithOptions`.  See https://github.com/kube-reporting/metering-operator/blob/62484305833c3576b59f1889b110538b2c78da97/pkg/generated/informers/externalversions/factory.go#L70

