### PR TITLE
test/e2e: Disable the node selector e2e test by default.

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -179,6 +179,43 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "missing-storage.yaml",
 		},
 		{
+			Name:                      "ValidHDFS-ValidNodeSelector",
+			MeteringOperatorImageRepo: meteringOperatorImageRepo,
+			MeteringOperatorImageTag:  meteringOperatorImageTag,
+			// TODO: transistion this to a periodic test and
+			// update the `Skip` condition to !runAllInstallTests
+			// TODO: disabling this test for the time being as
+			// we're labeling nodes and firing off this metering
+			// installation before the machineautoscaler has provisioned
+			// any new machine. The result is the new machines that get
+			// provisioned, don't have this custom node label we added in
+			// the preInstallFunc closure.
+			Skip:           true,
+			PreInstallFunc: customNodeSelectorFunc,
+			InstallSubTests: []InstallTestCase{
+				{
+					Name:     "testNodeSelectorConfigurationWorks",
+					TestFunc: testNodeSelectorConfigurationWorks,
+				},
+				{
+					Name:     "testReportingProducesCorrectDataForInput",
+					TestFunc: testReportingProducesCorrectDataForInput,
+					ExtraEnvVars: []string{
+						"REPORTING_OPERATOR_DISABLE_PROMETHEUS_METRICS_IMPORTER=true",
+					},
+				},
+				{
+					Name:     "testPrometheusConnectorWorks",
+					TestFunc: testPrometheusConnectorWorks,
+				},
+				{
+					Name:     "testReportingOperatorServiceCABundleExists",
+					TestFunc: testReportingOperatorServiceCABundleExists,
+				},
+			},
+			MeteringConfigManifestFilename: "node-selector-prometheus-importer-disabled.yaml",
+		},
+		{
 			Name:                      "ValidHDFS-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
@@ -221,37 +258,6 @@ func TestManualMeteringInstall(t *testing.T) {
 				},
 			},
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-disabled.yaml",
-		},
-		{
-			Name:                      "ValidHDFS-ValidNodeSelector",
-			MeteringOperatorImageRepo: meteringOperatorImageRepo,
-			MeteringOperatorImageTag:  meteringOperatorImageTag,
-			// TODO: transistion this to a periodic test and
-			// update the `Skip` condition to !runAllInstallTests
-			Skip:           false,
-			PreInstallFunc: customNodeSelectorFunc,
-			InstallSubTests: []InstallTestCase{
-				{
-					Name:     "testNodeSelectorConfigurationWorks",
-					TestFunc: testNodeSelectorConfigurationWorks,
-				},
-				{
-					Name:     "testReportingProducesCorrectDataForInput",
-					TestFunc: testReportingProducesCorrectDataForInput,
-					ExtraEnvVars: []string{
-						"REPORTING_OPERATOR_DISABLE_PROMETHEUS_METRICS_IMPORTER=true",
-					},
-				},
-				{
-					Name:     "testPrometheusConnectorWorks",
-					TestFunc: testPrometheusConnectorWorks,
-				},
-				{
-					Name:     "testReportingOperatorServiceCABundleExists",
-					TestFunc: testReportingOperatorServiceCABundleExists,
-				},
-			},
-			MeteringConfigManifestFilename: "node-selector-prometheus-importer-disabled.yaml",
 		},
 		{
 			Name:                      "ValidHDFS-MySQLDatabase",


### PR DESCRIPTION
This test is causing frequent e2e flakes as we're adding this custom testing label
to the available sets of nodes in the prior to firing off any metering installations.
The result is that all of the metering installations fight for their pods to be scheduled,
which is fine as the machineautoscaler will provision new machines. With this node selector
test, that's problematic as the new machines that the machineautoscaler provisions will not
have the custom testing node label, so pods will never schedule.