### PR TITLE
charts,manifests: Add the zap-level argument to the ansible-operator container.

### DIFF
--- a/charts/metering-ansible-operator/templates/_helpers.tpl
+++ b/charts/metering-ansible-operator/templates/_helpers.tpl
@@ -27,6 +27,8 @@ template:
     - name: operator
       image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
       imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+      args:
+      - "--zap-level=info"
       env:
       - name: ANSIBLE_DEBUG_LOGS
         value: "True"

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
@@ -23,6 +23,8 @@ spec:
       - name: operator
         image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
         imagePullPolicy: Always
+        args:
+        - "--zap-level=info"
         env:
         - name: ANSIBLE_DEBUG_LOGS
           value: "True"

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -472,6 +472,8 @@ spec:
                 - name: operator
                   image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
                   imagePullPolicy: Always
+                  args:
+                  - "--zap-level=info"
                   env:
                   - name: ANSIBLE_DEBUG_LOGS
                     value: "True"

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
@@ -23,6 +23,8 @@ spec:
       - name: operator
         image: "quay.io/coreos/metering-ansible-operator:release-4.6"
         imagePullPolicy: Always
+        args:
+        - "--zap-level=info"
         env:
         - name: ANSIBLE_DEBUG_LOGS
           value: "True"

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -470,6 +470,8 @@ spec:
                 - name: operator
                   image: "quay.io/coreos/metering-ansible-operator:release-4.6"
                   imagePullPolicy: Always
+                  args:
+                  - "--zap-level=info"
                   env:
                   - name: ANSIBLE_DEBUG_LOGS
                     value: "True"


### PR DESCRIPTION
This field controls the internal ansible-operator logging level. We can default this logging level to logging both Ansible playbook logs and the internal ansible-operator logs, with the intention of editing this value on the deployment/CSV objects if you want to change the verbosity of the default logging.

Other available values for this argument are 'debug' and 'error' (or providing the verbosity of the logs using an integer):
- https://github.com/operator-framework/operator-sdk/blob/be718958884e04b4c4adfab5e0054524bba5226b/pkg/log/zap/flags.go#L52

In the case where you only want to stream the Ansible playbook logs and not the internal ansible-operator logs, you would edit the value of this argument to '--zap-level=error' in the metering-ansible-operator deployment and that would reduce the general verbosity of the container logs:

```bash
$ oc -n openshift-metering edit deployment metering-operator
...
containers:
- name: operator
  ...
  args:
  - --zap-level=error
  ...
```