### PR TITLE
test/e2e: Add a post-install test that verifies that the metering-ansible-operator is exposing metrics properly.

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -212,6 +212,10 @@ func TestManualMeteringInstall(t *testing.T) {
 					},
 				},
 				{
+					Name:     "testMeteringAnsibleOperatorMetricsWork",
+					TestFunc: testMeteringAnsibleOperatorMetricsWork,
+				},
+				{
 					Name:     "testPrometheusConnectorWorks",
 					TestFunc: testPrometheusConnectorWorks,
 				},

--- a/test/e2e/metering_ansible_operator_metrics_test.go
+++ b/test/e2e/metering_ansible_operator_metrics_test.go
@@ -1,0 +1,38 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kube-reporting/metering-operator/test/reportingframework"
+	"github.com/kube-reporting/metering-operator/test/testhelpers"
+)
+
+const (
+	prometheusPodName       = "presto-k8s-0"
+	prometheusNamespace     = "openshift-monitoring"
+	prometheusContainerName = "prometheus"
+	prometheusQueryEndpoint = "http://127.0.0.1:9090/api/v1/query"
+)
+
+// testMeteringAnsibleOperatorMetricsWork ensures that the ServiceMonitor object the ansible-operator
+// creates for the metering-ansible-operator is exposing metrics correctly. It execs in the prometheus-k8s-0
+// Pod in the openshift-monitoring namespace and fires off a known metric that gets collected in the test
+// namespace. This is a follow-up to the fixes made in https://github.com/kube-reporting/metering-operator/pull/1235.
+func testMeteringAnsibleOperatorMetricsWork(t *testing.T, rf *reportingframework.ReportingFramework) {
+	query := fmt.Sprintf("query=workqueue_work_duration_seconds_count{namespace='%s',job='metering-operator-metrics'}", rf.Namespace)
+
+	cmd := []string{
+		"curl", "-k", "-G", "-s", "--data-urlencode", query, prometheusQueryEndpoint,
+	}
+	options := testhelpers.NewExecOptions(prometheusPodName, prometheusNamespace, prometheusContainerName, false, cmd)
+	stdoutBuf, stderrBuf, err := testhelpers.ExecPodCommandWithOptions(rf.KubeConfig, rf.KubeClient, options)
+	t.Logf("Stdout output: %s", stdoutBuf.String())
+	t.Logf("Stderr output: %s", stderrBuf.String())
+	require.Nil(t, err, "expected running the prometheus query would produce no error")
+	require.Containsf(t, stdoutBuf.String(), "workqueue_work_duration_seconds_count", "expected the prometheus query would return the 'workqueue_work_duration_seconds_count' job name")
+	require.Containsf(t, stdoutBuf.String(), "success", "expected the prometheus query would return a successful status")
+	require.Len(t, stderrBuf.String(), 0, "expected that the stderr buffer would return nothing")
+}


### PR DESCRIPTION
This is a follow-up to the fixes made in https://github.com/kube-reporting/metering-operator/pull/1235 to make sure we don't regress in future releases.

At the moment, all this post-install test does is exec into the `prometheus-k8s` Pod in the openshift-monitoring namespace and ensures that the workqueue_work_duration_seconds_count metric returns a successful status. The ansible-operator, which will expose this metric, creates a ServiceMonitor for the metering-operator-metrics service name, so we should be able to query for the value of this metric in the test namespace that has deployed Metering.