### PR TITLE
pkg/operator: Update the scheme used for the event record to include the metering v1 scheme.

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -25,6 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	meteringv1scheme "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned/scheme"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	coordinatorv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -305,6 +308,8 @@ func newReportingOperator(
 		reporting.NewReportListerGetter(reportInformer.Lister()),
 	)
 
+	logger.Infof("setting up event broadcasters")
+	utilruntime.Must(meteringv1scheme.AddToScheme(scheme.Scheme))
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(logger.Infof)
 	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.Events(cfg.OwnNamespace)})

--- a/test/e2e/ensure_leader_election_event_is_created.go
+++ b/test/e2e/ensure_leader_election_event_is_created.go
@@ -1,0 +1,30 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-reporting/metering-operator/test/reportingframework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const leaderElectionName = "reporting-operator-leader-lease"
+
+func testLeaderElectionEventIsCreated(t *testing.T, rf *reportingframework.ReportingFramework) {
+	events, err := rf.KubeClient.CoreV1().Events(rf.Namespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to list the events in the test namespace")
+
+	var found bool
+	for _, event := range events.Items {
+		if event.InvolvedObject.Kind != "ConfigMap" {
+			continue
+		}
+		if event.InvolvedObject.Name == leaderElectionName {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "expected to find the leader election event created")
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -260,6 +260,10 @@ func TestManualMeteringInstall(t *testing.T) {
 					Name:     "testReportingOperatorServiceCABundleExists",
 					TestFunc: testReportingOperatorServiceCABundleExists,
 				},
+				{
+					Name:     "testLeaderElectionEventIsCreated",
+					TestFunc: testLeaderElectionEventIsCreated,
+				},
 			},
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-disabled.yaml",
 		},


### PR DESCRIPTION
In order to broadcast k8s events to help report errors for the metering-related resources, we need to add the metering scheme that gets generated from the `pkg/apis/metering/v1/register.go` implementation on top of the default scheme the controller was using the report the leader election event. Changing the event recorder to use the metering scheme, in addition to the default scheme allows us to broadcast events to different object's lifecycles.