### PR TITLE
pkg/operator: Requeue a Report that has reached its expiration date during the op.runReport method.

### DIFF
--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -365,7 +365,6 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) 
 		return nil
 	}
 
-	runningCond := meteringUtil.GetReportCondition(report.Status, metering.ReportRunning)
 	queryGetter := reporting.NewReportQueryListerGetter(op.reportQueryLister)
 
 	// validate that Report contains valid Spec fields
@@ -500,7 +499,12 @@ func (op *Reporting) runReport(logger log.FieldLogger, report *metering.Report) 
 		}
 	}
 
-	var runningMsg, runningReason string
+	runningCond := meteringUtil.GetReportCondition(report.Status, metering.ReportRunning)
+
+	var (
+		runningMsg    string
+		runningReason string
+	)
 	if report.Spec.RunImmediately {
 		runningReason = meteringUtil.RunImmediatelyReason
 		runningMsg = fmt.Sprintf("Report %s scheduled: runImmediately=true and reporting period [%s to %s].", report.Name, reportPeriod.periodStart, reportPeriod.periodEnd)


### PR DESCRIPTION
More follow-up changes introduced in #1298.

We should be checking whether the Report we're currently processing in the op.runReport method has reached its expiration date and requeueing that object such that op.syncReport will properly manage it.

This produces the following output in the reporting-operator container logs:

```go
time="2020-08-01T17:22:08Z" level=info msg="syncing Report tflannag/node-cpu-capacity-now" app=metering component=reportWorker logID=7ygCr5kB0Q
time="2020-08-01T17:22:08Z" level=info msg="deleted Report: node-cpu-capacity-now in the Namespace: tflannag because it reached the expiration time" app=metering
time="2020-08-01T17:22:08Z" level=info msg="requeueing report that has reached its expiration date during the op.runReport method" app=metering component=reportWorker logID=7ygCr5kB0Q namespace=tflannag report=node-cpu-capacity-now
time="2020-08-01T17:22:08Z" level=info msg="successfully synced Report \"tflannag/node-cpu-capacity-now\"" Report=tflannag/node-cpu-capacity-now app=metering component=reportWorker logID=7ygCr5kB0Q
time="2020-08-01T17:22:08Z" level=info msg="syncing Report tflannag/node-cpu-capacity-now" app=metering component=reportWorker logID=aChSoIlXus
time="2020-08-01T17:22:08Z" level=info msg="report tflannag/node-cpu-capacity-now does not exist anymore, stopping and removing any running jobs for Report" app=metering component=reportWorker logID=aChSoIlXus namespace=tflannag report=node-cpu-capacity-now
time="2020-08-01T17:22:08Z" level=info msg="successfully synced Report \"tflannag/node-cpu-capacity-now\"" Report=tflannag/node-cpu-capacity-now app=metering component=reportWorker logID=aChSoIlXus
```