### PR TITLE
test/e2e: Migrate to using the 10.2 MariaDB imagestream in tests.

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -289,7 +289,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			// some issues with using mariadb as a direct replacement
 			// as Hive server hangs during the create table call
 			// and requires a restart to work properly.
-			Skip:           true,
+			Skip:           false,
 			PreInstallFunc: createMySQLDatabase,
 			InstallSubTests: []InstallTestCase{
 				{

--- a/test/e2e/manifests/meteringconfigs/mysql.yaml
+++ b/test/e2e/manifests/meteringconfigs/mysql.yaml
@@ -56,10 +56,10 @@ spec:
             memory: 650Mi
       config:
         db:
-          driver: com.mysql.jdbc.Driver
+          driver: org.mariadb.jdbc.Driver
           username: testuser
           password: testpass
-          url: jdbc:mysql://mariadb.mysql.svc.cluster.local:3306/metastore
+          url: jdbc:mariadb://mariadb.mysql.svc.cluster.local:3306/metastore
   hadoop:
     spec:
       hdfs:

--- a/test/e2e/manifests/meteringconfigs/mysql.yaml
+++ b/test/e2e/manifests/meteringconfigs/mysql.yaml
@@ -59,7 +59,7 @@ spec:
           driver: com.mysql.jdbc.Driver
           username: testuser
           password: testpass
-          url: jdbc:mysql://mysql.mysql.svc.cluster.local:3306/metastore
+          url: jdbc:mysql://mariadb.mysql.svc.cluster.local:3306/metastore
   hadoop:
     spec:
       hdfs:

--- a/test/e2e/manifests/meteringconfigs/mysql.yaml
+++ b/test/e2e/manifests/meteringconfigs/mysql.yaml
@@ -46,7 +46,7 @@ spec:
         resources:
           requests:
             cpu: 1
-            memory: 650Mi
+            memory: 2Gi
         storage:
           size: 5Gi
       server:

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -357,7 +357,7 @@ func createMySQLDatabase(ctx *deployframework.DeployerCtx) error {
 		"oc",
 		"-n", mysqlNamespace,
 		"new-app",
-		"--image-stream", "mysql:5.7",
+		"--image-stream", "mariadb:10.2",
 		"MYSQL_USER=testuser",
 		"MYSQL_PASSWORD=testpass",
 		"MYSQL_DATABASE=metastore",

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -3,14 +3,15 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/kube-reporting/metering-operator/pkg/deploy"
-	"k8s.io/client-go/kubernetes"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kube-reporting/metering-operator/pkg/deploy"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kube-reporting/metering-operator/test/deployframework"
 	"github.com/kube-reporting/metering-operator/test/testhelpers"
@@ -357,7 +358,7 @@ func createMySQLDatabase(ctx *deployframework.DeployerCtx) error {
 		"oc",
 		"-n", mysqlNamespace,
 		"new-app",
-		"--image-stream", "mariadb:10.2",
+		"--image-stream", "mariadb:latest",
 		"MYSQL_USER=testuser",
 		"MYSQL_PASSWORD=testpass",
 		"MYSQL_DATABASE=metastore",


### PR DESCRIPTION
It looks like the MySQL 5.7 imagestream was recently removed from 4.6 clusters, and we still have the open BZ for Metering cannot work with the most recently GA'd MySQL release, which is causing this e2e test to constantly fail.

Looking at the MariaDB vs. MySQL compatibility chart, it looks like 10.2/10.3/10.4 are all compatible with MySQL 5.7:
- https://mariadb.com/kb/en/mariadb-vs-mysql-compatibility/

These changes just update the imagestream we create in the e2e test to use the mariadb:10.2 version.