### PR TITLE
Operator refactor - validation and import cleanup

### DIFF
--- a/pkg/operator/aws_usage_hive.go
+++ b/pkg/operator/aws_usage_hive.go
@@ -41,7 +41,7 @@ var (
 )
 
 // CreateAWSUsageTable instantiates a new external HiveTable CR for AWS Billing/Usage reports stored in S3.
-func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSource *metering.ReportDataSource, tableName, bucket, prefix string, manifests []*aws.Manifest) (*metering.HiveTable, error) {
+func (op *defaultReportingOperator) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSource *metering.ReportDataSource, tableName, bucket, prefix string, manifests []*aws.Manifest) (*metering.HiveTable, error) {
 	location, err := hive.S3Location(bucket, prefix)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (op *Reporting) createAWSUsageHiveTableCR(logger logrus.FieldLogger, dataSo
 	return hiveTable, nil
 }
 
-func (op *Reporting) updateAWSBillingPartitions(logger log.FieldLogger, dataSource *metering.ReportDataSource, source *metering.S3Bucket, hiveTable *metering.HiveTable, manifests []*aws.Manifest) error {
+func (op *defaultReportingOperator) updateAWSBillingPartitions(logger log.FieldLogger, dataSource *metering.ReportDataSource, source *metering.S3Bucket, hiveTable *metering.HiveTable, manifests []*aws.Manifest) error {
 	logger.Infof("updating partitions for Hive table %s", hiveTable.Name)
 	// Fetch the billing manifests
 	if len(manifests) == 0 {

--- a/pkg/operator/datasources.go
+++ b/pkg/operator/datasources.go
@@ -17,7 +17,7 @@ import (
 
 	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
 	"github.com/kube-reporting/metering-operator/pkg/aws"
-	cbInterfaces "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned/typed/metering/v1"
+	clientset "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned/typed/metering/v1"
 	"github.com/kube-reporting/metering-operator/pkg/hive"
 	"github.com/kube-reporting/metering-operator/pkg/operator/prestostore"
 	"github.com/kube-reporting/metering-operator/pkg/operator/reporting"
@@ -752,7 +752,7 @@ func (op *defaultReportingOperator) queueDependentReportsForDataSource(dataSourc
 	return nil
 }
 
-func updateReportDataSource(dsClient cbInterfaces.ReportDataSourceInterface, dsName string, updateFunc func(*metering.ReportDataSource)) (*metering.ReportDataSource, error) {
+func updateReportDataSource(dsClient clientset.ReportDataSourceInterface, dsName string, updateFunc func(*metering.ReportDataSource)) (*metering.ReportDataSource, error) {
 	var ds *metering.ReportDataSource
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		newDS, err := dsClient.Get(context.TODO(), dsName, metav1.GetOptions{})

--- a/pkg/operator/health.go
+++ b/pkg/operator/health.go
@@ -12,7 +12,7 @@ type statusResponse struct {
 // healthinessHandler is the readiness check for the metering operator. If this
 // no requests will be sent to this pod, and rolling updates will not proceed
 // until the checks succeed.
-func (op *Reporting) readinessHandler(w http.ResponseWriter, r *http.Request) {
+func (op *defaultReportingOperator) readinessHandler(w http.ResponseWriter, r *http.Request) {
 	logger := newRequestLogger(op.logger, r, op.rand)
 	if !op.isInitialized() {
 		logger.Debugf("not ready: operator is not yet initialized")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/kube-reporting/metering-operator/pkg/db"
-	cbClientset "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned"
+	clientset "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned"
 	meteringv1scheme "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned/scheme"
 	factory "github.com/kube-reporting/metering-operator/pkg/generated/informers/externalversions"
 	listers "github.com/kube-reporting/metering-operator/pkg/generated/listers/metering/v1"
@@ -57,7 +57,7 @@ type defaultReportingOperator struct {
 
 	kubeClient        corev1.CoreV1Interface
 	coordinatorClient coordinatorv1.CoordinationV1Interface
-	meteringClient    cbClientset.Interface
+	meteringClient    clientset.Interface
 	eventRecorder     record.EventRecorder
 
 	informerFactory factory.SharedInformerFactory
@@ -149,7 +149,7 @@ func New(logger log.FieldLogger, cfg Config) (ReportingOperator, error) {
 	}
 
 	logger.Debugf("setting up Metering client...")
-	meteringClient, err := cbClientset.NewForConfig(kubeConfig)
+	meteringClient, err := clientset.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create Metering client: %v", err)
 	}
@@ -177,7 +177,7 @@ func newReportingOperator(
 	kubeConfig *rest.Config,
 	kubeClient corev1.CoreV1Interface,
 	coordinatorClient coordinatorv1.CoordinationV1Interface,
-	meteringClient cbClientset.Interface,
+	meteringClient clientset.Interface,
 	informerNamespace string,
 ) ReportingOperator {
 	informerFactory := factory.NewSharedInformerFactoryWithOptions(meteringClient, defaultResyncPeriod, factory.WithNamespace(informerNamespace), factory.WithTweakListOptions(nil))

--- a/pkg/operator/promsum.go
+++ b/pkg/operator/promsum.go
@@ -161,7 +161,7 @@ type prometheusImportResults struct {
 	MetricsImportedCount int    `json:"metricsImportedCount"`
 }
 
-func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace, dsName string, start, end time.Time) ([]*prometheusImportResults, error) {
+func (op *defaultReportingOperator) importPrometheusForTimeRange(ctx context.Context, namespace, dsName string, start, end time.Time) ([]*prometheusImportResults, error) {
 	reportDataSources, err := op.meteringClient.MeteringV1().ReportDataSources(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -263,7 +263,7 @@ func (op *Reporting) importPrometheusForTimeRange(ctx context.Context, namespace
 	return results, g.Wait()
 }
 
-func (op *Reporting) getQueryIntervalForReportDataSource(reportDataSource *metering.ReportDataSource) time.Duration {
+func (op *defaultReportingOperator) getQueryIntervalForReportDataSource(reportDataSource *metering.ReportDataSource) time.Duration {
 	queryConf := reportDataSource.Spec.PrometheusMetricsImporter.QueryConfig
 	queryInterval := op.cfg.PrometheusQueryConfig.QueryInterval.Duration
 	if queryConf != nil {
@@ -274,7 +274,7 @@ func (op *Reporting) getQueryIntervalForReportDataSource(reportDataSource *meter
 	return queryInterval
 }
 
-func (op *Reporting) newPromImporterCfg(reportDataSource *metering.ReportDataSource, query string, prestoTable *metering.PrestoTable) (prestostore.Config, error) {
+func (op *defaultReportingOperator) newPromImporterCfg(reportDataSource *metering.ReportDataSource, query string, prestoTable *metering.PrestoTable) (prestostore.Config, error) {
 	chunkSize := op.cfg.PrometheusQueryConfig.ChunkSize.Duration
 	stepSize := op.cfg.PrometheusQueryConfig.StepSize.Duration
 
@@ -322,7 +322,7 @@ func (op *Reporting) newPromImporterCfg(reportDataSource *metering.ReportDataSou
 	}, nil
 }
 
-func (op *Reporting) newPromImporter(logger logrus.FieldLogger, reportDataSource *metering.ReportDataSource, prestoTable *metering.PrestoTable, cfg prestostore.Config) (*prestostore.PrometheusImporter, error) {
+func (op *defaultReportingOperator) newPromImporter(logger logrus.FieldLogger, reportDataSource *metering.ReportDataSource, prestoTable *metering.PrestoTable, cfg prestostore.Config) (*prestostore.PrometheusImporter, error) {
 	metricsCollectors := op.newPromImporterMetricsCollectors(reportDataSource, prestoTable, cfg)
 	var promConn prom.API
 	var err error
@@ -338,7 +338,7 @@ func (op *Reporting) newPromImporter(logger logrus.FieldLogger, reportDataSource
 	return prestostore.NewPrometheusImporter(logger, promConn, op.prometheusMetricsRepo, op.clock, cfg, metricsCollectors), nil
 }
 
-func (op *Reporting) newPromImporterMetricsCollectors(reportDataSource *metering.ReportDataSource, prestoTable *metering.PrestoTable, cfg prestostore.Config) prestostore.ImporterMetricsCollectors {
+func (op *defaultReportingOperator) newPromImporterMetricsCollectors(reportDataSource *metering.ReportDataSource, prestoTable *metering.PrestoTable, cfg prestostore.Config) prestostore.ImporterMetricsCollectors {
 	promLabels := prometheus.Labels{
 		"reportdatasource": reportDataSource.Name,
 		"namespace":        reportDataSource.Namespace,

--- a/pkg/operator/queues.go
+++ b/pkg/operator/queues.go
@@ -16,13 +16,13 @@ import (
 	_ "github.com/kube-reporting/metering-operator/pkg/util/workqueue/prometheus" // for prometheus metric registration
 )
 
-func (op *Reporting) shutdownQueues() {
+func (op *defaultReportingOperator) shutdownQueues() {
 	for _, queue := range op.queueList {
 		queue.ShutDown()
 	}
 }
 
-func (op *Reporting) addReport(obj interface{}) {
+func (op *defaultReportingOperator) addReport(obj interface{}) {
 	report := obj.(*metering.Report)
 	if report.DeletionTimestamp != nil {
 		op.deleteReport(report)
@@ -32,7 +32,7 @@ func (op *Reporting) addReport(obj interface{}) {
 	op.enqueueReport(report)
 }
 
-func (op *Reporting) updateReport(prev, cur interface{}) {
+func (op *defaultReportingOperator) updateReport(prev, cur interface{}) {
 	prevReport := prev.(*metering.Report)
 	curReport := cur.(*metering.Report)
 	if curReport.DeletionTimestamp != nil {
@@ -57,7 +57,7 @@ func (op *Reporting) updateReport(prev, cur interface{}) {
 	op.enqueueReport(curReport)
 }
 
-func (op *Reporting) deleteReport(obj interface{}) {
+func (op *defaultReportingOperator) deleteReport(obj interface{}) {
 	report, ok := obj.(*metering.Report)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -79,7 +79,7 @@ func (op *Reporting) deleteReport(obj interface{}) {
 	op.reportQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReport(report *metering.Report) {
+func (op *defaultReportingOperator) enqueueReport(report *metering.Report) {
 	key, err := cache.MetaNamespaceKeyFunc(report)
 	if err != nil {
 		op.logger.WithError(err).Errorf("Couldn't get key for object %#v: %v", report, err)
@@ -88,7 +88,7 @@ func (op *Reporting) enqueueReport(report *metering.Report) {
 	op.reportQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReportAfter(report *metering.Report, duration time.Duration) {
+func (op *defaultReportingOperator) enqueueReportAfter(report *metering.Report, duration time.Duration) {
 	key, err := cache.MetaNamespaceKeyFunc(report)
 	if err != nil {
 		op.logger.WithError(err).Errorf("Couldn't get key for object %#v: %v", report, err)
@@ -97,7 +97,7 @@ func (op *Reporting) enqueueReportAfter(report *metering.Report, duration time.D
 	op.reportQueue.AddAfter(key, duration)
 }
 
-func (op *Reporting) addReportDataSource(obj interface{}) {
+func (op *defaultReportingOperator) addReportDataSource(obj interface{}) {
 	ds := obj.(*metering.ReportDataSource)
 	if ds.DeletionTimestamp != nil {
 		op.deleteReportDataSource(ds)
@@ -107,7 +107,7 @@ func (op *Reporting) addReportDataSource(obj interface{}) {
 	op.enqueueReportDataSource(ds)
 }
 
-func (op *Reporting) updateReportDataSource(prev, cur interface{}) {
+func (op *defaultReportingOperator) updateReportDataSource(prev, cur interface{}) {
 	curReportDataSource := cur.(*metering.ReportDataSource)
 	prevReportDataSource := prev.(*metering.ReportDataSource)
 	if curReportDataSource.DeletionTimestamp != nil {
@@ -134,7 +134,7 @@ func (op *Reporting) updateReportDataSource(prev, cur interface{}) {
 	op.enqueueReportDataSource(curReportDataSource)
 }
 
-func (op *Reporting) deleteReportDataSource(obj interface{}) {
+func (op *defaultReportingOperator) deleteReportDataSource(obj interface{}) {
 	dataSource, ok := obj.(*metering.ReportDataSource)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -156,7 +156,7 @@ func (op *Reporting) deleteReportDataSource(obj interface{}) {
 	op.reportDataSourceQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReportDataSource(ds *metering.ReportDataSource) {
+func (op *defaultReportingOperator) enqueueReportDataSource(ds *metering.ReportDataSource) {
 	key, err := cache.MetaNamespaceKeyFunc(ds)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"reportDataSource": ds.Name, "namespace": ds.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", ds)
@@ -165,7 +165,7 @@ func (op *Reporting) enqueueReportDataSource(ds *metering.ReportDataSource) {
 	op.reportDataSourceQueue.Add(key)
 }
 
-func (op *Reporting) enqueueReportDataSourceAfter(ds *metering.ReportDataSource, duration time.Duration) {
+func (op *defaultReportingOperator) enqueueReportDataSourceAfter(ds *metering.ReportDataSource, duration time.Duration) {
 	key, err := cache.MetaNamespaceKeyFunc(ds)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"reportDataSource": ds.Name, "namespace": ds.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", ds)
@@ -174,13 +174,13 @@ func (op *Reporting) enqueueReportDataSourceAfter(ds *metering.ReportDataSource,
 	op.reportDataSourceQueue.AddAfter(key, duration)
 }
 
-func (op *Reporting) addReportQuery(obj interface{}) {
+func (op *defaultReportingOperator) addReportQuery(obj interface{}) {
 	query := obj.(*metering.ReportQuery)
 	op.logger.Infof("adding ReportQuery %s/%s", query.Namespace, query.Name)
 	op.enqueueReportQuery(query)
 }
 
-func (op *Reporting) updateReportQuery(prev, cur interface{}) {
+func (op *defaultReportingOperator) updateReportQuery(prev, cur interface{}) {
 	curReportQuery := cur.(*metering.ReportQuery)
 	prevReportQuery := prev.(*metering.ReportQuery)
 	logger := op.logger.WithFields(log.Fields{"reportQuery": curReportQuery.Name, "namespace": curReportQuery.Namespace})
@@ -202,7 +202,7 @@ func (op *Reporting) updateReportQuery(prev, cur interface{}) {
 	op.enqueueReportQuery(curReportQuery)
 }
 
-func (op *Reporting) enqueueReportQuery(query *metering.ReportQuery) {
+func (op *defaultReportingOperator) enqueueReportQuery(query *metering.ReportQuery) {
 	key, err := cache.MetaNamespaceKeyFunc(query)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"reportQuery": query.Name, "namespace": query.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", query)
@@ -211,7 +211,7 @@ func (op *Reporting) enqueueReportQuery(query *metering.ReportQuery) {
 	op.reportQueryQueue.Add(key)
 }
 
-func (op *Reporting) addPrestoTable(obj interface{}) {
+func (op *defaultReportingOperator) addPrestoTable(obj interface{}) {
 	table := obj.(*metering.PrestoTable)
 	if table.DeletionTimestamp != nil {
 		op.deletePrestoTable(table)
@@ -222,7 +222,7 @@ func (op *Reporting) addPrestoTable(obj interface{}) {
 	op.enqueuePrestoTable(table)
 }
 
-func (op *Reporting) updatePrestoTable(_, cur interface{}) {
+func (op *defaultReportingOperator) updatePrestoTable(_, cur interface{}) {
 	curPrestoTable := cur.(*metering.PrestoTable)
 	if curPrestoTable.DeletionTimestamp != nil {
 		op.deletePrestoTable(curPrestoTable)
@@ -233,7 +233,7 @@ func (op *Reporting) updatePrestoTable(_, cur interface{}) {
 	op.enqueuePrestoTable(curPrestoTable)
 }
 
-func (op *Reporting) deletePrestoTable(obj interface{}) {
+func (op *defaultReportingOperator) deletePrestoTable(obj interface{}) {
 	prestoTable, ok := obj.(*metering.PrestoTable)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -271,7 +271,7 @@ func (op *Reporting) deletePrestoTable(obj interface{}) {
 	op.prestoTableQueue.Add(key)
 }
 
-func (op *Reporting) enqueuePrestoTable(table *metering.PrestoTable) {
+func (op *defaultReportingOperator) enqueuePrestoTable(table *metering.PrestoTable) {
 	key, err := cache.MetaNamespaceKeyFunc(table)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"prestoTable": table.Name, "namespace": table.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", table)
@@ -280,7 +280,7 @@ func (op *Reporting) enqueuePrestoTable(table *metering.PrestoTable) {
 	op.prestoTableQueue.Add(key)
 }
 
-func (op *Reporting) addHiveTable(obj interface{}) {
+func (op *defaultReportingOperator) addHiveTable(obj interface{}) {
 	table := obj.(*metering.HiveTable)
 	if table.DeletionTimestamp != nil {
 		op.deleteHiveTable(table)
@@ -291,7 +291,7 @@ func (op *Reporting) addHiveTable(obj interface{}) {
 	op.enqueueHiveTable(table)
 }
 
-func (op *Reporting) updateHiveTable(_, cur interface{}) {
+func (op *defaultReportingOperator) updateHiveTable(_, cur interface{}) {
 	curHiveTable := cur.(*metering.HiveTable)
 	if curHiveTable.DeletionTimestamp != nil {
 		op.deleteHiveTable(curHiveTable)
@@ -302,7 +302,7 @@ func (op *Reporting) updateHiveTable(_, cur interface{}) {
 	op.enqueueHiveTable(curHiveTable)
 }
 
-func (op *Reporting) deleteHiveTable(obj interface{}) {
+func (op *defaultReportingOperator) deleteHiveTable(obj interface{}) {
 	hiveTable, ok := obj.(*metering.HiveTable)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -340,7 +340,7 @@ func (op *Reporting) deleteHiveTable(obj interface{}) {
 	op.hiveTableQueue.Add(key)
 }
 
-func (op *Reporting) enqueueHiveTable(table *metering.HiveTable) {
+func (op *defaultReportingOperator) enqueueHiveTable(table *metering.HiveTable) {
 	key, err := cache.MetaNamespaceKeyFunc(table)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"hiveTable": table.Name, "namespace": table.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", table)
@@ -349,7 +349,7 @@ func (op *Reporting) enqueueHiveTable(table *metering.HiveTable) {
 	op.hiveTableQueue.Add(key)
 }
 
-func (op *Reporting) addStorageLocation(obj interface{}) {
+func (op *defaultReportingOperator) addStorageLocation(obj interface{}) {
 	storageLocation := obj.(*metering.StorageLocation)
 	if storageLocation.DeletionTimestamp != nil {
 		op.deleteStorageLocation(storageLocation)
@@ -360,7 +360,7 @@ func (op *Reporting) addStorageLocation(obj interface{}) {
 	op.enqueueStorageLocation(storageLocation)
 }
 
-func (op *Reporting) updateStorageLocation(_, cur interface{}) {
+func (op *defaultReportingOperator) updateStorageLocation(_, cur interface{}) {
 	curStorageLocation := cur.(*metering.StorageLocation)
 	if curStorageLocation.DeletionTimestamp != nil {
 		op.deleteStorageLocation(curStorageLocation)
@@ -371,7 +371,7 @@ func (op *Reporting) updateStorageLocation(_, cur interface{}) {
 	op.enqueueStorageLocation(curStorageLocation)
 }
 
-func (op *Reporting) deleteStorageLocation(obj interface{}) {
+func (op *defaultReportingOperator) deleteStorageLocation(obj interface{}) {
 	storageLocation, ok := obj.(*metering.StorageLocation)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -410,7 +410,7 @@ func (op *Reporting) deleteStorageLocation(obj interface{}) {
 	op.storageLocationQueue.Add(key)
 }
 
-func (op *Reporting) enqueueStorageLocation(storageLocation *metering.StorageLocation) {
+func (op *defaultReportingOperator) enqueueStorageLocation(storageLocation *metering.StorageLocation) {
 	key, err := cache.MetaNamespaceKeyFunc(storageLocation)
 	if err != nil {
 		op.logger.WithFields(log.Fields{"storageLocation": storageLocation.Name, "namespace": storageLocation.Namespace}).WithError(err).Errorf("couldn't get key for object: %#v", storageLocation)
@@ -421,7 +421,7 @@ func (op *Reporting) enqueueStorageLocation(storageLocation *metering.StorageLoc
 
 type workerProcessFunc func(logger log.FieldLogger) bool
 
-func (op *Reporting) processResource(logger log.FieldLogger, handlerFunc syncHandler, objType string, queue workqueue.RateLimitingInterface, maxRequeues int) bool {
+func (op *defaultReportingOperator) processResource(logger log.FieldLogger, handlerFunc syncHandler, objType string, queue workqueue.RateLimitingInterface, maxRequeues int) bool {
 	obj, quit := queue.Get()
 	if quit {
 		logger.Infof("queue is shutting down, exiting %s worker", objType)
@@ -435,7 +435,7 @@ func (op *Reporting) processResource(logger log.FieldLogger, handlerFunc syncHan
 
 type syncHandler func(logger log.FieldLogger, key string) error
 
-func (op *Reporting) runHandler(logger log.FieldLogger, handlerFunc syncHandler, objType string, obj interface{}, queue workqueue.RateLimitingInterface, maxRequeues int) {
+func (op *defaultReportingOperator) runHandler(logger log.FieldLogger, handlerFunc syncHandler, objType string, obj interface{}, queue workqueue.RateLimitingInterface, maxRequeues int) {
 	logger = logger.WithFields(newLogIdentifier(op.rand))
 	if key, ok := op.getKeyFromQueueObj(logger, objType, obj, queue); ok {
 		logger.Infof("syncing %s %s", objType, key)
@@ -452,7 +452,7 @@ func (op *Reporting) runHandler(logger log.FieldLogger, handlerFunc syncHandler,
 // workqueue means the items in the informer cache may actually be
 // more up to date that when the item was initially put onto the
 // workqueue.
-func (op *Reporting) getKeyFromQueueObj(logger log.FieldLogger, objType string, obj interface{}, queue workqueue.RateLimitingInterface) (string, bool) {
+func (op *defaultReportingOperator) getKeyFromQueueObj(logger log.FieldLogger, objType string, obj interface{}, queue workqueue.RateLimitingInterface) (string, bool) {
 	if key, ok := obj.(string); ok {
 		return key, ok
 	}
@@ -462,7 +462,7 @@ func (op *Reporting) getKeyFromQueueObj(logger log.FieldLogger, objType string, 
 }
 
 // handleErr checks if an error happened and makes sure we will retry later.
-func (op *Reporting) handleErr(logger log.FieldLogger, err error, objType string, obj interface{}, queue workqueue.RateLimitingInterface, maxRequeues int) {
+func (op *defaultReportingOperator) handleErr(logger log.FieldLogger, err error, objType string, obj interface{}, queue workqueue.RateLimitingInterface, maxRequeues int) {
 	logger = logger.WithField(objType, obj)
 
 	if err == nil {

--- a/pkg/operator/reportquery.go
+++ b/pkg/operator/reportquery.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kube-reporting/metering-operator/pkg/operator/reporting"
 )
 
-func (op *Reporting) runReportQueryWorker() {
+func (op *defaultReportingOperator) runReportQueryWorker() {
 	logger := op.logger.WithField("component", "reportQueryWorker")
 	logger.Infof("ReportQuery worker started")
 	// 10 requeues compared to the 5 others have because
@@ -23,7 +23,7 @@ func (op *Reporting) runReportQueryWorker() {
 	}
 }
 
-func (op *Reporting) syncReportQuery(logger log.FieldLogger, key string) error {
+func (op *defaultReportingOperator) syncReportQuery(logger log.FieldLogger, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		logger.WithError(err).Errorf("invalid resource key :%s", key)
@@ -45,18 +45,18 @@ func (op *Reporting) syncReportQuery(logger log.FieldLogger, key string) error {
 	return op.handleReportQuery(logger, q)
 }
 
-func (op *Reporting) handleReportQuery(logger log.FieldLogger, query *metering.ReportQuery) error {
+func (op *defaultReportingOperator) handleReportQuery(logger log.FieldLogger, query *metering.ReportQuery) error {
 	// queue any reportDataSources using this query to create views
 	return op.queueDependentReportDataSourcesForQuery(query)
 }
 
-func (op *Reporting) uninitialiedDependendenciesHandler() *reporting.UninitialiedDependendenciesHandler {
+func (op *defaultReportingOperator) uninitialiedDependendenciesHandler() *reporting.UninitialiedDependendenciesHandler {
 	return &reporting.UninitialiedDependendenciesHandler{
 		HandleUninitializedReportDataSource: op.enqueueReportDataSource,
 	}
 }
 
-func (op *Reporting) queueDependentReportDataSourcesForQuery(query *metering.ReportQuery) error {
+func (op *defaultReportingOperator) queueDependentReportDataSourcesForQuery(query *metering.ReportQuery) error {
 	reportDataSourceLister := op.meteringClient.MeteringV1().ReportDataSources(query.Namespace)
 	reportDataSources, err := reportDataSourceLister.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/operator/storage.go
+++ b/pkg/operator/storage.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
-	cbListers "github.com/kube-reporting/metering-operator/pkg/generated/listers/metering/v1"
+	listers "github.com/kube-reporting/metering-operator/pkg/generated/listers/metering/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func (op *defaultReportingOperator) getDefaultStorageLocation(lister cbListers.StorageLocationLister, namespace string) (*metering.StorageLocation, error) {
+func (op *defaultReportingOperator) getDefaultStorageLocation(lister listers.StorageLocationLister, namespace string) (*metering.StorageLocation, error) {
 	storageLocations, err := lister.StorageLocations(namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err

--- a/pkg/operator/storage.go
+++ b/pkg/operator/storage.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func (op *Reporting) getDefaultStorageLocation(lister cbListers.StorageLocationLister, namespace string) (*metering.StorageLocation, error) {
+func (op *defaultReportingOperator) getDefaultStorageLocation(lister cbListers.StorageLocationLister, namespace string) (*metering.StorageLocation, error) {
 	storageLocations, err := lister.StorageLocations(namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (op *Reporting) getDefaultStorageLocation(lister cbListers.StorageLocationL
 
 }
 
-func (op *Reporting) getStorage(storage *metering.StorageLocationRef, namespace string) (*metering.StorageLocation, error) {
+func (op *defaultReportingOperator) getStorage(storage *metering.StorageLocationRef, namespace string) (*metering.StorageLocation, error) {
 	// Nothing specified, try to use default storage location
 	if storage == nil || storage.StorageLocationName == "" {
 		storageLocation, err := op.getDefaultStorageLocation(op.storageLocationLister, namespace)
@@ -52,7 +52,7 @@ func (op *Reporting) getStorage(storage *metering.StorageLocationRef, namespace 
 	return nil, fmt.Errorf("no default storageLocation and storageLocationName is empty")
 }
 
-func (op *Reporting) getHiveStorage(storageRef *metering.StorageLocationRef, namespace string) (*metering.StorageLocation, error) {
+func (op *defaultReportingOperator) getHiveStorage(storageRef *metering.StorageLocationRef, namespace string) (*metering.StorageLocation, error) {
 	storageLocation, err := op.getStorage(storageRef, namespace)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -1,0 +1,168 @@
+package operator
+
+import (
+	"time"
+
+	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
+	"github.com/kube-reporting/metering-operator/pkg/operator/reporting"
+)
+
+// DependencyResolver analyzes report dependencies for reports, report queries, and data sources.
+type DependencyResolver interface {
+	// ResolveDependencies determines, for the given namespace and report query inputs, any report, report
+	// query, and data source dependencies.
+	ResolveDependencies(namespace string, inputDefs []metering.ReportQueryInputDefinition, inputVals []metering.ReportQueryInputValue) (*reporting.DependencyResolutionResult, error)
+}
+
+// TLSConfig allows configuration of using TLS (on/off) as well as the cert and key.
+type TLSConfig struct {
+	// UseTLS if true TLS is requested and cert/key must be provided for valid config.
+	// TODO: we should just key on the existence of this, not a bool, unless we want to
+	// configure TLS and not use it.
+	UseTLS bool
+	// TLSCert is the certificate used to serve TLS.
+	TLSCert string
+	// TLSKey is the key used to serve TLS.
+	TLSKey string
+}
+
+// PrometheusConfig provides the configuration options to set up a Prometheus connections from a URL.
+type PrometheusConfig struct {
+	// Address is the URL to reach Prometheus.
+	Address string
+	// SkipTLSVerify should not be used in a production environment.  This is used to configure
+	// the transport to not verify the sever it is connecting too.  For testing only.
+	SkipTLSVerify bool
+	// BearerToken is the bearer token for authentication.
+	BearerToken string
+	// BearerTokenFile is a path to a file that contains the bearer token.  If configured the
+	// the contents are periodically read and the last successfully read value takes precedence over
+	// BearerToken.
+	BearerTokenFile string
+	// CAFile is the path of the PEM-encoded server trusted root certificates.
+	CAFile string
+}
+
+// Config holds the user-facing configuration options for running the reporting operator.
+type Config struct {
+	// Hostname is used as the identity of the resource lock for leader election as well as the event
+	// source when recording events.
+	Hostname string
+
+	// OwnNamespace is the namespace the operator is running in.  It is also used as the informer namespace
+	// if AllNamespaces or TargetNamespaces are not defined.  OwnNamespace is also the target sink for event
+	// recording.
+	OwnNamespace string
+	// AllNamespaces should be set to true if the operator should watch all namespaces for metering.openshift.io
+	// resources.  This should be set to true if more than one namespace is passed in TargetNamespaces.
+	AllNamespaces bool
+	// TargetNamespaces are the the namespaces for reporting-operator to watch for metering.openshift.io resources.
+	TargetNamespaces []string
+
+	// Kubeconfig is the path to the kubeconfig file.  If unset default config loading rules will be used.
+	Kubeconfig string
+
+	// APIListen configures the ip:port to listen on for the reporting API.
+	APIListen string
+	// MetricsListen configures the ip:port to listen on for Prometheus metrics.
+	MetricsListen string
+	// PprofListen configures the ip:port to listen on for the pprof debug info.
+	PprofListen string
+
+	// HiveHost configures the hostname:port for connecting to Hive.
+	HiveHost string
+	// HiveUseTLS, when set to true, enables TLS when connecting to Hive.  When set, HiveCAFile should also be set.
+	HiveUseTLS bool
+	// HiveCAFile configures the path to the certificate authority to use to connect to Hive. If empty, defaults to
+	// system CAs.  Should be set when HiveUseTLS is set to true.
+	HiveCAFile string
+	// HiveTLSInsecureSkipVerify is not for production use.  Setting to true disables TLS verification when connecting
+	// to Hive.  For testing only.
+	HiveTLSInsecureSkipVerify bool
+
+	// HiveUseClientCertAuth enables TLS client certificate authentication when HiveUseTLS is also enabled.
+	HiveUseClientCertAuth bool
+	// HiveClientCertFile configures the path to the client certificate to use to connect to Hive.
+	HiveClientCertFile string
+	// HiveClientKeyFile configures the path to the client key to use to connect to Hive.
+	HiveClientKeyFile string
+
+	// PrestoHost configures the hostname:port for connecting to Presto.
+	PrestoHost string
+	// PrestoUseTLS enables TLS when connecting to Presto.
+	PrestoUseTLS bool
+	// PrestoCAFile configures path to the certificate authority to use to connect to Presto.
+	PrestoCAFile string
+	// PrestoTLSInsecureSkipVerify is not for production use.  Setting to true disables TLS verification when connecting
+	// to Presto.  For testing only.
+	PrestoTLSInsecureSkipVerify bool
+
+	// PrestoUseClientCertAuth enables TLS client certificate authentication when PrestoUseTLS is also enabled.
+	PrestoUseClientCertAuth bool
+	// PrestoClientCertFile configures the path to the client certificate to use to connect to Presto.
+	PrestoClientCertFile string
+	// PrestoClientKeyFile configures the path to the client key to use to connect to Presto.
+	PrestoClientKeyFile string
+
+	// PrestoMaxQueryLength configures the capacity of the buffer pool for the Presto store.
+	// TODO: why would someone set this?
+	PrestoMaxQueryLength int
+
+	// DisablePrometheusMetricsImporter disables collecting Prometheus metrics periodically.
+	DisablePrometheusMetricsImporter bool
+	// EnableFinalizers, if enabled, then finalizers will be set on some resources to ensure the reporting-operator
+	// is able to perform cleanup before the resource is deleted from the API.
+	EnableFinalizers bool
+
+	// LogDMLQueries controls if we log data manipulation queries made via Presto (SELECT, INSERT, etc).
+	LogDMLQueries bool
+	// LogDDLQueries controls if we log data definition language queries made via Hive (CREATE TABLE, DROP TABLE, etc).
+	LogDDLQueries bool
+
+	// PrometheusQueryConfig holds the PrometheusQueryConfig api configuration.
+	PrometheusQueryConfig metering.PrometheusQueryConfig
+	// PrometheusDataSourceMaxQueryRangeDuration if non-zero specifies the maximum duration of time to query from
+	// Prometheus. When back filling, this value is used for the chunkSize when querying Prometheus.
+	PrometheusDataSourceMaxQueryRangeDuration time.Duration
+	// PrometheusDataSourceMaxBackfillImportDuration if non-zero specifies the maximum duration of time before the
+	// current to look back for data when back filling. Only one of PrometheusDataSourceMaxBackfillImportDuration and
+	// PrometheusDataSourceGlobalImportFromTime should be set.
+	PrometheusDataSourceMaxBackfillImportDuration time.Duration
+	// PrometheusDataSourceGlobalImportFromTime, if non-empty, indicates when Prometheus ReportDataSource data should
+	// be back filled from.
+	PrometheusDataSourceGlobalImportFromTime *time.Time
+
+	// ProxyTrustedCABundle configures the path to the certificate authority bundle used to connect to the cluster-wide
+	// https proxy.
+	ProxyTrustedCABundle string
+
+	// LeaderLeaseDuration is the duration that non-leader candidates will wait to force acquire leadership.  This
+	// value, halved, will be used as the renewal deadline duration for the acting master.
+	LeaderLeaseDuration time.Duration
+
+	// APITLSConfig configures TLS options for API traffic.
+	APITLSConfig TLSConfig
+	// MetricsTLSConfig configures TLS options for Prometheus metrics endpoint traffic.
+	MetricsTLSConfig TLSConfig
+	// PrometheusConfig configures connectivity options for Prometheus.
+	PrometheusConfig PrometheusConfig
+}
+
+const (
+	// defaultResyncPeriod is the default informer sync period.
+	defaultResyncPeriod = time.Minute * 15
+	// prestoUsername is the default presto user name for building the presto query endpoint.
+	prestoUsername = "reporting-operator"
+
+	// DefaultPrometheusQueryInterval - Query Prometheus every 5 minutes
+	DefaultPrometheusQueryInterval = time.Minute * 5
+	// DefaultPrometheusQueryStepSize - Query data from Prometheus at a 60 second resolution
+	// (one data point per minute max)
+	DefaultPrometheusQueryStepSize = time.Minute
+	// DefaultPrometheusQueryChunkSize the default value for how much data we will insert into Presto per Prometheus query.
+	DefaultPrometheusQueryChunkSize = 5 * time.Minute
+	// DefaultPrometheusDataSourceMaxQueryRangeDuration is how much data we will query from Prometheus at once
+	DefaultPrometheusDataSourceMaxQueryRangeDuration = 10 * time.Minute
+	// DefaultPrometheusDataSourceMaxBackfillImportDuration how far we will query for backlogged data.
+	DefaultPrometheusDataSourceMaxBackfillImportDuration = 2 * time.Hour
+)

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -1,11 +1,16 @@
 package operator
 
 import (
+	"context"
 	"time"
 
 	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
 	"github.com/kube-reporting/metering-operator/pkg/operator/reporting"
 )
+
+type ReportingOperator interface {
+	Run(ctx context.Context) error
+}
 
 // DependencyResolver analyzes report dependencies for reports, report queries, and data sources.
 type DependencyResolver interface {

--- a/pkg/operator/validation.go
+++ b/pkg/operator/validation.go
@@ -46,8 +46,6 @@ func IsValidListenConfig(cfg *Config) error {
 	errs := []error{}
 
 	errs = append(errs, isValidHostPort(cfg.APIListen, "apiListen"))
-	errs = append(errs, isValidHostPort(cfg.MetricsListen, "metricsListen"))
-	errs = append(errs, isValidHostPort(cfg.PprofListen, "pprofListen"))
 
 	if len(errs) > 0 {
 		return errors.NewAggregate(errs)
@@ -58,8 +56,6 @@ func IsValidListenConfig(cfg *Config) error {
 // IsValidPrestoConfig ensure all Presto* fields are valid if provided.
 func IsValidPrestoConfig(cfg *Config) error {
 	errs := []error{}
-
-	errs = append(errs, isValidHostPort(cfg.PrestoHost, "prestoHost"))
 
 	if !cfg.PrestoUseTLS {
 		if cfg.PrestoUseClientCertAuth {
@@ -91,8 +87,6 @@ func IsValidPrestoConfig(cfg *Config) error {
 // IsValidHiveConfig ensure all Hive* fields are valid if provided.
 func IsValidHiveConfig(cfg *Config) error {
 	errs := []error{}
-
-	errs = append(errs, isValidHostPort(cfg.HiveHost, "hiveHost"))
 
 	if !cfg.HiveUseTLS {
 		if cfg.HiveUseClientCertAuth {

--- a/pkg/operator/validation.go
+++ b/pkg/operator/validation.go
@@ -1,0 +1,178 @@
+package operator
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+)
+
+// IsValidConfig checks the validity of all configuration options.
+func IsValidConfig(cfg *Config) error {
+	errs := []error{}
+
+	errs = append(errs, IsValidNamespaceConfig(cfg))
+	errs = append(errs, IsValidListenConfig(cfg))
+	errs = append(errs, IsValidPrestoConfig(cfg))
+	errs = append(errs, IsValidHiveConfig(cfg))
+	errs = append(errs, IsValidKubeConfig(cfg.Kubeconfig))
+	errs = append(errs, IsValidPrometheusConfig(cfg))
+
+	if err := isValidTLSConfig(&cfg.APITLSConfig); err != nil {
+		errs = append(errs, fmt.Errorf("error validating apiTLSConfig: %s", err.Error()))
+	}
+
+	if err := isValidTLSConfig(&cfg.MetricsTLSConfig); err != nil {
+		errs = append(errs, fmt.Errorf("error validating metricsTLSConfig: %s", err.Error()))
+	}
+
+	if len(errs) != 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// IsValidNamespaceConfig ensures that if you are using target namespaces the all namespace field is correct.
+func IsValidNamespaceConfig(cfg *Config) error {
+	if len(cfg.TargetNamespaces) > 1 && !cfg.AllNamespaces {
+		return fmt.Errorf("must set allNamespaces if more than one namespace is passed to targetNamespaces")
+	}
+	return nil
+}
+
+// IsValidListenConfig ensures all *Listen fields are set to valid host/ports if they have a value set.
+func IsValidListenConfig(cfg *Config) error {
+	errs := []error{}
+
+	errs = append(errs, isValidHostPort(cfg.APIListen, "apiListen"))
+	errs = append(errs, isValidHostPort(cfg.MetricsListen, "metricsListen"))
+	errs = append(errs, isValidHostPort(cfg.PprofListen, "pprofListen"))
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// IsValidPrestoConfig ensure all Presto* fields are valid if provided.
+func IsValidPrestoConfig(cfg *Config) error {
+	errs := []error{}
+
+	errs = append(errs, isValidHostPort(cfg.PrestoHost, "prestoHost"))
+
+	if !cfg.PrestoUseTLS {
+		if cfg.PrestoUseClientCertAuth {
+			errs = append(errs, fmt.Errorf("prestoUseClientCertAuth cannot be set to true if prestoUseTLS is false"))
+		}
+
+		if len(cfg.PrestoCAFile) > 0 {
+			errs = append(errs, fmt.Errorf("prestoCAFile cannot be set if prestoUseTLS is false"))
+		}
+	}
+
+	if len(cfg.PrestoCAFile) > 0 {
+		if _, err := os.Stat(cfg.PrestoCAFile); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if (len(cfg.PrestoClientCertFile) > 0 && len(cfg.PrestoClientKeyFile) == 0) ||
+		(len(cfg.PrestoClientKeyFile) > 0 && len(cfg.PrestoClientCertFile) == 0) {
+		errs = append(errs, fmt.Errorf("prestoClientCertFile and prestoClientKeyFile must both be specified or neither specified"))
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// IsValidHiveConfig ensure all Hive* fields are valid if provided.
+func IsValidHiveConfig(cfg *Config) error {
+	errs := []error{}
+
+	errs = append(errs, isValidHostPort(cfg.HiveHost, "hiveHost"))
+
+	if !cfg.HiveUseTLS {
+		if cfg.HiveUseClientCertAuth {
+			errs = append(errs, fmt.Errorf("hiveUseClientCertAuth cannot be set to true if hiveUseTLS is false"))
+		}
+
+		if len(cfg.HiveCAFile) > 0 {
+			errs = append(errs, fmt.Errorf("hiveCAFile cannot be set if hiveUseTLS is false"))
+		}
+	}
+
+	if len(cfg.HiveCAFile) > 0 {
+		if _, err := os.Stat(cfg.HiveCAFile); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if (len(cfg.HiveClientCertFile) > 0 && len(cfg.HiveClientKeyFile) == 0) ||
+		(len(cfg.HiveClientKeyFile) > 0 && len(cfg.HiveClientCertFile) == 0) {
+		errs = append(errs, fmt.Errorf("hiveClientCertFile and hiveClientKeyFile must both be specified or neither specified"))
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// IsValidKubeConfig ensures the kube config is set to a valid file if provided.
+func IsValidKubeConfig(kubeconfig string) error {
+	if len(kubeconfig) > 0 {
+		if _, err := os.Stat(kubeconfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsValidPrometheusConfig ensures prometheus configuration is valid.
+func IsValidPrometheusConfig(cfg *Config) error {
+	errs := []error{}
+	if cfg.PrometheusConfig.CAFile != "" {
+		if _, err := os.Stat(cfg.PrometheusConfig.CAFile); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// PrometheusDataSourceMaxBackfillImportDuration overrides PrometheusDataSourceGlobalImportFromTime
+	// don't set both.
+	if cfg.PrometheusDataSourceGlobalImportFromTime != nil && cfg.PrometheusDataSourceMaxBackfillImportDuration > 0 {
+		errs = append(errs, fmt.Errorf("prometheusDataSourceGlobalImportFromTime and prometheusDataSourceMaxBackfillImportDuration cannot both be set"))
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// IsValidTLSConfig ensures the TLS config is valid.
+func isValidTLSConfig(cfg *TLSConfig) error {
+	if cfg.UseTLS {
+		if cfg.TLSCert == "" {
+			return fmt.Errorf("must set TLS certificate if TLS is enabled")
+		}
+		if cfg.TLSKey == "" {
+			return fmt.Errorf("must set TLS private key if TLS is enabled")
+		}
+	}
+	return nil
+}
+
+// isValidHostPort attempts to split a non empty hp into host and port, returning any errors found.
+// TODO this is only validating non-empty strings.  We may want to check for empty strings an report errors.
+// TODO this requires a port to be specified, is that one of our requirements?
+func isValidHostPort(hp string, name string) error {
+	if len(hp) > 0 {
+		if _, _, err := net.SplitHostPort(hp); err != nil {
+			return fmt.Errorf("invalid %s: %s", name, err.Error())
+		}
+	}
+	return nil
+}

--- a/pkg/operator/validation_test.go
+++ b/pkg/operator/validation_test.go
@@ -1,0 +1,300 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsValidConfig(t *testing.T) {
+	tests := map[string]struct {
+		makeCfg     func() *Config
+		expectedErr string
+	}{
+		"valid config": {
+			makeCfg: func() *Config { return validConfig() },
+		},
+		"invalid namespace config": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.AllNamespaces = false
+				cfg.TargetNamespaces = []string{"foo", "bar"}
+				return cfg
+			},
+			expectedErr: "must set allNamespaces if more than one namespace is passed to targetNamespaces",
+		},
+		"listen config - valid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.APIListen = "foo:8080"
+				cfg.MetricsListen = "foo:443"
+				cfg.PprofListen = ":8080"
+				return cfg
+			},
+		},
+		"listen config - invalid API Listen": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.APIListen = "foo"
+				return cfg
+			},
+			expectedErr: "invalid apiListen",
+		},
+		"listen config - invalid metrics listen": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.MetricsListen = "foo"
+				return cfg
+			},
+			expectedErr: "invalid metricsListen",
+		},
+		"listen config - invalid pprof listen": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PprofListen = "foo"
+				return cfg
+			},
+			expectedErr: "invalid pprofListen",
+		},
+		"presto config - valid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoHost = "foo:8080"
+				return cfg
+			},
+		},
+		"presto config - invalid use tls with client cert auth": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoUseTLS = false
+				cfg.PrestoUseClientCertAuth = true
+				return cfg
+			},
+			expectedErr: "prestoUseClientCertAuth cannot be set to true if prestoUseTLS is false",
+		},
+		"presto config - invalid use tls with CA file": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoUseTLS = false
+				cfg.PrestoCAFile = "/tmp" // is this going to fail on macs?  Could probably be done more reliably
+				return cfg
+			},
+			expectedErr: "prestoCAFile cannot be set if prestoUseTLS is false",
+		},
+		"presto config - invalid use tls with CA file that doesn't exist": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoUseTLS = true
+				cfg.PrestoCAFile = "/garbageFile"
+				return cfg
+			},
+			expectedErr: "no such file or directory",
+		},
+		"presto config - valid client cert/key config": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoClientCertFile = "/foo"
+				cfg.PrestoClientKeyFile = "/foo"
+				return cfg
+			},
+		},
+		"presto config - invalid client cert/key config - no cert": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoClientKeyFile = "/foo"
+				return cfg
+			},
+			expectedErr: "prestoClientCertFile and prestoClientKeyFile must both be specified or neither specified",
+		},
+		"presto config - invalid client cert/key config - no key": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrestoClientCertFile = "/foo"
+				return cfg
+			},
+			expectedErr: "prestoClientCertFile and prestoClientKeyFile must both be specified or neither specified",
+		},
+		"hive config - valid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveHost = "foo:8080"
+				return cfg
+			},
+		},
+		"hive config - invalid use tls with client cert auth": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveUseTLS = false
+				cfg.HiveUseClientCertAuth = true
+				return cfg
+			},
+			expectedErr: "hiveUseClientCertAuth cannot be set to true if hiveUseTLS is false",
+		},
+		"hive config - invalid use tls with CA file": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveUseTLS = false
+				cfg.HiveCAFile = "/tmp" // is this going to fail on macs?  Could probably be done more reliably
+				return cfg
+			},
+			expectedErr: "hiveCAFile cannot be set if hiveUseTLS is false",
+		},
+		"hive config - invalid use tls with CA file that doesn't exist": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveUseTLS = true
+				cfg.HiveCAFile = "/garbageFile"
+				return cfg
+			},
+			expectedErr: "no such file or directory",
+		},
+		"hive config - valid client cert/key config": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveClientCertFile = "/foo"
+				cfg.HiveClientKeyFile = "/foo"
+				return cfg
+			},
+		},
+		"hive config - invalid client cert/key config - no cert": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveClientKeyFile = "/foo"
+				return cfg
+			},
+			expectedErr: "hiveClientCertFile and hiveClientKeyFile must both be specified or neither specified",
+		},
+		"hive config - invalid client cert/key config - no key": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.HiveClientCertFile = "/foo"
+				return cfg
+			},
+			expectedErr: "hiveClientCertFile and hiveClientKeyFile must both be specified or neither specified",
+		},
+		"kube config - valid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.Kubeconfig = "/tmp" // will this fail on macs?
+				return cfg
+			},
+		},
+		"kube config - invalid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.Kubeconfig = "/garbageFile"
+				return cfg
+			},
+			expectedErr: "no such file or directory",
+		},
+		"prometheus config - invalid CA File": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrometheusConfig.CAFile = "/garbageFile"
+				return cfg
+			},
+			expectedErr: "no such file or directory",
+		},
+		"prometheus config - invalid import fields": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.PrometheusDataSourceMaxBackfillImportDuration = time.Second
+				now := time.Now()
+				cfg.PrometheusDataSourceGlobalImportFromTime = &now
+				return cfg
+			},
+			expectedErr: "prometheusDataSourceGlobalImportFromTime and prometheusDataSourceMaxBackfillImportDuration cannot both be set",
+		},
+		"api tls config - valid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.APITLSConfig = TLSConfig{
+					UseTLS:  true,
+					TLSCert: "/foo",
+					TLSKey:  "/foo",
+				}
+				return cfg
+			},
+		},
+		"api tls config - missing cert": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.APITLSConfig = TLSConfig{
+					UseTLS: true,
+					TLSKey: "/foo",
+				}
+				return cfg
+			},
+			expectedErr: "must set TLS certificate if TLS is enabled",
+		},
+		"api tls config - missing key": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.APITLSConfig = TLSConfig{
+					UseTLS:  true,
+					TLSCert: "/foo",
+				}
+				return cfg
+			},
+			expectedErr: "must set TLS private key if TLS is enabled",
+		},
+		"metrics tls config - valid": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.MetricsTLSConfig = TLSConfig{
+					UseTLS:  true,
+					TLSCert: "/foo",
+					TLSKey:  "/foo",
+				}
+				return cfg
+			},
+		},
+		"metrics tls config - missing cert": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.MetricsTLSConfig = TLSConfig{
+					UseTLS: true,
+					TLSKey: "/foo",
+				}
+				return cfg
+			},
+			expectedErr: "must set TLS certificate if TLS is enabled",
+		},
+		"metrics tls config - missing key": {
+			makeCfg: func() *Config {
+				cfg := validConfig()
+				cfg.MetricsTLSConfig = TLSConfig{
+					UseTLS:  true,
+					TLSCert: "/foo",
+				}
+				return cfg
+			},
+			expectedErr: "must set TLS private key if TLS is enabled",
+		},
+	}
+
+	for name, test := range tests {
+		err := IsValidConfig(test.makeCfg())
+		if len(test.expectedErr) == 0 && err == nil {
+			continue //good test
+		}
+		if len(test.expectedErr) == 0 && err != nil {
+			t.Errorf("%s expected no error but received %s", name, err.Error())
+			continue
+		}
+		if len(test.expectedErr) > 0 && err == nil {
+			t.Errorf("%s expected an error but didn't receive one", name)
+			continue
+		}
+		// expected error, got error, check that the error was what we wanted to avoid false passes
+		if !strings.Contains(err.Error(), test.expectedErr) {
+			t.Errorf("%s did not find the expected error string in %s", name, err.Error())
+		}
+	}
+}
+
+func validConfig() *Config {
+	return &Config{
+		AllNamespaces: true,
+	}
+}

--- a/pkg/operator/validation_test.go
+++ b/pkg/operator/validation_test.go
@@ -27,8 +27,6 @@ func TestIsValidConfig(t *testing.T) {
 			makeCfg: func() *Config {
 				cfg := validConfig()
 				cfg.APIListen = "foo:8080"
-				cfg.MetricsListen = "foo:443"
-				cfg.PprofListen = ":8080"
 				return cfg
 			},
 		},
@@ -39,22 +37,6 @@ func TestIsValidConfig(t *testing.T) {
 				return cfg
 			},
 			expectedErr: "invalid apiListen",
-		},
-		"listen config - invalid metrics listen": {
-			makeCfg: func() *Config {
-				cfg := validConfig()
-				cfg.MetricsListen = "foo"
-				return cfg
-			},
-			expectedErr: "invalid metricsListen",
-		},
-		"listen config - invalid pprof listen": {
-			makeCfg: func() *Config {
-				cfg := validConfig()
-				cfg.PprofListen = "foo"
-				return cfg
-			},
-			expectedErr: "invalid pprofListen",
 		},
 		"presto config - valid": {
 			makeCfg: func() *Config {


### PR DESCRIPTION
Round 1 - go!

Let's see what clean up we can do here @timflannagan1.

This has the following commits that can be reviewed independently

1.  move the type declarations to their own file and try to comment them up for future readers
2.  since the reporting operator was not exporting anything, introduce an interface and unexport the type.  Consumers deal with the interface now
3.  move all the smaller validation blurbs from the various sections that are called during `New`, `newOperator`, and `Run` methods and consolidate on a single validation call to ensure the config is good during `New`.  No good config == no operator to run.  Bonus: Add tests for all validations
4.  rename cb* imports to remove references to chargeback

There are a couple questions sprinkled in where things weren't obvious.