### PR TITLE
test/e2e: Disable the MySQL Hive metastore e2e test.

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -283,8 +283,13 @@ func TestManualMeteringInstall(t *testing.T) {
 			Name:                      "ValidHDFS-MySQLDatabase",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
-			Skip:                      false,
-			PreInstallFunc:            createMySQLDatabase,
+			// TODO: disable this for now as the mysql:5.7 image
+			// stream was recently removed from 4.6 and there are
+			// some issues with using mariadb as a direct replacement
+			// as Hive server hangs during the create table call
+			// and requires a restart to work properly.
+			Skip:           true,
+			PreInstallFunc: createMySQLDatabase,
 			InstallSubTests: []InstallTestCase{
 				{
 					Name:     "testReportingProducesData",


### PR DESCRIPTION
The MySQL 5.7 imagestream has been recently removed from the 4.6 release, which ends up breaking this e2e test as we're attempting to instantiate a 5.7 MySQL service with an image that doesn't exist. Let's disable this test for now and circle back to it later.