### PR TITLE
test: Add comments and perform general cleanup for the various reportingframework method and functions.

### DIFF
--- a/test/reportingframework/db.go
+++ b/test/reportingframework/db.go
@@ -9,6 +9,11 @@ import (
 	"github.com/kube-reporting/metering-operator/pkg/operator/prestostore"
 )
 
+const prometheusDataSourceAPIEndpointPrefix = "/api/v1/datasources/prometheus/store/"
+
+// StoreDataSourceData is a reportingframework method responsible for making
+// the metering push API call to inject the list of @metrics prometheus metrics
+// into a particular ReportDatasource custom resource database table.
 func (rf *ReportingFramework) StoreDataSourceData(dataSourceName string, metrics []*prestostore.PrometheusMetric) error {
 	params := operator.StorePrometheusMetricsDataRequest(metrics)
 	body, err := json.Marshal(params)
@@ -16,7 +21,9 @@ func (rf *ReportingFramework) StoreDataSourceData(dataSourceName string, metrics
 		return err
 	}
 
-	url := fmt.Sprintf("/api/v1/datasources/prometheus/store/%s/%s", rf.Namespace, dataSourceName)
+	// build up the URL the post api request is expecting.
+	// ex: $HOST/api/v1/datasources/prometheus/store/tflannag/namespace-cpu-request
+	url := fmt.Sprintf("%s/%s/%s", prometheusDataSourceAPIEndpointPrefix, rf.Namespace, dataSourceName)
 	respBody, respCode, err := rf.ReportingOperatorPOSTRequest(url, body)
 	if err != nil {
 		return fmt.Errorf("error storing datasource data: %s", err)

--- a/test/reportingframework/framework.go
+++ b/test/reportingframework/framework.go
@@ -13,13 +13,16 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 
-	metering "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned/typed/metering/v1"
+	meteringv1 "github.com/kube-reporting/metering-operator/pkg/generated/clientset/versioned/typed/metering/v1"
 	"github.com/kube-reporting/metering-operator/pkg/operator"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 )
 
+// ReportingFramework is a type responsible for storing all
+// of the state necessary to perform post-install tests
+// against a particular metering installation.
 type ReportingFramework struct {
-	MeteringClient metering.MeteringV1Interface
+	MeteringClient meteringv1.MeteringV1Interface
 	KubeClient     kubernetes.Interface
 	RouteClient    routev1client.RouteV1Client
 	KubeConfig     *rest.Config
@@ -54,7 +57,7 @@ func New(
 	reportOutputDir string,
 	kubeconfig *rest.Config,
 	kubeClient kubernetes.Interface,
-	meteringClient metering.MeteringV1Interface,
+	meteringClient meteringv1.MeteringV1Interface,
 ) (*ReportingFramework, error) {
 	kubeAPIURL, kubeAPIPath, err := rest.DefaultServerURL(kubeconfig.Host, kubeconfig.APIPath, schema.GroupVersion{}, true)
 	if err != nil {

--- a/test/reportingframework/prestotables.go
+++ b/test/reportingframework/prestotables.go
@@ -12,12 +12,19 @@ import (
 	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
 )
 
+// GetPrestoTable is a reportingframework method that makes the
+// client-go API request for the @name PrestoTable.
 func (rf *ReportingFramework) GetPrestoTable(name string) (*metering.PrestoTable, error) {
 	return rf.MeteringClient.PrestoTables(rf.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
+// WaitForPrestoTable is a reportingframework method responsbile
+// for ensuring that the @name PrestoTable custom resource in the
+// rf.Namespace namespace has is reporting a ready status. We define
+// "ready" here based on the @tableFunc anonymous function parameter.
 func (rf *ReportingFramework) WaitForPrestoTable(t *testing.T, name string, pollInterval, timeout time.Duration, tableFunc func(table *metering.PrestoTable) (bool, error)) (*metering.PrestoTable, error) {
 	t.Helper()
+
 	var table *metering.PrestoTable
 	return table, wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 		var err error
@@ -33,6 +40,9 @@ func (rf *ReportingFramework) WaitForPrestoTable(t *testing.T, name string, poll
 	})
 }
 
+// PrestoTableExists is a reportingframework method that determines
+// whether or not the @name PrestoTable custom resource in the
+// rf.Namespace namespace has a populated database table in Presto.
 func (rf *ReportingFramework) PrestoTableExists(t *testing.T, name string) (bool, error) {
 	prestoTable, err := rf.MeteringClient.PrestoTables(rf.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {

--- a/test/reportingframework/report.go
+++ b/test/reportingframework/report.go
@@ -98,7 +98,7 @@ func (rf *ReportingFramework) GetReportResults(t *testing.T, report *metering.Re
 		"format":    "json",
 	}
 	err := wait.Poll(time.Second*5, waitTimeout, func() (bool, error) {
-		respBody, respCode, err := rf.ReportingOperatorRequest("/api/v1/reports/get", queryParams)
+		respBody, respCode, err := rf.ReportingOperatorGetRequest("/api/v1/reports/get", queryParams)
 		require.NoError(t, err, "fetching Report results should be successful")
 
 		if respCode == http.StatusAccepted {

--- a/test/reportingframework/service.go
+++ b/test/reportingframework/service.go
@@ -100,10 +100,14 @@ func (rf *ReportingFramework) doRequest(endpoint, method string, body []byte, qu
 	return respBody, resp.StatusCode, nil
 }
 
-func (rf *ReportingFramework) ReportingOperatorRequest(endpoint string, query map[string]string) (respBody []byte, code int, err error) {
+// ReportingOperatorGetRequest is a reportingframework method that performs
+// a single GET request to the metering API.
+func (rf *ReportingFramework) ReportingOperatorGetRequest(endpoint string, query map[string]string) (respBody []byte, code int, err error) {
 	return rf.doRequest(endpoint, "GET", nil, query)
 }
 
+// ReportingOperatorPOSTRequest is a reportingframework method that performs
+// a single POST request to the metering API.
 func (rf *ReportingFramework) ReportingOperatorPOSTRequest(endpoint string, body []byte) (respBody []byte, code int, err error) {
 	return rf.doRequest(endpoint, "POST", body, nil)
 }

--- a/test/reportingframework/service.go
+++ b/test/reportingframework/service.go
@@ -20,35 +20,44 @@ const (
 	meteringRouteName                = "metering"
 )
 
-func (rf *ReportingFramework) doRequest(endpoint, method string, body []byte, query map[string]string) (respBody []byte, code int, err error) {
-	var u *url.URL
+func (rf *ReportingFramework) determineMeteringAPIUrl(endpoint string) (*url.URL, error) {
+	u := rf.ReportingAPIURL
 
 	if rf.UseRouteForReportingAPI {
-		// query all routes for the metering route
 		meteringRoute, err := rf.RouteClient.Routes(rf.Namespace).Get(context.Background(), meteringRouteName, metav1.GetOptions{})
 		if err != nil {
-			return nil, 0, fmt.Errorf("query for metering route failed, err: %v", err)
+			return nil, err
 		}
 
-		u = &url.URL{
+		return &url.URL{
 			Scheme: "https",
 			Host:   meteringRoute.Spec.Host,
 			Path:   endpoint,
-		}
-	} else if rf.UseKubeProxyForReportingAPI {
+		}, nil
+	}
+	if rf.UseKubeProxyForReportingAPI {
 		u = rf.KubeAPIURL
-		proto := "http"
+		scheme := "http"
+
 		if rf.HTTPSAPI {
-			proto = "https"
+			scheme = "https"
 		}
-		apiProxyPath := fmt.Sprintf("/api/v1/namespaces/%s/services/%s/proxy/", rf.Namespace, net.JoinSchemeNamePort(proto, reportingOperatorServiceName, reportingOperatorServicePortName))
+		apiProxyPath := fmt.Sprintf("/api/v1/namespaces/%s/services/%s/proxy/", rf.Namespace, net.JoinSchemeNamePort(scheme, reportingOperatorServiceName, reportingOperatorServicePortName))
 		u.Path = path.Join(apiProxyPath, endpoint)
-	} else {
-		u = rf.ReportingAPIURL
-		if rf.HTTPSAPI {
-			u.Scheme = "https"
-		}
-		u.Path = endpoint
+		return u, nil
+	}
+	if rf.HTTPSAPI {
+		u.Scheme = "https"
+	}
+	u.Path = endpoint
+
+	return u, nil
+}
+
+func (rf *ReportingFramework) doRequest(endpoint, method string, body []byte, query map[string]string) (respBody []byte, code int, err error) {
+	u, err := rf.determineMeteringAPIUrl(endpoint)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to successfully return an initialized url.URL object: %v", err)
 	}
 
 	req := &http.Request{


### PR DESCRIPTION
All of the reportingframework methods, sans a couple, were severely lacking comments that explained what that method was trying to accomplish.

This also tries to make some of the imports naming a bit more consistent.