### PR TITLE
olm_deploy: Add the metering-ansible-operator bundle format.

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=metering-ocp
+LABEL operators.operatorframework.io.bundle.channels.v1=4.6
+LABEL operators.operatorframework.io.bundle.channel.default.v1=4.6
+
+COPY olm_deploy/bundle/manifests /manifests/
+COPY olm_deploy/bundle/metadata /metadata/

--- a/olm_deploy/bundle/manifests/hive.crd.yaml
+++ b/olm_deploy/bundle/manifests/hive.crd.yaml
@@ -1,0 +1,281 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hivetables.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: hivetables
+    singular: hivetable
+    kind: HiveTable
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Table Name
+      type: string
+      jsonPath: .status.tableName
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: |
+          HiveTable is a custom resource that represents a database table within Hive.
+          When created, a HiveTable resource causes the reporting-operator to create a
+          table witin Hive according to the configuration provided.
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            description: |
+              HiveTableSpec is the desired specification of a HiveTable custom resource.
+              Required fields: database, tableName, and columns.
+              More info: https://github.com/kube-reporting/metering-operator/blob/master/Documentation/hivetables.md
+            required:
+            - databaseName
+            - tableName
+            - columns
+            properties:
+              databaseName:
+                type: string
+                description: |
+                  DatabaseName is the name of the Hive database to use.
+                  Generally, this field should be set to "default", or the value of the "databaseName" in a Hive StorageLocation.
+                  More info: https://github.com/kube-reporting/metering-operator/blob/master/Documentation/storagelocations.md
+                minLength: 1
+              tableName:
+                type: string
+                description: |
+                  TableName is the desired name of the table to be created in Hive.
+                minLength: 1
+              columns:
+                type: array
+                description: |
+                  A list of columns that match the schema of the HiveTable.
+                  For each list item, you must specify a `name` field, which is the name of an individual column for the Hive table,
+                  and a `type` field, which corresponds to a valid type in Hive.
+                  Note: the only complex types supported are map's of primitive types.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types
+                items:
+                  type: object
+                  required:
+                  - name
+                  - type
+                  properties:
+                    name:
+                      type: string
+                      description: |
+                        The name of the column.
+                      minLength: 1
+                    type:
+                      type: string
+                      description: |
+                        The column data type.
+                      minLength: 1
+              partitionedBy:
+                type: array
+                description: |
+                  A list of columns that are used as partition columns.
+                  Columns in "partitionedBy" and "columns" must not overlap.
+                  For each list item, you must specify both a `name` and `type` field.
+                  Note: this is an optional field.
+                minItems: 1
+                items:
+                  type: object
+                  required:
+                  - name
+                  - type
+                  properties:
+                    name:
+                      type: string
+                      description: |
+                        The name of the column.
+                      minLength: 1
+                    type:
+                      type: string
+                      description: |
+                        The column data type.
+                      minLength: 1
+              clusteredBy:
+                type: array
+                description: |
+                  A list of columns from "columns" to use for bucketed tables.
+                  This field must be set if "numBuckets" is specified.
+                  Note: this is an optional field.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+                minItems: 1
+                items:
+                  type: string
+              sortedBy:
+                type: array
+                description: |
+                  A list of column names from "columns" to use for bucketed tables.
+                  This field must be set if "clusteredBy" and "numBuckets" are specified.
+                  Note: this is an optional field.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+                required:
+                - name
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: |
+                        The name of the column from "columns".
+                      minLength: 1
+                    descending:
+                      type: boolean
+                      description: |
+                        Descending controls whether the column is descending or ascending.
+                        If "descending" is true, then the column is descending, else ascending.
+                        If this field is unspecified, then it defaults to Hive's default behavior.
+                        Note: this is an optional field.
+              numBuckets:
+                type: integer
+                description: |
+                  The number of buckets to create for a bucketed table.
+                  If this field is set, then "clusteredBy" also needs to be set.
+                  Note: this is an optional field.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL+BucketedTables
+                format: int32
+                minimum: 0
+              location:
+                type: string
+                description: |
+                  Location specifies the HDFS path to store this Hive table.
+                  This field can be set to any URI supported by Hive.
+                  Currently, `sda://`, `hdfs://`, and `/local/path` are supported based URIs.
+                  Note: this is an optional field.
+                format: uri
+                minLength: 1
+              rowFormat:
+                type: string
+                description: |
+                  RowFormat controls how Hive serializes and deserializes rows.
+                  Note: this is an optional field.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe
+                minLength: 1
+              fileFormat:
+                type: string
+                description: |
+                  FileFormat controls the file format used for storing files in the filesystem.
+                  Note: this is an optional field.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe
+                minLength: 1
+              tableProperties:
+                type: object
+                description: |
+                  TableProperties is an array and allows you to tag the table definition with your
+                  own metadata key/value pairs. Some predefined properties exist to control
+                  behavior of the table as well.
+                  Note: this is an optional field.
+                  More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-listTableProperties
+                additionalProperties:
+                  type: string
+              external:
+                type: boolean
+                description: |
+                  External controls whether an external table is created, instead of a managed table.
+                  If external is set to true, this causes Hive to point to an existing location,
+                  as specified by the "location" field.
+                  Note: this is an optional field.
+              managePartitions:
+                type: boolean
+                description: |
+                  ManagePartitions controls whether the reporting-operator needs to check
+                  if the table partitions match the partitions listed in the "partitions" field.
+                  Note: this is an optional field.
+              partitions:
+                type: array
+                description: |
+                  A list of partitions that this Hive table should contain.
+                  Note: this is an optional field.
+                items:
+                  type: object
+                  required:
+                  - partitionSpec
+                  - location
+                  properties:
+                    partitionSpec:
+                      type: object
+                      description: |
+                        PartitionSpec is a map containing string keys and values, where each key
+                        is expected to be the name of a partition column, and the value is the
+                        value of the partition column.
+                      additionalProperties:
+                        type: string
+                    location:
+                      type: string
+                      description: |
+                        Location specifies where the data for this partition is stored.
+                        This should be a sub-directory of the "location" field.
+                      minLength: 1
+                      format: uri
+          status:
+            type: object
+            properties:
+              databaseName:
+                type: string
+              tableName:
+                type: string
+              location:
+                type: string
+                format: uri
+              rowFormat:
+                type: string
+              fileFormat:
+                type: string
+              numBucket:
+                type: integer
+                format: int32
+              external:
+                type: boolean
+              columns:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+              partitionedBy:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+              clusteredBy:
+                type: array
+                items:
+                  type: string
+              sortedBy:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    decending:
+                      type: boolean
+              tableProperties:
+                type: object
+                additionalProperties:
+                  type: string
+              partitions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                    partitionSpec:
+                      type: object
+                      additionalProperties:
+                        type: string
+

--- a/olm_deploy/bundle/manifests/meteringconfig.crd.yaml
+++ b/olm_deploy/bundle/manifests/meteringconfig.crd.yaml
@@ -1,0 +1,2833 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: meteringconfigs.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    kind: MeteringConfig
+    listKind: MeteringConfigList
+    plural: meteringconfigs
+    singular: meteringconfig
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          spec:
+            type: object
+            required:
+            - storage
+            properties:
+              logHelmTemplate:
+                type: boolean
+
+              unsupportedFeatures:
+                type: object
+                properties:
+                  enableHDFS:
+                    type: boolean
+
+              disableOCPFeatures:
+                type: boolean
+
+              storage:
+                type: object
+                required:
+                - type
+                - hive
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - hive
+                  hive:
+                    type: object
+                    required:
+                    - type
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                        - hdfs
+                        - sharedPVC
+                        - s3
+                        - azure
+                        - gcs
+                        - s3Compatible
+                      hdfs:
+                        type: object
+                        required:
+                        - namenode
+                        properties:
+                          namenode:
+                            type: string
+                            format: uri
+                            minLength: 1
+                      s3:
+                        type: object
+                        required:
+                        - bucket
+                        - secretName
+                        properties:
+                          bucket:
+                            type: string
+                            minLength: 1
+                          region:
+                            type: string
+                            minLength: 1
+                          secretName:
+                            type: string
+                            minLength: 1
+                          createBucket:
+                            type: boolean
+                      azure:
+                        type: object
+                        required:
+                        - container
+                        oneOf:
+                        - required:
+                          - secretName
+                          allOf:
+                          - not:
+                              required:
+                              - storageAccountName
+                          - not:
+                              required:
+                              - secretAccessKey
+                        - required:
+                          - storageAccountName
+                          - secretAccessKey
+                          allOf:
+                          - not:
+                              required:
+                              - secretName
+                        properties:
+                          createSecret:
+                            type: boolean
+                          container:
+                            type: string
+                            minLength: 1
+                          secretName:
+                            type: string
+                            minLength: 1
+                          storageAccountName:
+                            type: string
+                            minLength: 1
+                          secretAccessKey:
+                            type: string
+                            minLength: 1
+                          rootDirectory:
+                            type: string
+                            minLength: 1
+                      gcs:
+                        type: object
+                        required:
+                          - bucket
+                        oneOf:
+                        - required:
+                          - serviceAccountKeyJSON
+                          allOf:
+                          - not:
+                              required:
+                              - secretName
+                        - required:
+                          - secretName
+                          allOf:
+                          - not:
+                              required:
+                              - serviceAccountKeyJSON
+                        properties:
+                          bucket:
+                            type: string
+                            minLength: 1
+                          secretName:
+                            type: string
+                            minLength: 1
+                          createSecret:
+                            type: boolean
+                          serviceAccountKeyJSON:
+                            type: string
+                            minLength: 1
+                      s3Compatible:
+                        type: object
+                        required:
+                          - bucket
+                          - endpoint
+                        properties:
+                          bucket:
+                            type: string
+                            minLength: 1
+                          secretName:
+                            type: string
+                            minLength: 1
+                          createSecret:
+                            type: boolean
+                          accessKeyID:
+                            type: string
+                            minLength: 1
+                          secretAccessKey:
+                            type: string
+                            minLength: 1
+                          endpoint:
+                            type: string
+                            format: uri
+                            minLength: 1
+                          ca:
+                            type: object
+                            properties:
+                              createSecret:
+                                type: boolean
+                              secretName:
+                                type: string
+                                minLength: 1
+                              content:
+                                type: string
+                                minLength: 1
+                        oneOf:
+                        - required:
+                          - accessKeyID
+                          - secretAccessKey
+                          properties:
+                            createSecret:
+                              enum:
+                              - true
+                          allOf:
+                          - not:
+                              required:
+                              - secretName
+                        - required:
+                          - secretName
+                          properties:
+                            createSecret:
+                              enum:
+                              - false
+                          allOf:
+                          - not:
+                              required:
+                              - accessKeyID
+                              - secretAccessKey
+                      sharedPVC:
+                        type: object
+                        properties:
+                          createPVC:
+                            type: boolean
+                          claimName:
+                            type: string
+                            minLength: 1
+                          storageClass:
+                            type: string
+                            minLength: 1
+                          size:
+                            type: string
+                            minLength: 1
+                          mountPath:
+                            type: string
+                            minLength: 1
+                        oneOf:
+                        - required:
+                          - claimName
+                        - required:
+                          - storageClass
+                          - createPVC
+                          properties:
+                            createPVC:
+                              enum:
+                              - true
+                    oneOf:
+                    # note: this is for spec.storage.hive
+                    - required:
+                      - hdfs
+                      properties:
+                        type:
+                          enum:
+                          - hdfs
+                      allOf:
+                      - not:
+                          required:
+                          - s3
+                      - not:
+                          required:
+                          - azure
+                      - not:
+                          required:
+                          - gcs
+                      - not:
+                          required:
+                          - s3Compatible
+                      - not:
+                          required:
+                          - sharedPVC
+                    - required:
+                      - s3
+                      properties:
+                        type:
+                          enum:
+                          - s3
+                      allOf:
+                      - not:
+                          required:
+                          - hdfs
+                      - not:
+                          required:
+                          - azure
+                      - not:
+                          required:
+                          - gcs
+                      - not:
+                          required:
+                          - s3Compatible
+                      - not:
+                          required:
+                          - sharedPVC
+                    - required:
+                      - azure
+                      properties:
+                        type:
+                          enum:
+                          - azure
+                      allOf:
+                      - not:
+                          required:
+                          - hdfs
+                      - not:
+                          required:
+                          - s3
+                      - not:
+                          required:
+                          - gcs
+                      - not:
+                          required:
+                          - s3Compatible
+                      - not:
+                          required:
+                          - sharedPVC
+                    - required:
+                      - gcs
+                      properties:
+                        type:
+                          enum:
+                          - gcs
+                      allOf:
+                      - not:
+                          required:
+                          - hdfs
+                      - not:
+                          required:
+                          - s3
+                      - not:
+                          required:
+                          - azure
+                      - not:
+                          required:
+                          - sharedPVC
+                      - not:
+                          required:
+                          - s3Compatible
+                    - required:
+                      - s3Compatible
+                      properties:
+                        type:
+                          enum:
+                          - s3Compatible
+                      allOf:
+                      - not:
+                          required:
+                          - hdfs
+                      - not:
+                          required:
+                          - azure
+                      - not:
+                          required:
+                          - gcs
+                      - not:
+                          required:
+                          - s3
+                      - not:
+                          required:
+                          - sharedPVC
+                    - required:
+                      - sharedPVC
+                      properties:
+                        type:
+                          enum:
+                          - sharedPVC
+                      allOf:
+                      - not:
+                          required:
+                          - hdfs
+                      - not:
+                          required:
+                          - s3
+                      - not:
+                          required:
+                          - gcs
+                      - not:
+                          required:
+                          - s3Compatible
+                      - not:
+                          required:
+                          - azure
+
+              tls:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  certificate:
+                    type: string
+                  key:
+                    type: string
+                  secretName:
+                    type: string
+                oneOf:
+                - required:
+                  - enabled
+                  allOf:
+                  - not:
+                      required:
+                      - certificate
+                  - not:
+                      required:
+                      - key
+                - required:
+                  - enabled
+                  - certificate
+                  - key
+                  properties:
+                    enabled:
+                      enum:
+                      - false
+                    certificate:
+                      minLength: 1
+                    key:
+                      minLength: 1
+
+              permissions:
+                type: object
+                properties:
+                  meteringAdmins:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - kind
+                      - name
+                      properties:
+                        kind:
+                          type: string
+                          minLength: 1
+                        name:
+                          type: string
+                          minLength: 1
+                        namespace:
+                          type: string
+                          minLength: 1
+                        apiGroup:
+                          type: string
+                          minLength: 1
+                  meteringViewers:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - kind
+                      - name
+                      properties:
+                        kind:
+                          type: string
+                          minLength: 1
+                        name:
+                          type: string
+                          minLength: 1
+                        namespace:
+                          type: string
+                          minLength: 1
+                        apiGroup:
+                          type: string
+                          minLength: 1
+                  reportExporters:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - kind
+                      - name
+                      properties:
+                        kind:
+                          type: string
+                          minLength: 1
+                        name:
+                          type: string
+                          minLength: 1
+                        namespace:
+                          type: string
+                          minLength: 1
+                        apiGroup:
+                          type: string
+                          minLength: 1
+                  reportingAdmins:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - kind
+                      - name
+                      properties:
+                        kind:
+                          type: string
+                          minLength: 1
+                        name:
+                          type: string
+                          minLength: 1
+                        namespace:
+                          type: string
+                          minLength: 1
+                        apiGroup:
+                          type: string
+                          minLength: 1
+                  reportingViewers:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - kind
+                      - name
+                      properties:
+                        kind:
+                          type: string
+                          minLength: 1
+                        name:
+                          type: string
+                          minLength: 1
+                        namespace:
+                          type: string
+                          minLength: 1
+
+              monitoring:
+                type: object
+                properties:
+                  createRBAC:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  namespace:
+                    type: string
+
+              openshift-reporting:
+                type: object
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      defaultStorageLocation:
+                        type: object
+                        required:
+                        - enabled
+                        - isDefault
+                        - name
+                        - type
+                        - hive
+                        properties:
+                          enabled:
+                            type: boolean
+                          isDefault:
+                            type: boolean
+                          name:
+                            type: string
+                          type:
+                            type: string
+                          hive:
+                            type: object
+                            required:
+                            - databaseName
+                            - unmanagedDatabase
+                            properties:
+                              databaseName:
+                                type: string
+                              unmanagedDatabase:
+                                type: boolean
+                              location:
+                                type: string
+                      awsBillingReportDataSource:
+                        type: object
+                        properties:
+                          enabled:
+                            type: boolean
+                          bucket:
+                            type: string
+                          prefix:
+                            type: string
+                          region:
+                            type: string
+                      defaultReportDataSources:
+                        type: object
+                        properties:
+                          base:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  - spec
+                                  properties:
+                                    name:
+                                      type: string
+                                    spec:
+                                      type: object
+                                      required:
+                                      - reportQueryView
+                                      properties:
+                                        reportQueryView:
+                                          type: object
+                                          required:
+                                          - queryName
+                                          properties:
+                                            queryName:
+                                              type: string
+                          postKube_1_14:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+
+              reporting-operator:
+                type: object
+                required:
+                - spec
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      affinity:
+                        type: object
+                      annotations:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      apiService:
+                        type: object
+                        properties:
+                          nodePort:
+                            type: integer
+                          type:
+                            type: string
+                      authProxy:
+                        type: object
+                        properties:
+                          enabled:
+                            type: boolean
+                          authenticatedEmails:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                              createSecret:
+                                type: boolean
+                              data:
+                                type: string
+                                minLength: 1
+                              secretName:
+                                type: string
+                                minLength: 1
+                            oneOf:
+                            - required:
+                              - enabled
+                              properties:
+                                enabled:
+                                  enum:
+                                  - false
+                              allOf:
+                              - not:
+                                  required:
+                                  - createSecret
+                              - not:
+                                  required:
+                                  - data
+                              - not:
+                                  required:
+                                  - secretName
+                            - required:
+                              - enabled
+                              - createSecret
+                              - secretName
+                              properties:
+                                enabled:
+                                  enum:
+                                  - true
+                                createSecret:
+                                  enum:
+                                  - false
+                              allOf:
+                              - not:
+                                  required:
+                                  - seed
+                            - required:
+                              - enabled
+                              - createSecret
+                              - data
+                              properties:
+                                enabled:
+                                  enum:
+                                  - true
+                                createSecret:
+                                  enum:
+                                  - true
+                          cookie:
+                            type: object
+                            properties:
+                              createSecret:
+                                type: boolean
+                              secretName:
+                                type: string
+                                minLength: 1
+                              seed:
+                                type: string
+                                minLength: 32
+                            oneOf:
+                            - required:
+                              - createSecret
+                              - seed
+                              properties:
+                                createSecret:
+                                  enum:
+                                  - true
+                            - required:
+                              - createSecret
+                              - secretName
+                              properties:
+                                createSecret:
+                                  enum:
+                                  - false
+                              allOf:
+                              - not:
+                                  required:
+                                  - seed
+                          delegateURLs:
+                            type: object
+                            properties:
+                              enabled:
+                                type: boolean
+                              policy:
+                                type: string
+                                minLength: 1
+                          htpasswd:
+                            type: object
+                            properties:
+                              createSecret:
+                                type: boolean
+                              data:
+                                type: string
+                                minLength: 1
+                              secretName:
+                                type: string
+                                minLength: 1
+                            oneOf:
+                            - required:
+                              - createSecret
+                              - data
+                              properties:
+                                createSecret:
+                                  enum:
+                                  - true
+                            - required:
+                              - createSecret
+                              - secretName
+                              properties:
+                                createSecret:
+                                  enum:
+                                  - false
+                              allOf:
+                              - not:
+                                  required:
+                                  - data
+                          image:
+                            type: object
+                            properties:
+                              pullPolicy:
+                                type: string
+                                minLength: 1
+                              pullSecrets:
+                                type: array
+                                items:
+                                  type: string
+                              repository:
+                                type: string
+                                minLength: 1
+                              tag:
+                                type: string
+                                minLength: 1
+                          rbac:
+                            type: object
+                            required:
+                            - createAuthProxyClusterRole
+                            properties:
+                              createAuthProxyClusterRole:
+                                type: boolean
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              requests:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                          subjectAccessReview:
+                            type: object
+                            required:
+                            - enabled
+                            properties:
+                              enabled:
+                                type: boolean
+                              policy:
+                                type: string
+                                minLength: 1
+                      config:
+                        type: object
+                        properties:
+                          allNamespaces:
+                            type: boolean
+                          aws:
+                            type: object
+                            properties:
+                              accessKeyID:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                          enableFinalizers:
+                            type: boolean
+                          hive:
+                            type: object
+                            properties:
+                              auth:
+                                type: object
+                                properties:
+                                  certificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  key:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                - required:
+                                  - certificate
+                                  - key
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    certificate:
+                                      minLength: 1
+                                    key:
+                                      minLength: 1
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    enabled:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                              host:
+                                type: string
+                              tls:
+                                type: object
+                                properties:
+                                  caCertificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                - required:
+                                  - caCertificate
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    caCertificate:
+                                      minLength: 1
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    enabled:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                          leaderLeaseDuration:
+                            type: string
+                          logDDLQueries:
+                            type: boolean
+                          logDMLQueries:
+                            type: boolean
+                          logLevel:
+                            type: string
+                          logReports:
+                            type: boolean
+                          presto:
+                            type: object
+                            properties:
+                              auth:
+                                type: object
+                                properties:
+                                  certificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  key:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                - required:
+                                  - certificate
+                                  - key
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    certificate:
+                                      minLength: 1
+                                    key:
+                                      minLength: 1
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                              host:
+                                type: string
+                              maxQueryLength:
+                                type: integer
+                              tls:
+                                type: object
+                                properties:
+                                  caCertificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                - required:
+                                  - caCertificate
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    certificate:
+                                      minLength: 1
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                          prometheus:
+                            type: object
+                            properties:
+                              certificateAuthority:
+                                type: object
+                                properties:
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      create:
+                                        type: boolean
+                                      enabled:
+                                        type: boolean
+                                      filename:
+                                        type: string
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                  useServiceAccountCA:
+                                    type: boolean
+                              metricsImporter:
+                                type: object
+                                properties:
+                                  auth:
+                                    type: object
+                                    properties:
+                                      tokenSecret:
+                                        type: object
+                                        properties:
+                                          create:
+                                            type: boolean
+                                          enabled:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                      useServiceAccountToken:
+                                        type: boolean
+                                  config:
+                                    type: object
+                                    properties:
+                                      chunkSize:
+                                        type: string
+                                      importFrom:
+                                        type: string
+                                      maxImportBackfillDuration:
+                                        type: string
+                                      maxQueryRangeDuration:
+                                        type: string
+                                      pollInterval:
+                                        type: string
+                                      stepSize:
+                                        type: string
+                                  enabled:
+                                    type: boolean
+                              url:
+                                type: string
+                          tls:
+                            type: object
+                            properties:
+                              api:
+                                type: object
+                                properties:
+                                  caCertificate:
+                                    type: string
+                                  certificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  key:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                - required:
+                                  - caCertificate
+                                  - certificate
+                                  - key
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    caCertificate:
+                                      minLength: 1
+                                    certificate:
+                                      minLength: 1
+                                    key:
+                                      minLength: 1
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                      image:
+                        type: object
+                        properties:
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            type: array
+                            items:
+                              type: string
+                          repository:
+                            type: string
+                          tag:
+                            type: string
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      nodeSelector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      rbac:
+                        type: object
+                        required:
+                        - createClusterMonitoringViewRBAC
+                        properties:
+                          createClusterMonitoringViewRBAC:
+                            type: boolean
+                      replicas:
+                        type: integer
+                        format: int32
+                      resources:
+                        type: object
+                        properties:
+                          limits:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          requests:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                      route:
+                        type: object
+                        required:
+                        - enabled
+                        properties:
+                          enabled:
+                            type: boolean
+                          name:
+                            type: string
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                      updateStrategy:
+                        type: object
+                        required:
+                        - type
+                        properties:
+                          type:
+                            type: string
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                            format: int64
+                          runAsGroup:
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                            format: int64
+
+              presto:
+                type: object
+                required:
+                - spec
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      annotations:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      terminationGracePeriodSeconds:
+                        type: integer
+                      config:
+                        type: object
+                        properties:
+                          auth:
+                            type: object
+                            properties:
+                              caCertificate:
+                                type: string
+                              certificate:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              enabled:
+                                type: boolean
+                              key:
+                                type: string
+                              secretName:
+                                type: string
+                            oneOf:
+                            - required:
+                              - enabled
+                              properties:
+                                enabled:
+                                  enum:
+                                  - false
+                              allOf:
+                              - not:
+                                  required:
+                                  - caCertificate
+                              - not:
+                                  required:
+                                  - certificate
+                              - not:
+                                  required:
+                                  - key
+                              - not:
+                                  required:
+                                  - createSecret
+                              - not:
+                                  required:
+                                  - secretName
+                            - required:
+                              - createSecret
+                              - secretName
+                              properties:
+                                createSecret:
+                                  enum:
+                                  - false
+                                secretName:
+                                  minLength: 1
+                              allOf:
+                              - not:
+                                  required:
+                                  - caCertificate
+                              - not:
+                                  required:
+                                  - certificate
+                              - not:
+                                  required:
+                                  - key
+                            - required:
+                              - caCertificate
+                              - certificate
+                              - key
+                              - createSecret
+                              - secretName
+                              properties:
+                                caCertificate:
+                                  minLength: 1
+                                certificate:
+                                  minLength: 1
+                                key:
+                                  minLength: 1
+                                enabled:
+                                  enum:
+                                  - true
+                                createSecret:
+                                  enum:
+                                  - true
+                                secretName:
+                                  minLength: 1
+                          aws:
+                            type: object
+                            properties:
+                              accessKeyID:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                          azure:
+                            type: object
+                            properties:
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                              storageAccountName:
+                                type: string
+                          gcs:
+                            type: object
+                            properties:
+                              secretName:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              serviceAccountKeyJSON:
+                                type: string
+
+                          s3Compatible:
+                            type: object
+                            properties:
+                              secretName:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              accessKeyID:
+                                type: string
+                              secretAccessKey:
+                                type: string
+                              endpoint:
+                                type: string
+                                format: uri
+                              ca:
+                                type: object
+                                properties:
+                                  createSecret:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                    minLength: 1
+                                  content:
+                                    type: string
+                                    minLength: 1
+
+                          connectors:
+                            type: object
+                            properties:
+                              extraConnectorFiles:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    content:
+                                      type: string
+                              hive:
+                                type: object
+                                properties:
+                                  useHadoopConfig:
+                                    type: boolean
+                                  hadoopConfigSecretName:
+                                    type: string
+                                  metastoreTimeout:
+                                    type: string
+                                  metastoreURI:
+                                    type: string
+                                  tls:
+                                    type: object
+                                    properties:
+                                      caCertificate:
+                                        type: string
+                                      certificate:
+                                        type: string
+                                      createSecret:
+                                        type: boolean
+                                      enabled:
+                                        type: boolean
+                                      key:
+                                        type: string
+                                      secretName:
+                                        type: string
+                                    oneOf:
+                                    - required:
+                                      - enabled
+                                      properties:
+                                        enabled:
+                                          enum:
+                                          - false
+                                      allOf:
+                                      - not:
+                                          required:
+                                          - caCertificate
+                                      - not:
+                                          required:
+                                          - certificate
+                                      - not:
+                                          required:
+                                          - key
+                                      - not:
+                                          required:
+                                          - createSecret
+                                      - not:
+                                          required:
+                                          - secretName
+                                    - required:
+                                      - createSecret
+                                      - secretName
+                                      properties:
+                                        createSecret:
+                                          enum:
+                                          - false
+                                        secretName:
+                                          minLength: 1
+                                      allOf:
+                                      - not:
+                                          required:
+                                          - caCertificate
+                                      - not:
+                                          required:
+                                          - certificate
+                                      - not:
+                                          required:
+                                          - key
+                                    - required:
+                                      - caCertificate
+                                      - certificate
+                                      - key
+                                      - createSecret
+                                      - secretName
+                                      properties:
+                                        caCertificate:
+                                          minLength: 1
+                                        certificate:
+                                          minLength: 1
+                                        key:
+                                          minLength: 1
+                                        enabled:
+                                          enum:
+                                          - true
+                                        createSecret:
+                                          enum:
+                                          - true
+                                        secretName:
+                                          minLength: 1
+                                  s3:
+                                    type: object
+                                    properties:
+                                      useInstanceCredentials:
+                                        type: boolean
+                              prometheus:
+                                type: object
+                                properties:
+                                  enabled:
+                                    description: Whether or not to enable the Presto-Prometheus connector.
+                                    type: boolean
+                                  config:
+                                    type: object
+                                    properties:
+                                      uri:
+                                        description: URI for Prometheus.
+                                        type: string
+                                        format: uri
+                                      chunkSizeDuration:
+                                        description: Default size of each Prometheus query chunk.
+                                        type: string
+                                      maxQueryRangeDuration:
+                                        description: Default range for Prometheus query, divided into chunkSizeDuration chunks.
+                                        type: string
+                                      cacheDuration:
+                                        description: Time to live for Presto checking connector properties values.
+                                        type: string
+                                  auth:
+                                    type: object
+                                    properties:
+                                      bearerTokenFile:
+                                        description: Path to token file for bearer authentication to Prometheus.
+                                        type: string
+                                      useServiceAccountToken:
+                                        description: Whether to use the cluster service account token for the bearer token
+                                        type: boolean
+                          environment:
+                            type: string
+                          maxQueryLength:
+                            type: integer
+                          nodeSchedulerIncludeCoordinator:
+                            type: boolean
+                          tls:
+                            type: object
+                            properties:
+                              caCertificate:
+                                type: string
+                              certificate:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              enabled:
+                                type: boolean
+                              key:
+                                type: string
+                              secretName:
+                                type: string
+                            oneOf:
+                            - required:
+                              - enabled
+                              properties:
+                                enabled:
+                                  enum:
+                                  - false
+                              allOf:
+                              - not:
+                                  required:
+                                  - caCertificate
+                              - not:
+                                  required:
+                                  - certificate
+                              - not:
+                                  required:
+                                  - key
+                              - not:
+                                  required:
+                                  - createSecret
+                              - not:
+                                  required:
+                                  - secretName
+                            - required:
+                              - createSecret
+                              - secretName
+                              properties:
+                                createSecret:
+                                  enum:
+                                  - false
+                                secretName:
+                                  minLength: 1
+                              allOf:
+                              - not:
+                                  required:
+                                  - caCertificate
+                            - required:
+                              - caCertificate
+                              - createSecret
+                              - secretName
+                              properties:
+                                certificate:
+                                  minLength: 1
+                                enabled:
+                                  enum:
+                                  - true
+                                createSecret:
+                                  enum:
+                                  - true
+                                secretName:
+                                  minLength: 1
+                      coordinator:
+                        type: object
+                        properties:
+                          affinity:
+                            type: object
+                            properties:
+                              podAntiAffinity:
+                                type: object
+                                properties:
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - topologyKey
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - key
+                                                - operator
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                        topologyKey:
+                                          type: string
+                          config:
+                            type: object
+                            properties:
+                              jvm:
+                                type: object
+                                properties:
+                                  G1HeapRegionSize:
+                                    x-kubernetes-int-or-string: true
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                  concGCThreads:
+                                    type: integer
+                                    minimum: 0
+                                  extraFlags:
+                                    type: array
+                                    items:
+                                      type: string
+                                  initialRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  initiatingHeapOccupancyPercent:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  maxCachedBufferSize:
+                                    type: integer
+                                    minimum: 0
+                                  maxDirectMemorySize:
+                                    x-kubernetes-int-or-string: true
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                  maxGcPauseMillis:
+                                    type: integer
+                                    minimum: 0
+                                  maxRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  minRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  parallelGCThreads:
+                                    type: integer
+                                    minimum: 0
+                                  permSize:
+                                    type: string
+                                    minLength: 2
+                                  reservedCodeCacheSize:
+                                    type: string
+                                    minLength: 2
+                              logLevel:
+                                type: string
+                              taskMaxWorkerThreads:
+                                type: integer
+                              taskMinDrivers:
+                                type: integer
+                          nodeSelector:
+                            type: object
+                            additionalProperties:
+                              type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              requests:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                          terminationGracePeriodSeconds:
+                            type: integer
+                          tolerations:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                      image:
+                        type: object
+                        properties:
+                          pullPolicy:
+                            type: string
+                          repository:
+                            type: string
+                          tag:
+                            type: string
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                            format: int64
+                          runAsGroup:
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                            format: int64
+                      worker:
+                        type: object
+                        properties:
+                          affinity:
+                            type: object
+                            properties:
+                              podAntiAffinity:
+                                type: object
+                                properties:
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - topologyKey
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          required:
+                                          - matchExpressions
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - key
+                                                - operator
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                        topologyKey:
+                                          type: string
+                          config:
+                            type: object
+                            properties:
+                              jvm:
+                                type: object
+                                properties:
+                                  G1HeapRegionSize:
+                                    x-kubernetes-int-or-string: true
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                  concGCThreads:
+                                    type: integer
+                                    minimum: 0
+                                  extraFlags:
+                                    type: array
+                                    items:
+                                      type: string
+                                  initialRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  initiatingHeapOccupancyPercent:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  maxCachedBufferSize:
+                                    type: integer
+                                    minimum: 0
+                                  maxDirectMemorySize:
+                                    x-kubernetes-int-or-string: true
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                  maxGcPauseMillis:
+                                    type: integer
+                                    minimum: 0
+                                  maxRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  minRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  parallelGCThreads:
+                                    type: integer
+                                    minimum: 0
+                                  permSize:
+                                    type: string
+                                    minLength: 2
+                                  reservedCodeCacheSize:
+                                    type: string
+                                    minLength: 2
+                              logLevel:
+                                type: string
+                              taskMaxWorkerThreads:
+                                type: integer
+                              taskMinDrivers:
+                                type: integer
+                          nodeSelector:
+                            type: object
+                            additionalProperties:
+                              type: string
+                          replicas:
+                            type: integer
+                            format: int32
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              requests:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                          terminationGracePeriodSeconds:
+                            type: integer
+                          tolerations:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+
+              hive:
+                type: object
+                required:
+                - spec
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      annotations:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      config:
+                        type: object
+                        properties:
+                          aws:
+                            type: object
+                            properties:
+                              accessKeyID:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                          azure:
+                            type: object
+                            properties:
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                              storageAccountName:
+                                type: string
+                          gcs:
+                            type: object
+                            properties:
+                              secretName:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              serviceAccountKeyJSON:
+                                type: string
+                          s3Compatible:
+                            type: object
+                            properties:
+                              secretName:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              accessKeyID:
+                                type: string
+                              secretAccessKey:
+                                type: string
+                              endpoint:
+                                type: string
+                                format: uri
+                              ca:
+                                type: object
+                                properties:
+                                  createSecret:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                    minLength: 1
+                                  content:
+                                    type: string
+                                    minLength: 1
+                          db:
+                            type: object
+                            properties:
+                              autoCreateMetastoreSchema:
+                                type: boolean
+                              driver:
+                                type: string
+                              enableMetastoreSchemaVerification:
+                                type: boolean
+                              password:
+                                type: string
+                              url:
+                                type: string
+                              username:
+                                type: string
+                          defaultFileFormat:
+                            type: string
+                          hadoopConfigSecretName:
+                            type: string
+                          metastoreClientSocketTimeout:
+                            type: string
+                          metastoreWarehouseDir:
+                            type: string
+                          sharedVolume:
+                            type: object
+                            properties:
+                              claimName:
+                                type: string
+                              createPVC:
+                                type: boolean
+                              enabled:
+                                type: boolean
+                              mountPath:
+                                type: string
+                              size:
+                                type: string
+                              storageClass:
+                                type: string
+                          useHadoopConfig:
+                            type: boolean
+                      image:
+                        type: object
+                        properties:
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            type: array
+                            items:
+                              type: string
+                          repository:
+                            type: string
+                          tag:
+                            type: string
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      metastore:
+                        type: object
+                        properties:
+                          affinity:
+                            type: object
+                          config:
+                            type: object
+                            properties:
+                              auth:
+                                type: object
+                                properties:
+                                  enabled:
+                                    type: boolean
+                              jvm:
+                                type: object
+                                properties:
+                                  initialRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  maxRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  minRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                              logLevel:
+                                type: string
+                              tls:
+                                type: object
+                                properties:
+                                  caCertificate:
+                                    type: string
+                                  certificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  key:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                - required:
+                                  - caCertificate
+                                  - certificate
+                                  - key
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    caCertificate:
+                                      minLength: 1
+                                    certificate:
+                                      minLength: 1
+                                    key:
+                                      minLength: 1
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                          livenessProbe:
+                            type: object
+                            properties:
+                              failureThreshold:
+                                type: integer
+                              initialDelaySeconds:
+                                type: integer
+                              periodSeconds:
+                                type: integer
+                              successThreshold:
+                                type: integer
+                              tcpSocket:
+                                type: object
+                                properties:
+                                  port:
+                                    type: integer
+                              timeoutSeconds:
+                                type: integer
+                          nodeSelector:
+                            type: object
+                            additionalProperties:
+                              type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              requests:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                          storage:
+                            type: object
+                            properties:
+                              class:
+                                type: string
+                              create:
+                                type: boolean
+                              size:
+                                type: string
+                          tolerations:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                            format: int64
+                          runAsGroup:
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                            format: int64
+                      server:
+                        type: object
+                        properties:
+                          affinity:
+                            type: object
+                          config:
+                            type: object
+                            properties:
+                              auth:
+                                type: object
+                                properties:
+                                  enabled:
+                                    type: boolean
+                              jvm:
+                                type: object
+                                properties:
+                                  initialRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  maxRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                                  minRAMPercentage:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 100
+                              logLevel:
+                                type: string
+                              metastoreTLS:
+                                type: object
+                                properties:
+                                  caCertificate:
+                                    type: string
+                                  certificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  key:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                - required:
+                                  - caCertificate
+                                  - certificate
+                                  - key
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    caCertificate:
+                                      minLength: 1
+                                    certificate:
+                                      minLength: 1
+                                    key:
+                                      minLength: 1
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                              tls:
+                                type: object
+                                properties:
+                                  caCertificate:
+                                    type: string
+                                  certificate:
+                                    type: string
+                                  createSecret:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  key:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                oneOf:
+                                - required:
+                                  - enabled
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - false
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                  - not:
+                                      required:
+                                      - createSecret
+                                  - not:
+                                      required:
+                                      - secretName
+                                - required:
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - false
+                                    secretName:
+                                      minLength: 1
+                                  allOf:
+                                  - not:
+                                      required:
+                                      - caCertificate
+                                  - not:
+                                      required:
+                                      - certificate
+                                  - not:
+                                      required:
+                                      - key
+                                - required:
+                                  - caCertificate
+                                  - certificate
+                                  - key
+                                  - createSecret
+                                  - secretName
+                                  properties:
+                                    caCertificate:
+                                      minLength: 1
+                                    certificate:
+                                      minLength: 1
+                                    key:
+                                      minLength: 1
+                                    enabled:
+                                      enum:
+                                      - true
+                                    createSecret:
+                                      enum:
+                                      - true
+                                    secretName:
+                                      minLength: 1
+                          livenessProbe:
+                            type: object
+                            properties:
+                              failureThreshold:
+                                type: integer
+                              initialDelaySeconds:
+                                type: integer
+                              periodSeconds:
+                                type: integer
+                              successThreshold:
+                                type: integer
+                              tcpSocket:
+                                type: object
+                                properties:
+                                  port:
+                                    type: integer
+                              timeoutSeconds:
+                                type: integer
+                          nodeSelector:
+                            type: object
+                            additionalProperties:
+                              type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              requests:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                          tolerations:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                      terminationGracePeriodSeconds:
+                        type: integer
+
+              __ghostunnel:
+                type: object
+                properties:
+                  image:
+                    type: object
+                    properties:
+                      pullPolicy:
+                        type: string
+                      repository:
+                        type: string
+                      tag:
+                        type: string
+
+              hadoop:
+                type: object
+                required:
+                - spec
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      config:
+                        type: object
+                        properties:
+                          aws:
+                            type: object
+                            properties:
+                              accessKeyID:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                          azure:
+                            type: object
+                            properties:
+                              createSecret:
+                                type: boolean
+                              secretAccessKey:
+                                type: string
+                              secretName:
+                                type: string
+                              storageAccountName:
+                                type: string
+                          gcs:
+                            type: object
+                            properties:
+                              secretName:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              serviceAccountKeyJSON:
+                                type: string
+                          s3Compatible:
+                            type: object
+                            properties:
+                              secretName:
+                                type: string
+                              createSecret:
+                                type: boolean
+                              accessKeyID:
+                                type: string
+                              secretAccessKey:
+                                type: string
+                              endpoint:
+                                type: string
+                                format: uri
+                              ca:
+                                type: object
+                                properties:
+                                  createSecret:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                    minLength: 1
+                                  content:
+                                    type: string
+                                    minLength: 1
+                          defaultFS:
+                            type: string
+                      configSecretName:
+                        type: string
+                      hdfs:
+                        type: object
+                        properties:
+                          enabled:
+                            type: boolean
+                          config:
+                            type: object
+                            properties:
+                              datanodeDataDirPerms:
+                                type: string
+                              logLevel:
+                                type: string
+                              replicationFactor:
+                                type: integer
+                          datanode:
+                            type: object
+                            properties:
+                              affinity:
+                                type: object
+                                properties:
+                                  podAntiAffinity:
+                                    type: object
+                                    properties:
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                            topologyKey:
+                                              type: string
+                              annotations:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              config:
+                                type: object
+                                properties:
+                                  jvm:
+                                    type: object
+                                    properties:
+                                      initialRAMPercentage:
+                                        type: integer
+                                        minimum: 0
+                                        maximum: 100
+                                      maxRAMPercentage:
+                                        type: integer
+                                        minimum: 0
+                                        maximum: 100
+                                      minRAMPercentage:
+                                        type: integer
+                                        minimum: 0
+                                        maximum: 100
+                              labels:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              nodeSelector:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              replicas:
+                                type: integer
+                                format: int32
+                              resources:
+                                type: object
+                                properties:
+                                  limits:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  requests:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: object
+                                properties:
+                                  class:
+                                    type: string
+                                  size:
+                                    type: string
+                              terminationGracePeriodSeconds:
+                                type: integer
+                              tolerations:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  enabled:
+                                    type: boolean
+                          namenode:
+                            type: object
+                            properties:
+                              affinity:
+                                type: object
+                                properties:
+                                  podAntiAffinity:
+                                    type: object
+                                    properties:
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                            topologyKey:
+                                              type: string
+                              annotations:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              config:
+                                type: object
+                                properties:
+                                  jvm:
+                                    type: object
+                                    properties:
+                                      initialRAMPercentage:
+                                        type: integer
+                                        minimum: 0
+                                        maximum: 100
+                                      maxRAMPercentage:
+                                        type: integer
+                                        minimum: 0
+                                        maximum: 100
+                                      minRAMPercentage:
+                                        type: integer
+                                        minimum: 0
+                                        maximum: 100
+                              labels:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              nodeSelector:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              resources:
+                                type: object
+                                properties:
+                                  limits:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  requests:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: object
+                                properties:
+                                  class:
+                                    type: string
+                                  size:
+                                    type: string
+                              terminationGracePeriodSeconds:
+                                type: integer
+                              tolerations:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                          securityContext:
+                            type: object
+                            properties:
+                              fsGroup:
+                                type: integer
+                                format: int64
+                              runAsGroup:
+                                type: integer
+                                format: int64
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                type: integer
+                                format: int64
+                      image:
+                        type: object
+                        properties:
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            type: array
+                            items:
+                              type: string
+                          repository:
+                            type: string
+                          tag:
+                            type: string
+

--- a/olm_deploy/bundle/manifests/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/olm_deploy/bundle/manifests/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -1,0 +1,577 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: metering-operator.v4.6.0
+  namespace: placeholder
+  annotations:
+    olm.skipRange: ">=4.3.0 <4.6.0"
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "MeteringConfig",
+          "metadata": {
+            "name": "operator-metering"
+          },
+          "spec": {
+            "storage": {
+              "hive": {
+                "s3": {
+                  "bucket": "bucketname/path/",
+                  "createBucket": true,
+                  "region": "us-west-1",
+                  "secretName": "my-aws-secret"
+                },
+                "type": "s3"
+              },
+              "type": "hive"
+            }
+          }
+        },
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "Report",
+          "metadata": {
+            "name": "unready-deployment-replicas-hourly"
+          },
+          "spec": {
+            "query": "unready-deployment-replicas",
+            "schedule": {
+              "period": "hourly"
+            }
+          }
+        },
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "ReportQuery",
+          "metadata": {
+            "name": "unready-deployment-replicas"
+          },
+          "spec": {
+            "columns": [
+              {
+                "name": "period_start",
+                "type": "timestamp"
+              },
+              {
+                "name": "period_end",
+                "type": "timestamp"
+              },
+              {
+                "name": "namespace",
+                "type": "varchar"
+              },
+              {
+                "name": "deployment",
+                "type": "varchar"
+              },
+              {
+                "name": "total_replica_unready_seconds",
+                "type": "double"
+              },
+              {
+                "name": "avg_replica_unready_seconds",
+                "type": "double"
+              }
+            ],
+            "inputs": [
+              {
+                "name": "ReportingStart",
+                "type": "time"
+              },
+              {
+                "name": "ReportingEnd",
+                "type": "time"
+              },
+              {
+                "default": "unready-deployment-replicas",
+                "name": "UnreadyDeploymentReplicasDataSourceName",
+                "type": "ReportDataSource"
+              }
+            ],
+            "query": "SELECT\n    timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' AS period_start,\n    timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,\n    labels['namespace'] AS namespace,\n    labels['deployment'] AS deployment,\n    sum(amount * \"timeprecision\") AS total_replica_unready_seconds,\n    avg(amount * \"timeprecision\") AS avg_replica_unready_seconds\nFROM {| dataSourceTableName .Report.Inputs.UnreadyDeploymentReplicasDataSourceName |}\nWHERE \"timestamp\" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'\nAND \"timestamp\" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'\nGROUP BY labels['namespace'], labels['deployment']\nORDER BY total_replica_unready_seconds DESC, avg_replica_unready_seconds DESC, namespace ASC, deployment ASC\n"
+          }
+        },
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "ReportDataSource",
+          "metadata": {
+            "name": "unready-deployment-replicas"
+          },
+          "spec": {
+            "prometheusMetricsImporter": {
+              "query": "sum(kube_deployment_status_replicas_unavailable) by (namespace, deployment)\n"
+            }
+          }
+        },
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "StorageLocation",
+          "metadata": {
+            "name": "s3-storage-example"
+          },
+          "spec": {
+            "hive": {
+              "databaseName": "metering-s3",
+              "location": "s3a://bucketName/pathInBucket",
+              "unmanagedDatabase": true
+            }
+          }
+        },
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "PrestoTable",
+          "metadata": {
+            "name": "example-baremetal-cost"
+          },
+          "spec": {
+            "catalog": "hive",
+            "columns": [
+              {
+                "name": "cost_per_gigabyte_hour",
+                "type": "double"
+              },
+              {
+                "name": "cost_per_cpu_hour",
+                "type": "double"
+              },
+              {
+                "name": "currency",
+                "type": "varchar"
+              }
+            ],
+            "createTableAs": true,
+            "query": "SELECT * FROM (\n  VALUES (10.00, 50.00, 'USD')\n) AS t (cost_per_gigabyte_hour, cost_per_cpu_hour, currency)\n",
+            "schema": "default",
+            "tableName": "example_baremetal_cost"
+          }
+        },
+        {
+          "apiVersion": "metering.openshift.io/v1",
+          "kind": "HiveTable",
+          "metadata": {
+            "name": "apache-log",
+            "annotations": {
+              "reference": "based on the RegEx example from https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe"
+            }
+          },
+          "spec": {
+            "columns": [
+              {
+                "name": "host",
+                "type": "string"
+              },
+              {
+                "name": "identity",
+                "type": "string"
+              },
+              {
+                "name": "user",
+                "type": "string"
+              },
+              {
+                "name": "time",
+                "type": "string"
+              },
+              {
+                "name": "request",
+                "type": "string"
+              },
+              {
+                "name": "status",
+                "type": "string"
+              },
+              {
+                "name": "size",
+                "type": "string"
+              },
+              {
+                "name": "referer",
+                "type": "string"
+              },
+              {
+                "name": "agent",
+                "type": "string"
+              }
+            ],
+            "databaseName": "default",
+            "external": true,
+            "fileFormat": "TEXTFILE",
+            "location": "s3a://my-bucket/apache_logs",
+            "rowFormat": "SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'\nWITH SERDEPROPERTIES (\n  \"input.regex\" = \"([^ ]*) ([^ ]*) ([^ ]*) (-|\\\\[[^\\\\]]*\\\\]) ([^ \\\"]*|\\\"[^\\\"]*\\\") (-|[0-9]*) (-|[0-9]*)(?: ([^ \\\"]*|\\\"[^\\\"]*\\\") ([^ \\\"]*|\\\"[^\\\"]*\\\"))?\"\n)\n",
+            "tableName": "apache_log"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Monitoring
+    certified: "false"
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.6
+    createdAt: 2019-01-01T11:59:59Z
+    description: Chargeback and reporting tool to provide accountability for how resources
+      are used across a cluster
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-metering
+    operators.openshift.io/capability: '["fips", "cluster-proxy"]'
+    repository: https://github.com/kube-reporting/metering-operator
+    support: Red Hat, Inc.
+
+spec:
+  displayName: Metering
+  description: |
+    The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).
+
+    Read the user guide for more details on [running and viewing your first report](https://docs.openshift.com/container-platform/4.6/metering/metering-using-metering.html).
+
+    ### Core capabilities
+
+    * **Long term storage** - Break down the reserved and utlized resources requested by applications and store the information as long as needed.
+
+    * **Pod, Namespace & Cluster Reports** - Built in reports exist to break down CPU and RAM in any way you desire.
+
+    * **Scheduled Reports** - Schedule reports to run on a standard interval, eg. daily or monthly. Use these reports, for instance, as the basis for chargeback and showback.
+
+    * **Post-Processing** - Reports are generated in either CSV, JSON, or tabular formatting and stored in persistent storage for further post-processing. Use this to send reminder emails, integrate into your ERP system, or graph on a dashboard.
+
+    * **Roll-up reports** - Reports can be used as a source for other reports, allowing for more complex queries that span longer periods than those supported by the data source.
+
+    * **HTTP API** - Reports can be queried from an in-cluster HTTP API in addition to reading from persistent storage.
+
+    * **Integration with AWS EC2 billing** - Connect metering to AWS to calculate the EC2 costs of your resources.
+
+    ### Before you start
+
+    Metering runs a big data stack to crunch your data and requires at least 4GB of RAM and 4 CPU cores.
+    At least one Node should have 2GB of RAM and 2 CPU cores.
+    Memory and CPU consumption may often be lower, but will spike when running reports, or collecting data for larger clusters.
+
+    Metering requires configuring storage, please review the [configuring persistent storage documentation](https://docs.openshift.com/container-platform/4.6/metering/configuring-metering/metering-configure-persistent-storage.html) before proceeding.
+
+    ### Common Configurations
+
+    * **Store data in object storage or in a PersistentVolume** - Store your report output [in an object storage bucket or in a PersistentVolume](https://docs.openshift.com/container-platform/4.6/metering/configuring-metering/metering-configure-persistent-storage.html).
+
+    * **Configure AWS Billing Data Source** - Assign Pod $$ costs on using your [AWS billing reports stored in S3](https://docs.openshift.com/container-platform/4.6/metering/configuring-metering/metering-configure-aws-billing-correlation.html).
+
+    * **Use Reports** - Customize what how you process data. [Specify what you want to report on, set the schedule, and reporting time period](https://docs.openshift.com/container-platform/4.6/metering/reports/metering-about-reports.html#metering-reports_metering-about-reports).
+
+  keywords: [metering metrics reporting prometheus chargeback]
+  version: "4.6.0"
+  minKubeVersion: "1.18.3"
+  maturity: stable
+  maintainers:
+    - email: sd-operator-metering@redhat.com
+      name: Red Hat
+
+  links:
+    - name: Documentation
+      url: https://docs.openshift.com/container-platform/4.6/metering/metering-about-metering.html
+
+  provider:
+    name: Red Hat
+
+  icon:
+    - base64data: PHN2ZyBpZD0iYmI5OWY3NGMtM2VkOS00OWU2LWE0OWQtNDI3ODA5NWU5ZWI4IiBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDcyMS4xNSA3MjEuMTUiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuYjdmMDIwYzgtMjFkMS00NWVmLWE0NTktNzJhNWE0MmE5MjJlIHsKICAgICAgICBmaWxsOiAjZGIzOTI3OwogICAgICB9CgogICAgICAuZjM0NTNmYmYtODk1My00NjE3LWJlNTEtMWZkZDJiOTdiMDBlIHsKICAgICAgICBmaWxsOiAjY2IzNjI4OwogICAgICB9CgogICAgICAuYjFhNGZjNTMtYWFlNS00ZWI5LTliN2ItYTAxYmMxYTU0ZmFjIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICB9CgogICAgICAuYTc4NTliZDQtYjA1My00YzVmLTk5MGQtYzRmNzFkNDgwZTM4IHsKICAgICAgICBmaWxsOiAjZTNlM2UyOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8dGl0bGU+UHJvZHVjdF9JY29uLVJlZF9IYXQtTWV0ZXJpbmctUkdCPC90aXRsZT4KICA8Y2lyY2xlIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIGN4PSIzNjAuNTc1IiBjeT0iMzYwLjU3NSIgcj0iMzU4LjU3NiIvPgogIDxwYXRoIGNsYXNzPSJmMzQ1M2ZiZi04OTUzLTQ2MTctYmU1MS0xZmRkMmI5N2IwMGUiIGQ9Ik02MTUuNTMsMTA4LjkxNiwxMDguNDY0LDYxNS45ODNjMTQwLjE0MywxMzguNjE3LDM2Ni4xMTEsMTM4LjE2NCw1MDUuNjcxLTEuNFM3NTQuMTQ5LDI0OS4wNTksNjE1LjUzLDEwOC45MTZaIi8+CiAgPHBhdGggY2xhc3M9ImIxYTRmYzUzLWFhZTUtNGViOS05YjdiLWEwMWJjMWE1NGZhYyIgZD0iTTM3MC4xMzEsMTYzLjkzMmwxNzAuMyw5OC4zMjFWNDU4LjlsLTE3MC4zLDk4LjMyMUwxOTkuODMzLDQ1OC45VjI2Mi4yNTNsMTcwLjMtOTguMzIxbTAtMjMuMDk0LTEwLDUuNzczLTE3MC4zLDk4LjMyMi0xMCw1Ljc3M1Y0NzAuNDQ0bDEwLDUuNzczLDE3MC4zLDk4LjMyMiwxMCw1Ljc3MywxMC01Ljc3MywxNzAuMy05OC4zMjIsMTAtNS43NzNWMjUwLjcwNmwtMTAtNS43NzMtMTcwLjMtOTguMzIyLTEwLTUuNzczWiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiMWE0ZmM1My1hYWU1LTRlYjktOWI3Yi1hMDFiYzFhNTRmYWMiIHBvaW50cz0iMzU0LjE2NyA1MTMuMjQyIDIyNi43NjggNDM5LjY4OCAyMjYuNzY4IDI5NS4yMjQgMzU0LjE2NyAzNjguNzc4IDM1NC4xNjcgNTEzLjI0MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJhNzg1OWJkNC1iMDUzLTRjNWYtOTkwZC1jNGY3MWQ0ODBlMzgiIHBvaW50cz0iMzg2LjAxNyA1MTMuMjQyIDUxMy40MTYgNDM5LjY4OCA1MTMuNDE2IDI5NS4yMjQgMzg2LjAxNyAzNjguNzc4IDM4Ni4wMTcgNTEzLjI0MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiMWE0ZmM1My1hYWU1LTRlYjktOWI3Yi1hMDFiYzFhNTRmYWMiIHBvaW50cz0iMjQyLjY5MyAyNjcuOTcyIDM3MC4wOTIgMTk0LjQxOCA0OTcuNDkxIDI2Ny45NzIgMzcwLjA5MiAzNDEuNTI2IDI0Mi42OTMgMjY3Ljk3MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMjg2LjQ4OCAyNjkuMTM0IDI5My4zMDQgMjY0LjczMiAzNzMuOTAxIDMxMS4yNjUgMzY3LjA4NSAzMTUuNjY3IDI4Ni40ODggMjY5LjEzNCIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzAwLjIyNSAyNjkuMTM0IDM0NS43OTIgMjQyLjA3NCAzNjAuNTgxIDI1MC42OTkgMzE1LjAxNCAyNzcuNzU4IDMwMC4yMjUgMjY5LjEzNCIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzIzLjAwOCAyODIuMTYgMzk4LjU2MyAyMzUuODY2IDQxMy4zNTIgMjQ0LjQ5IDMzNy43OTggMjkwLjc4NSAzMjMuMDA4IDI4Mi4xNiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzQ1Ljc5MiAyOTUuMTg3IDQwNi44NCAyNTkuMzQ3IDQyMS42MyAyNjcuOTcyIDM2MC41ODEgMzAzLjgxMSAzNDUuNzkyIDI5NS4xODciLz4KPC9zdmc+Cg==
+      mediatype: image/svg+xml
+
+  labels:
+    operator-metering: "true"
+
+  selector:
+    matchLabels:
+      operator-metering: "true"
+
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: metering-operator
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - services/finalizers
+            - deployments/finalizers
+            verbs:
+            - update
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+          - apiGroups:
+            - config.openshift.io
+            resources:
+            - proxies
+            verbs:
+            - list
+            - get
+          - apiGroups:
+            - config.openshift.io
+            resources:
+            - networks
+            verbs:
+            - list
+            - get
+          - apiGroups:
+            - authorization.k8s.io
+            resources:
+            - subjectaccessreviews
+            verbs:
+            - create
+          - apiGroups:
+            - authentication.k8s.io
+            resources:
+            - tokenreviews
+            verbs:
+            - create
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterrolebindings
+            - clusterroles
+            verbs:
+            - '*'
+
+      permissions:
+        - serviceAccountName: metering-operator
+          rules:
+          - apiGroups:
+            - metering.openshift.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - pods/attach
+            - pods/exec
+            - pods/portforward
+            - pods/proxy
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - configmaps
+            - endpoints
+            - persistentvolumeclaims
+            - secrets
+            - serviceaccounts
+            - services
+            - services/proxy
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - events
+            - namespaces/status
+            - pods/log
+            - pods/status
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - events
+            verbs:
+            - create
+            - update
+            - patch
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - apps
+            resources:
+            - daemonsets
+            - deployments
+            - deployments/finalizers
+            - deployments/rollback
+            - deployments/scale
+            - replicasets
+            - replicasets/scale
+            - statefulsets
+            verbs:
+            - '*'
+          - apiGroups:
+            - batch
+            resources:
+            - cronjobs
+            - jobs
+            verbs:
+            - '*'
+          - apiGroups:
+            - extensions
+            resources:
+            - daemonsets
+            - deployments
+            - deployments/rollback
+            - deployments/scale
+            - replicasets
+            - replicasets/scale
+            verbs:
+            - '*'
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            - authorization.openshift.io
+            resources:
+            - rolebindings
+            - roles
+            verbs:
+            - '*'
+          - apiGroups:
+            - route.openshift.io
+            resources:
+            - routes
+            verbs:
+            - '*'
+
+      deployments:
+        - name: metering-operator
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+            selector:
+              matchLabels:
+                app: metering-operator
+            template:
+              metadata:
+                labels:
+                  app: metering-operator
+                  name: metering-operator
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                - name: operator
+                  image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  imagePullPolicy: Always
+                  args:
+                  - "--zap-level=info"
+                  env:
+                  - name: ANSIBLE_DEBUG_LOGS
+                    value: "True"
+                  - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
+                    value: "1"
+                  - name: OPERATOR_NAME
+                    value: "metering-operator"
+                  - name: DISABLE_OCP_FEATURES
+                    value: "false"
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: METERING_ANSIBLE_OPERATOR_IMAGE
+                    value: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  - name: METERING_REPORTING_OPERATOR_IMAGE
+                    value: "quay.io/openshift/origin-metering-reporting-operator:4.6"
+                  - name: METERING_PRESTO_IMAGE
+                    value: "quay.io/openshift/origin-metering-presto:4.6"
+                  - name: METERING_HIVE_IMAGE
+                    value: "quay.io/openshift/origin-metering-hive:4.6"
+                  - name: METERING_HADOOP_IMAGE
+                    value: "quay.io/openshift/origin-metering-hadoop:4.6"
+                  - name: GHOSTUNNEL_IMAGE
+                    value: "quay.io/openshift/origin-ghostunnel:4.6"
+                  - name: OAUTH_PROXY_IMAGE
+                    value: "quay.io/openshift/origin-oauth-proxy:4.6"
+                  ports:
+                  - name: http-metrics
+                    containerPort: 8383
+                  - name: cr-metrics
+                    containerPort: 8686
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                  resources:
+                    limits:
+                      cpu: 1500m
+                      memory: 500Mi
+                    requests:
+                      cpu: 750m
+                      memory: 400Mi
+
+                volumes:
+                  - name: runner
+                    emptyDir: {}
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                serviceAccount: metering-operator
+
+  customresourcedefinitions:
+    owned:
+    - description: An instance of Metering with high-level configuration
+      displayName: Metering Configuration
+      kind: MeteringConfig
+      name: meteringconfigs.metering.openshift.io
+      version: v1
+    - description: A scheduled or on-off Metering Report summarizes data based on the
+        query specified.
+      displayName: Metering Report
+      kind: Report
+      name: reports.metering.openshift.io
+      version: v1
+    - description: A SQL query used by Metering to generate reports.
+      displayName: Metering Report Query
+      kind: ReportQuery
+      name: reportqueries.metering.openshift.io
+      version: v1
+    - description: Used under-the-hood. A resource representing a database table in Presto.
+        Used by ReportQueries to determine what tables exist, and by the HTTP API to determine
+        how to query a table.
+      displayName: Metering Data Source
+      kind: ReportDataSource
+      name: reportdatasources.metering.openshift.io
+      version: v1
+    - description: Represents a configurable storage location for Metering to store metering
+        and report data.
+      displayName: Metering Storage Location
+      kind: StorageLocation
+      name: storagelocations.metering.openshift.io
+      version: v1
+    - description: Used under-the-hood. A resource describing a source of data for usage
+        by Report Queries.
+      displayName: Metering Presto Table
+      kind: PrestoTable
+      name: prestotables.metering.openshift.io
+      version: v1
+    - description: Used under-the-hood. A resource representing a database table in Hive.
+      displayName: Metering Hive Table
+      kind: HiveTable
+      name: hivetables.metering.openshift.io
+      version: v1
+

--- a/olm_deploy/bundle/manifests/prestotable.crd.yaml
+++ b/olm_deploy/bundle/manifests/prestotable.crd.yaml
@@ -1,0 +1,154 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prestotables.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: prestotables
+    singular: prestotable
+    kind: PrestoTable
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Table Name
+      type: string
+      jsonPath: .status.tableName
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: |
+          PrestoTable is a custom resource that represents a database table accessible from within Presto.
+          When a PrestoTable resource is created, the reporting-operator creates a table within Presto according
+          to the configuration provided, or exposes an existing table.
+          More info: https://prestosql.io/docs/current/index.html
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            description: |
+              PrestoTableSpec is the desired specification of a PrestoTable custom resource.
+              Required fields: unmanaged, catalog, schema, tableName. Note: columns is required when unmanaged is set to false.
+              Optional fields: query, view, createTableAs, properties, and comment.
+              More info: https://github.com/kube-reporting/metering-operator/blob/master/Documentation/prestotables.md
+            required:
+            - unmanaged
+            - catalog
+            - schema
+            - tableName
+            properties:
+              unmanaged:
+                type: boolean
+                description: |
+                  Unmanaged indicates whether a PrestoTable resource is referencing an existing table,
+                  and if set to true, the operator should not attempt to create or manage that table within Presto.
+              catalog:
+                type: string
+                description: |
+                  Catalog specifies which catalog the Presto table is to be created within.
+                  In many cases, the catalog will be set to "hive".
+                  More info: https://prestosql.io/docs/current/overview/concepts.html#catalog
+                minLength: 1
+              schema:
+                type: string
+                description: |
+                  The schema within the Presto catalog for the table to created in,
+                  or the schema the table should exist in if unmanaged.
+                  If the catalog is `hive` then there will always be at least the `default` schema.
+                  More info: https://prestosql.io/docs/current/overview/concepts.html#schema
+                minLength: 1
+              tableName:
+                type: string
+                description: |
+                  TableName is the desired name of the table to be created in Presto,
+                  or in the case where "unmanaged" is set to false, the name of an existing table within Presto.
+                  More info: https://prestosql.io/docs/current/overview/concepts.html#table
+                minLength: 1
+              columns:
+                type: array
+                description: |
+                  A list of columns that match the schema of the PrestoTable.
+                  For each list item, you must specify a `name` field, which is the name of an individual column for the Presto table,
+                  and a `type` field, which corresponds to a valid type in Presto.
+                  More info: https://prestosql.io/docs/current/language/types.html
+                items:
+                  type: object
+                  required:
+                  - name
+                  - type
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    type:
+                      type: string
+                      minLength: 1
+              properties:
+                type: object
+                description: |
+                  Properties is a map containing string key and value pairs. Each key-value pair is a table property for
+                  configuring the table. The available properties depend on the "catalog" being used.
+                  Note: this is an optional field.
+                additionalProperties:
+                  type: string
+              comment:
+                type: string
+                description: |
+                  Sets a comment on the Presto table. Comments are just arbitrary strings that have no meaning to Presto,
+                  but can be used to store arbitrary information about a table.
+                  Note: this is an optional field.
+                minLength: 1
+              view:
+                type: boolean
+                description: |
+                  View controls whether the reporting-operator needs to create a view within Presto.
+                  If true, the reporting-operator uses the "query" field as the SELECT statement for creating the view.
+                  Note: this is an optional field.
+              createTableAs:
+                type: boolean
+                description: |
+                  CreateTableAs controls whether the reporting-operator needs to create a table within Presto.
+                  If true, the reporting-operator uses the "query" field as the SELECT statemtnt for creating the table.
+                  Note: this is an optional field.
+              query:
+                type: string
+                description: |
+                  Query is a string containing a SQL SELECT query used for creating a table or view.
+                  Note: this is an optional field.
+                  More info: https://prestosql.io/docs/current/overview/concepts.html#query
+                minLength: 1
+          status:
+            type: object
+            properties:
+              catalog:
+                type: string
+              schema:
+                type: string
+              tableName:
+                type: string
+              comment:
+                type: string
+              query:
+                type: string
+              view:
+                type: boolean
+              createTableAs:
+                type: boolean
+              properties:
+                type: object
+                additionalProperties:
+                  type: string
+              columns:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+

--- a/olm_deploy/bundle/manifests/report.crd.yaml
+++ b/olm_deploy/bundle/manifests/report.crd.yaml
@@ -1,0 +1,318 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reports.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: reports
+    singular: report
+    kind: Report
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Query
+      type: string
+      jsonPath: .spec.query
+    - name: Schedule
+      type: string
+      jsonPath: .spec.schedule.period
+    - name: Running
+      type: string
+      jsonPath: .status.conditions[?(@.type=="Running")].reason
+    - name: Failed
+      type: string
+      jsonPath: .status.conditions[?(@.type=="Failure")].reason
+    - name: Last Report Time
+      type: string
+      jsonPath: .status.lastReportTime
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            required:
+            - query
+            properties:
+              query:
+                type: string
+                minLength: 1
+              reportingStart:
+                type: string
+                format: date-time
+              reportingEnd:
+                type: string
+                format: date-time
+              expiration:
+                type: string
+                format: duration
+              runImmediately:
+                type: boolean
+              overwriteExistingData:
+                type: boolean
+              inputs:
+                type: array
+                minItems: 1
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    value:
+                      type: string
+              schedule:
+                type: object
+                required:
+                - period
+                properties:
+                  period:
+                    type: string
+                    minLength: 1
+                    enum:
+                    - hourly
+                    - daily
+                    - weekly
+                    - monthly
+                    - cron
+                  hourly:
+                    type: object
+                    properties:
+                      second:
+                        type: integer
+                        minimum: 0
+                        maximum: 60
+                      minute:
+                        type: integer
+                        minimum: 0
+                        maximum: 59
+                  daily:
+                    type: object
+                    properties:
+                      second:
+                        type: integer
+                        minimum: 0
+                        maximum: 60
+                      minute:
+                        type: integer
+                        minimum: 0
+                        maximum: 59
+                      hour:
+                        type: integer
+                        minimum: 0
+                        maximum: 23
+                  weekly:
+                    type: object
+                    properties:
+                      dayofWeek:
+                        type: string
+                        enum:
+                        - sun
+                        - sunday
+                        - mon
+                        - monday
+                        - tue
+                        - tues
+                        - tuesday
+                        - wed
+                        - weds
+                        - wednesday
+                        - thur
+                        - thurs
+                        - thursday
+                        - fri
+                        - friday
+                        - sat
+                        - saturday
+                      second:
+                        type: integer
+                        minimum: 0
+                        maximum: 60
+                      minute:
+                        type: integer
+                        minimum: 0
+                        maximum: 59
+                      hour:
+                        type: integer
+                        minimum: 0
+                        maximum: 23
+                      dayOfWeek:
+                        type: string
+                  monthly:
+                    type: object
+                    properties:
+                      dayOfMonth:
+                        type: integer
+                        minimum: 1
+                        maximum: 31
+                      second:
+                        type: integer
+                        minimum: 0
+                        maximum: 60
+                      minute:
+                        type: integer
+                        minimum: 0
+                        maximum: 59
+                      hour:
+                        type: integer
+                        minimum: 0
+                        maximum: 23
+                  cron:
+                    type: object
+                    required:
+                    - expression
+                    properties:
+                      expression:
+                        type: string
+                        pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
+                oneOf:
+                - properties:
+                    period:
+                      enum:
+                      - hourly
+                  allOf:
+                  - not:
+                      required:
+                      - daily
+                  - not:
+                      required:
+                      - weekly
+                  - not:
+                      required:
+                      - monthly
+                  - not:
+                      required:
+                      - cron
+                - properties:
+                    period:
+                      enum:
+                      - daily
+                  allOf:
+                  - not:
+                      required:
+                      - hourly
+                  - not:
+                      required:
+                      - weekly
+                  - not:
+                      required:
+                      - monthly
+                  - not:
+                      required:
+                      - cron
+                - properties:
+                    period:
+                      enum:
+                      - weekly
+                  allOf:
+                  - not:
+                      required:
+                      - hourly
+                  - not:
+                      required:
+                      - daily
+                  - not:
+                      required:
+                      - monthly
+                  - not:
+                      required:
+                      - cron
+                - properties:
+                    period:
+                      enum:
+                      - monthly
+                  allOf:
+                  - not:
+                      required:
+                      - hourly
+                  - not:
+                      required:
+                      - daily
+                  - not:
+                      required:
+                      - weekly
+                  - not:
+                      required:
+                      - cron
+                - properties:
+                    period:
+                      enum:
+                      - cron
+                  allOf:
+                  - not:
+                      required:
+                      - hourly
+                  - not:
+                      required:
+                      - daily
+                  - not:
+                      required:
+                      - weekly
+                  - not:
+                      required:
+                      - monthly
+            anyOf:
+            # runOnce report
+            - required:
+              - query
+              - reportingStart
+              - reportingEnd
+            # runImmediately report
+            - required:
+              - query
+              - runImmediately
+              - reportingEnd
+            # scheduled report
+            - required:
+              - query
+              - schedule
+          status:
+            type: object
+            properties:
+              lastReportTime:
+                type: string
+                format: date-time
+              nextReportTime:
+                type: string
+                format: date-time
+              tableRef:
+                type: object
+                properties:
+                  name:
+                    type: string
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastUpdateTime:
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                    status:
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - "Unknown"
+

--- a/olm_deploy/bundle/manifests/reportdatasource.crd.yaml
+++ b/olm_deploy/bundle/manifests/reportdatasource.crd.yaml
@@ -1,0 +1,180 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reportdatasources.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: reportdatasources
+    singular: reportdatasource
+    kind: ReportDataSource
+    shortNames:
+    - datasource
+    - datasources
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Earliest Metric
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.earliestImportedMetricTime
+    - name: Newest Metric
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.newestImportedMetricTime
+    - name: Import Start
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.importDataStartTime
+    - name: Import End
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.importDataEndTime
+    - name: Last Import Time
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.lastImportTime
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            properties:
+              prometheusMetricsImporter:
+                type: object
+                required:
+                - query
+                properties:
+                  query:
+                    type: string
+                    minLength: 1
+                  storage:
+                    type: object
+                    required:
+                    - storageLocationName
+                    properties:
+                      storageLocationName:
+                        type: string
+                        minLength: 1
+                  prometheusConfig:
+                    type: object
+                    required:
+                    - url
+                    properties:
+                      url:
+                        type: string
+                        format: uri
+              reportQueryView:
+                type: object
+                required:
+                - queryName
+                properties:
+                  queryName:
+                    type: string
+                    minLength: 1
+                  inputs:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: object
+                      required:
+                      - name
+                      - value
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                        value:
+                          type: string
+                  storage:
+                    type: object
+                    required:
+                    - storageLocationName
+                    properties:
+                      storageLocationName:
+                        type: string
+                        minLength: 1
+              awsBilling:
+                type: object
+                required:
+                - source
+                properties:
+                  source:
+                    type: object
+                    required:
+                    - bucket
+                    - region
+                    properties:
+                      bucket:
+                        type: string
+                        minLength: 1
+                      prefix:
+                        type: string
+                      region:
+                        type: string
+                        minLength: 1
+              prestoTable:
+                type: object
+                required:
+                - tableRef
+                properties:
+                  tableRef:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+              linkExistingTable:
+                type: object
+                required:
+                - tableName
+                properties:
+                  tableName:
+                    description: |
+                      TableName is the fully-qualified table name (i.e. catalog.schema.table_name) of an existing Presto table.
+                    type: string
+                    minLength: 1
+            oneOf:
+            - required:
+              - prometheusMetricsImporter
+            - required:
+              - reportQueryView
+            - required:
+              - awsBilling
+            - required:
+              - prestoTable
+            - required:
+              - linkExistingTable
+          status:
+            type: object
+            properties:
+              tableRef:
+                type: object
+                properties:
+                  name:
+                    type: string
+              prometheusMetricsImportStatus:
+                type: object
+                properties:
+                  lastImportTime:
+                    type: string
+                    format: date-time
+                  importDataStartTime:
+                    type: string
+                    format: date-time
+                  importDataEndTime:
+                    type: string
+                    format: date-time
+                  earliestImportedMetricTime:
+                    type: string
+                    format: date-time
+                  newestImportedMetricTime:
+                    type: string
+                    format: date-time
+

--- a/olm_deploy/bundle/manifests/reportquery.crd.yaml
+++ b/olm_deploy/bundle/manifests/reportquery.crd.yaml
@@ -1,0 +1,151 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reportqueries.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: reportqueries
+    singular: reportquery
+    kind: ReportQuery
+    shortNames:
+    - rq
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            required:
+            - columns
+            - query
+            properties:
+              columns:
+                type: array
+                minItems: 1
+                items:
+                  type: object
+                  required:
+                  - name
+                  - type
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    type:
+                      type: string
+                      enum:
+                      - BOOLEAN
+                      - TINYINT
+                      - SMALLINT
+                      - INTEGER
+                      - BIGINT
+                      - REAL
+                      - DOUBLE
+                      - DECIMAL
+                      - VARCHAR
+                      - CHAR
+                      - VARBINARY
+                      - JSON
+                      - DATE
+                      - TIME
+                      - TIMESTAMP
+                      - ARRAY
+                      - MAP
+                      - MAP<VARCHAR, VARCHAR>
+                      - MAP<VARCHAR, INT>
+                      - MAP<INT, INT>
+                      - MAP<INT, VARCHAR>
+                      - ROW
+                      - IPADDRESS
+                      - UUID
+                      - HYPERLOGLOG
+                      - P4HYPERLOGLOG
+                      - QDIGEST
+                      - boolean
+                      - tinyint
+                      - smallint
+                      - integer
+                      - bigint
+                      - real
+                      - double
+                      - decimal
+                      - varchar
+                      - char
+                      - varbinary
+                      - json
+                      - date
+                      - time
+                      - timestamp
+                      - array
+                      - map
+                      - map<varchar, varchar>
+                      - map<varchar, int>
+                      - map<int, int>
+                      - map<int, varchar>
+                      - row
+                      - ipaddress
+                      - uuid
+                      - hyperloglog
+                      - p4hyperloglog
+                      - qdigest
+                    unit:
+                      type: string
+                      enum:
+                      - date
+                      - kubernetes_pod
+                      - kubernetes_persistentvolumeclaim
+                      - kubernetes_persistentvolume
+                      - kubernetes_storageclass
+                      - kubernetes_namespace
+                      - kubernetes_node
+                      - bytes
+                      - byte_seconds
+                      - time
+                      - cpu_core_seconds
+                      - cpu_cores
+                      - memory_bytes
+                      - memory_byte_seconds
+                      - seconds
+                    tableHidden:
+                      type: boolean
+              inputs:
+                type: array
+                minItems: 1
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    type:
+                      type: string
+                      enum:
+                      - string
+                      - integer
+                      - time
+                      - ReportDataSource
+                      - ReportQuery
+                      - Report
+                    required:
+                      type: boolean
+                    default:
+                      type: string
+              query:
+                type: string
+                pattern: '[Ss][Ee][Ll][Ee][Cc][Tt]\s'
+                minLength: 1
+

--- a/olm_deploy/bundle/manifests/storagelocation.crd.yaml
+++ b/olm_deploy/bundle/manifests/storagelocation.crd.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: storagelocations.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: storagelocations
+    singular: storagelocation
+    kind: StorageLocation
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: |
+          StorageLocation is a custom resource that configures where data will
+          be stored by the reporting-operator. This included the data collected
+          from Prometheus, and the results produced by generating a `Report` custom
+          resources.
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            description: |
+              StorageLocationSpec is the desired specification of a StorageLocation custom resource.
+              Required fields: databaseName, unmanagedDatabase, and location.
+              More info: https://github.com/kube-reporting/metering-operator/blob/master/Documentation/storagelocations.md
+            properties:
+              hive:
+                type: object
+                description: |
+                  Configures the StorageLocation to store data in Presto by creating
+                  the table using Hive Server.
+                  Note: databaseName and unmanagedDatabase are required fields.
+                required:
+                - databaseName
+                - unmanagedDatabase
+                properties:
+                  databaseName:
+                    type: string
+                    description: |
+                      DatabaseName is the name of the database within hive.
+                    minLength: 1
+                  unmanagedDatabase:
+                    type: boolean
+                    description: |
+                      UnmanagedDatabase controls whether the StorageLocation will be actively
+                      managed, and if true, the databaseName needs to point to an existing table
+                      in Hive. If set to false, the reporting-operator creates a database in Hive.
+                  location:
+                    type: string
+                    description: |
+                      Location is the filesystem URL for Presto and Hive to use for the
+                      database. This can be in the form of `hdfs://` or `sda://` filesystem URL.
+                      If this field is unset, or set to an empty string, then the default
+                      filesystem URL for Hive is used.
+                      Note: this is an optional field.
+                    format: uri
+                  defaultTableProperties:
+                    type: object
+                    description: |
+                      DefaultTableProperties contains the configuration options for creating table
+                      using Hive.
+                      Note: this is an optional field.
+                    properties:
+                      fileFormat:
+                        type: string
+                        description: |
+                          FileFormat specifies the file format used for storing files in the file system.
+                          Note: this is an optional field.
+                          More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe
+                        minLength: 1
+                      rowFormat:
+                        type: string
+                        description: |
+                          RowFormat specifies the Hive row format, which is how Hive serializes and
+                          deserializes rows.
+                          Note: this is an optional field.
+                          More info: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe
+                        minLength: 1
+          status:
+            type: object
+            properties:
+              hive:
+                type: object
+                properties:
+                  databaseName:
+                    type: string
+                  location:
+                    type: string
+

--- a/olm_deploy/bundle/metadata/annotations.yaml
+++ b/olm_deploy/bundle/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: "4.6"
+  operators.operatorframework.io.bundle.channels.v1: "4.6"
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: metering-ocp


### PR DESCRIPTION
This is mainly a no-op at the moment as we consider how to best integrate this during the 4.6 release. We may want to merge these standalone, with the intention of integrating with CI as a follow-up, before fully migrating over from the old manifest bundle format to this new one.

A couple of open questions:
- ~Where should the image-references file be located?~ This isn't necessary and will break validation.
- ~Where should the art.yaml file be located?~ This isn't necessary and will break validation.
- ~Do we need to incorporate either right now if we don't need them for use throughout CI?~ Nope
- ~How to best organize the existing manifests with these newly introduced manifests, in addition to the olm_deploy manifests that are used to deploy metering in CI.~