### PR TITLE
olm_deploy: Use the ubi8-minimal base image for the registry Dockerfile.

### DIFF
--- a/olm_deploy/Dockerfile.registry
+++ b/olm_deploy/Dockerfile.registry
@@ -1,5 +1,5 @@
 FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /
 ARG MANIFEST_BUNDLE=manifests/deploy/openshift/olm/bundle


### PR DESCRIPTION
This updates the base image to use ubi8 instead of the previous Golang image, which helps significantly cut down the size of this image and we don't need much more besides a basic linux environment to utilize this image throughout the testing suite.