### PR TITLE
e2e: report expires with no dependency & does not expire with dependency

### DIFF
--- a/pkg/operator/http_test.go
+++ b/pkg/operator/http_test.go
@@ -118,7 +118,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 	}{
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -146,7 +146,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -187,7 +187,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -232,7 +232,7 @@ func TestAPIV1ReportsGet(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
 					Name: "timestamp",
@@ -394,7 +394,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -444,7 +444,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -475,7 +475,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -524,7 +524,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLFull(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -533,7 +533,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLFull(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -542,7 +542,7 @@ func TestAPIV2ReportsFull(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLFull(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -682,7 +682,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 	}{
 		"report-finished-with-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -734,7 +734,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-no-results": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -765,7 +765,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-finished-db-errored": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{
@@ -814,7 +814,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-not-specified": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLTable(namespace, testReportName),
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "the following fields are missing or empty: format",
@@ -823,7 +823,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"report-format-non-existent": {
 			reportName:            testReportName,
-			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:                testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:               apiReportV2URLTable(namespace, testReportName) + "?format=doesntexist",
 			expectedStatusCode:    http.StatusBadRequest,
 			expectedAPIError:      "format must be one of: csv, json or tabular",
@@ -832,7 +832,7 @@ func TestAPIV2ReportsTable(t *testing.T) {
 		},
 		"mismatched-results-schema-to-table-schema": {
 			reportName: testReportName,
-			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:     testhelpers.NewReport(testReportName, namespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			apiPath:    apiReportV2URLTable(namespace, testReportName) + testFormat,
 			query: testhelpers.NewReportQuery(testQueryName, namespace, []metering.ReportQueryColumn{
 				{

--- a/pkg/operator/reporting/templates_test.go
+++ b/pkg/operator/reporting/templates_test.go
@@ -180,7 +180,7 @@ func TestRenderQuery(t *testing.T) {
 				Query:          "SELECT * FROM {| reportTableName .Report.Inputs.MissingReportNameInReportsField |}",
 				RequiredInputs: []string{"MissingReportNameInReportsField"},
 				Reports: []*metering.Report{
-					testhelpers.NewReport("", testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+					testhelpers.NewReport("", testNamespace, testReportQuery, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 				},
 				PrestoTables: []*metering.PrestoTable{
 					newTestPrestoTable(ds1.Status.TableRef.Name, testNamespace, testCatalogName, testCatalogName, nil),
@@ -198,7 +198,7 @@ func TestRenderQuery(t *testing.T) {
 			name: "Report dependency was not found (due to Report.Name not matching name) returns error",
 			reportTemplate: &ReportQueryTemplateContext{
 				Reports: []*metering.Report{
-					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 				},
 				Query:             "SELECT * FROM {| reportTableName .Report.Inputs.ReportNameDoesNotMatchInputName |}",
 				RequiredInputs:    []string{"ReportNameDoesNotMatchInputName"},
@@ -221,7 +221,7 @@ func TestRenderQuery(t *testing.T) {
 				Query:          "SELECT * FROM {| reportTableName .Report.Inputs.MissingReportStatusTableRef|}",
 				RequiredInputs: []string{"MissingReportStatusTableRef"},
 				Reports: []*metering.Report{
-					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
+					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, nil, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: ""},
 					}, nil, false, nil),
 				},
@@ -240,7 +240,7 @@ func TestRenderQuery(t *testing.T) {
 				Query:          "SELECT * FROM {| reportTableName .Report.Inputs.EmptyReportStatusTableRef |}",
 				RequiredInputs: []string{"EmptyReportStatusTableRef"},
 				Reports: []*metering.Report{
-					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
+					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, nil, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: testReportName},
 					}, nil, false, nil),
 				},
@@ -262,7 +262,7 @@ func TestRenderQuery(t *testing.T) {
 				Query:          "SELECT * FROM {| reportTableName .Report.Inputs.ValidReportTableNameQuery |}",
 				RequiredInputs: []string{"ValidReportTableNameQuery"},
 				Reports: []*metering.Report{
-					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
+					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, nil, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: testReportName},
 					}, nil, false, nil),
 				},
@@ -530,7 +530,7 @@ func TestRenderQuery(t *testing.T) {
 				Query:          "SELECT * FROM {| reportTableName .Report.Inputs.NamespaceCpuUsage |} WHERE namespace = {| .Report.Inputs.Namespace |}",
 				RequiredInputs: []string{"NamespaceCpuUsage", "Namespace"},
 				Reports: []*metering.Report{
-					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, reportStart, reportEnd, metering.ReportStatus{
+					testhelpers.NewReport(testReportName, testNamespace, testReportQuery, nil, reportStart, reportEnd, metering.ReportStatus{
 						TableRef: v1.LocalObjectReference{Name: ds1.Status.TableRef.Name},
 					}, nil, false, nil),
 				},

--- a/pkg/operator/reporting/validate_test.go
+++ b/pkg/operator/reporting/validate_test.go
@@ -17,8 +17,8 @@ func TestValidateQueryDependencies(t *testing.T) {
 	dataSourceTableSet := testhelpers.NewReportDataSource("initialized-datasource", "default")
 	dataSourceTableSet.Status.TableRef.Name = reportingutil.DataSourceTableName("test-ns", "initialized-datasource")
 
-	reportTableUnset := testhelpers.NewReport("uninitialized-report", "default", "some-query", nil, nil, metering.ReportStatus{}, nil, false, nil)
-	reportTableSet := testhelpers.NewReport("initialized-report", "default", "some-query", nil, nil, metering.ReportStatus{
+	reportTableUnset := testhelpers.NewReport("uninitialized-report", "default", "some-query", nil, nil, nil, metering.ReportStatus{}, nil, false, nil)
+	reportTableSet := testhelpers.NewReport("initialized-report", "default", "some-query", nil, nil, nil, metering.ReportStatus{
 		TableRef: v1.LocalObjectReference{Name: reportingutil.ReportTableName("test-ns", "initialized-report")},
 	}, nil, false, nil)
 

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -126,12 +126,12 @@ func TestIsReportFinished(t *testing.T) {
 	}{
 		{
 			name:           "new report returns false",
-			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:         testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectFinished: false,
 		},
 		{
 			name: "finished status on run-once report returns true",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -140,7 +140,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "unset reportingEnd returns false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, nil, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, nil, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -149,7 +149,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "reportingEnd > lastReportTime returns false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -159,7 +159,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "reportingEnd < lastReportTime returns true",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ReportFinishedReason, testReportMessage),
 				},
@@ -169,7 +169,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is false and reason is Scheduled return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.ScheduledReason, testReportMessage),
 				},
@@ -178,7 +178,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is true and reason is Scheduled return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.ScheduledReason, testReportMessage),
 				},
@@ -187,7 +187,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is false and reason is InvalidReport return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.InvalidReportReason, testReportMessage),
 				},
@@ -196,7 +196,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is true and reason is InvalidReport return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.InvalidReportReason, testReportMessage),
 				},
@@ -205,7 +205,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is false and reason is RunImmediately return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionFalse, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
@@ -214,7 +214,7 @@ func TestIsReportFinished(t *testing.T) {
 		},
 		{
 			name: "when status running is true and reason is RunImmediately return false",
-			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{
+			report: testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{
 				Conditions: []metering.ReportCondition{
 					*meteringUtil.NewReportCondition(metering.ReportRunning, v1.ConditionTrue, meteringUtil.RunImmediatelyReason, testReportMessage),
 				},
@@ -322,43 +322,43 @@ func TestValidateReport(t *testing.T) {
 	}{
 		{
 			name:         "empty spec.query returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, "", reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, "", nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectErr:    true,
 			expectErrMsg: "must set spec.query",
 		},
 		{
 			name:         "spec.ReportingStart > spec.ReportingEnd returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportEnd, reportStart, metering.ReportStatus{}, nil, false, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, nil, reportEnd, reportStart, metering.ReportStatus{}, nil, false, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("spec.reportingEnd (%s) must be after spec.reportingStart (%s)", reportStart.String(), reportEnd.String()),
 		},
 		{
 			name:         "spec.ReportingEnd is unset and spec.RunImmediately is set returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, nil, metering.ReportStatus{}, nil, true, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, nil, reportStart, nil, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    true,
 			expectErrMsg: "spec.reportingEnd must be set if report.spec.runImmediately is true",
 		},
 		{
 			name:         "spec.QueryName does not exist returns err",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testNonExistentQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("ReportQuery (%s) does not exist", testNonExistentQueryName),
 		},
 		{
 			name:         "valid report with missing DataSource returns error",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("failed to resolve ReportQuery dependencies %s: %s", testInvalidQueryName, "ReportDataSource.metering.openshift.io \"this-does-not-exist\" not found"),
 		},
 		{
 			name:         "valid report with uninitalized DataSource returns error",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName2, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testInvalidQueryName2, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    true,
 			expectErrMsg: fmt.Sprintf("failed to validate ReportQuery dependencies %s: ReportQueryDependencyValidationError: uninitialized ReportDataSource dependencies: %s", testInvalidQueryName2, ds2.Name),
 		},
 		{
 			name:         "valid report with valid DataSource returns nil",
-			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
+			report:       testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, true, nil),
 			expectErr:    false,
 			expectErrMsg: "",
 		},
@@ -411,47 +411,47 @@ func TestGetReportPeriod(t *testing.T) {
 	}{
 		{
 			name:      "invalid report with an unset spec.Schedule field returns an error",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, nil, metering.ReportStatus{}, nil, false, nil),
 			expectErr: true,
 		},
 		{
 			name:      "valid report with an unset spec.Schedule field returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, nil, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "invalid schedule with a set spec.Schedule field returns error",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, invalidSchedule, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, invalidSchedule, false, nil),
 			expectErr: true,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and a set Spec.Status.LastReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{LastReportTime: lastReportTime}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.ReportingStart returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportStart, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and an unset Spec.ReportingStart returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, reportEnd, metering.ReportStatus{}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:      "valid schedule with a set spec.Schedule field and an unset Spec.Status.LastReportTime and a set Spec.NextReportTime returns nil",
-			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, metering.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false, nil),
+			report:    testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, reportEnd, metering.ReportStatus{NextReportTime: nextReportTime}, validSchedule, false, nil),
 			expectErr: false,
 		},
 		{
 			name:        "unset Spec.Schedule with reportPeriod.periodStart > reportPeriod.periodEnd returns panic",
-			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, reportEnd, reportStart, metering.ReportStatus{NextReportTime: nextReportTime}, nil, false, nil),
+			report:      testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, reportEnd, reportStart, metering.ReportStatus{NextReportTime: nextReportTime}, nil, false, nil),
 			expectErr:   false,
 			expectPanic: true,
 		},
@@ -490,12 +490,12 @@ func TestReportsExpireAsExpected(t *testing.T) {
 	}{
 		{
 			name:     "expired report should be deleted",
-			report:   testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false, &metav1.Duration{Duration: 1 * time.Minute}),
+			report:   testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, nil, metering.ReportStatus{}, nil, false, &metav1.Duration{Duration: 1 * time.Minute}),
 			nowAdder: 1,
 		},
 		{
 			name:     "not expired report should not be deleted",
-			report:   testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, metering.ReportStatus{}, nil, false, &metav1.Duration{Duration: 1 * time.Minute}),
+			report:   testhelpers.NewReport(testReportName, testNamespace, testQueryName, nil, nil, nil, metering.ReportStatus{}, nil, false, &metav1.Duration{Duration: 1 * time.Minute}),
 			nowAdder: -1,
 		},
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -277,6 +277,16 @@ func TestManualMeteringInstall(t *testing.T) {
 					Name:     "testFailedPrometheusQueryEvents",
 					TestFunc: testFailedPrometheusQueryEvents,
 				},
+				{
+					Name:         "testReportIsDeletedWhenNoDeps",
+					TestFunc:     testReportIsDeletedWhenNoDeps,
+					ExtraEnvVars: []string{},
+				},
+				{
+					Name:         "testReportIsNotDeletedWhenReportDependsOnIt",
+					TestFunc:     testReportIsNotDeletedWhenReportDependsOnIt,
+					ExtraEnvVars: []string{},
+				},
 			},
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-disabled.yaml",
 		},

--- a/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
+++ b/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
@@ -39,6 +39,8 @@ spec:
           requests:
             cpu: 1
             memory: 1Gi
+      image:
+        tag: "4.5"
 
   hive:
     spec:

--- a/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
+++ b/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
@@ -39,8 +39,6 @@ spec:
           requests:
             cpu: 1
             memory: 1Gi
-      image:
-        tag: "4.5"
 
   hive:
     spec:

--- a/test/e2e/report_dynamic_input_data_test.go
+++ b/test/e2e/report_dynamic_input_data_test.go
@@ -1,6 +1,14 @@
 package e2e
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/kube-reporting/metering-operator/test/testhelpers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,7 +97,7 @@ type reportProducesDataTestCase struct {
 	name          string
 	queryName     string
 	schedule      *metering.ReportSchedule
-	newReportFunc func(name, queryName string, schedule *metering.ReportSchedule, start, end *time.Time) *metering.Report
+	newReportFunc func(name, queryName string, schedule *metering.ReportSchedule, start, end *time.Time, expiration *metav1.Duration) *metering.Report
 	skip          bool
 	parallel      bool
 }
@@ -151,7 +159,7 @@ func testReportsProduceData(t *testing.T, testReportingFramework *reportingframe
 
 			t.Logf("reportStart: %s, reportEnd: %s", reportStart, reportEnd)
 
-			report := test.newReportFunc(test.name, test.queryName, test.schedule, &reportStart, &reportEnd)
+			report := test.newReportFunc(test.name, test.queryName, test.schedule, &reportStart, &reportEnd, nil)
 			reportRunTimeout := 10 * time.Minute
 			t.Logf("creating report %s and waiting %s to finish", report.Name, reportRunTimeout)
 			testReportingFramework.RequireReportSuccessfullyRuns(t, report, reportRunTimeout)
@@ -162,4 +170,140 @@ func testReportsProduceData(t *testing.T, testReportingFramework *reportingframe
 			assert.NotEmpty(t, reportResults, "reports should return at least 1 row")
 		})
 	}
+}
+
+func testReportIsDeletedWhenNoDeps(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
+	reportName := "report-should-delete"
+	// cron schedule to run every minute
+	cronSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron: &metering.ReportScheduleCron{
+			Expression: "*/1 * * * *",
+		},
+	}
+	var foundOnce bool
+	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
+	// If a report is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
+	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
+	waitTimeWhileCheckDeletion := 4 * time.Minute
+
+	report := testReportingFramework.NewSimpleReport(
+		reportName,
+		"namespace-memory-request",
+		cronSchedule,
+		nil,
+		nil,
+		expiration,
+	)
+	t.Logf("creating report %s and waiting %s to finish", report.Name, waitTimeWhileCheckDeletion)
+	createErr := testReportingFramework.CreateMeteringReport(report)
+	assert.NoError(t, createErr, "creating report should produce no error")
+
+	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
+		_, err := testReportingFramework.GetMeteringReport(reportName)
+		// `foundOnce` provides a latch that allows us to wait for report creation then exit on deletion
+		if err == nil {
+			foundOnce = true
+		}
+		if err != nil {
+			if foundOnce && apierrors.IsNotFound(err) {
+				return true, errors.New("report was deleted after being created")
+			}
+		}
+		// if we're exiting due to timeout, it's a fail
+		return false, nil
+	})
+	if err != nil {
+		assert.Contains(t, err.Error(), "was deleted", "report should have been deleted by retention period being reached")
+	}
+}
+
+func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
+	testQueryName := "namespace-cpu-usage"
+	subReportName := "subreport-should-not-delete"
+	// cron schedule to run every minute
+	cronSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron: &metering.ReportScheduleCron{
+			Expression: "*/1 * * * *",
+		},
+	}
+	var foundOnce = false
+	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
+	// If a subReport is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
+	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
+	waitTimeWhileCheckDeletion := 4 * time.Minute
+
+	subReport := testReportingFramework.NewSimpleReport(
+		subReportName,
+		testQueryName,
+		cronSchedule,
+		nil,
+		nil,
+		expiration,
+	)
+	t.Logf("creating subReport %s and waiting %s to finish", subReport.Name, waitTimeWhileCheckDeletion)
+
+	createErr := testReportingFramework.CreateMeteringReport(subReport)
+	assert.NoError(t, createErr, "creating subreport should produce no error")
+
+	newDefault := func(s string) *json.RawMessage {
+		v := json.RawMessage(s)
+		return &v
+	}
+
+	report := testhelpers.NewReport(
+		"report-depends-on-subreport",
+		testReportingFramework.Namespace,
+		testQueryName,
+		[]metering.ReportQueryInputValue{
+			metering.ReportQueryInputValue{
+				Name:  "Report",
+				Value: newDefault(`"` + subReportName + `"`),
+			},
+		},
+		nil,
+		nil,
+		metering.ReportStatus{},
+		cronSchedule,
+		false,
+		nil,
+	)
+
+	createErr = testReportingFramework.CreateMeteringReport(report)
+	assert.NoError(t, createErr, "creating report should produce no error")
+
+	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
+		_, err := testReportingFramework.GetMeteringReport(subReportName)
+		// `foundOnce` provides a latch that allows us to wait for subReport creation then exit on deletion
+		if err == nil {
+			foundOnce = true
+		}
+		if err != nil {
+			if foundOnce && apierrors.IsNotFound(err) {
+				return true, errors.New("subReport was deleted after being created")
+			}
+		}
+		// if we're exiting due to timeout, it's correct, because the subReport should not be deleted
+		return false, nil
+	})
+	assert.Contains(t,
+		err.Error(),
+		"timed out waiting",
+		"should have timed out waiting on subReport expiration as subReport should not have been deleted",
+	)
+	listOptions := metav1.ListOptions{}
+	events, err := testReportingFramework.KubeClient.CoreV1().Events(testReportingFramework.Namespace).List(
+		context.Background(),
+		listOptions,
+	)
+	require.NoError(t, err, "failed to list the events in the test namespace")
+	var found bool
+	for _, event := range events.Items {
+		if strings.Contains(event.InvolvedObject.Name, "subreport-should-not-delete") {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "expected to find an event related to Report not deleted because of dependencies")
 }

--- a/test/e2e/report_dynamic_input_data_test.go
+++ b/test/e2e/report_dynamic_input_data_test.go
@@ -228,7 +228,7 @@ func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFram
 			Expression: "*/1 * * * *",
 		},
 	}
-	var foundOnce = false
+	var foundOnce bool
 	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
 	// If a subReport is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
 	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.

--- a/test/e2e/report_static_input_data_test.go
+++ b/test/e2e/report_static_input_data_test.go
@@ -355,7 +355,7 @@ func testReportsProduceCorrectDataForInput(
 				t.Parallel()
 			}
 
-			report := testReportingFramework.NewSimpleReport(test.name, test.queryName, nil, &reportStart, &reportEnd)
+			report := testReportingFramework.NewSimpleReport(test.name, test.queryName, nil, &reportStart, &reportEnd, nil)
 
 			reportRunTimeout := 10 * time.Minute
 			t.Logf("creating report %s and waiting %s to finish", report.Name, reportRunTimeout)

--- a/test/reportingframework/report.go
+++ b/test/reportingframework/report.go
@@ -32,7 +32,7 @@ func (rf *ReportingFramework) GetMeteringReport(name string) (*metering.Report, 
 	return rf.MeteringClient.Reports(rf.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (rf *ReportingFramework) NewSimpleReport(name, queryName string, schedule *metering.ReportSchedule, reportingStart, reportingEnd *time.Time) *metering.Report {
+func (rf *ReportingFramework) NewSimpleReport(name, queryName string, schedule *metering.ReportSchedule, reportingStart, reportingEnd *time.Time, expiration *metav1.Duration) *metering.Report {
 	var start, end *metav1.Time
 	if reportingStart != nil {
 		start = &metav1.Time{Time: *reportingStart}
@@ -50,6 +50,7 @@ func (rf *ReportingFramework) NewSimpleReport(name, queryName string, schedule *
 			Schedule:       schedule,
 			ReportingStart: start,
 			ReportingEnd:   end,
+			Expiration:     expiration,
 		},
 	}
 }

--- a/test/testhelpers/helpers.go
+++ b/test/testhelpers/helpers.go
@@ -24,7 +24,19 @@ import (
 )
 
 // NewReport creates a mock report used for testing purposes.
-func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *time.Time, status metering.ReportStatus, schedule *metering.ReportSchedule, runImmediately bool, expiration *meta.Duration) *metering.Report {
+func NewReport(
+	name string,
+	namespace string,
+	testQueryName string,
+	inputs metering.ReportQueryInputValues,
+	reportStart *time.Time,
+	reportEnd *time.Time,
+	status metering.ReportStatus,
+	schedule *metering.ReportSchedule,
+	runImmediately bool,
+	expiration *meta.Duration,
+) *metering.Report {
+
 	var start, end *meta.Time
 	if reportStart != nil {
 		start = &meta.Time{Time: *reportStart}
@@ -39,6 +51,7 @@ func NewReport(name, namespace, testQueryName string, reportStart, reportEnd *ti
 		},
 		Spec: metering.ReportSpec{
 			QueryName:      testQueryName,
+			Inputs:         inputs,
 			ReportingStart: start,
 			ReportingEnd:   end,
 			Schedule:       schedule,


### PR DESCRIPTION
We need to test via e2e testing, the following situations:

- [X] Does a report with no dependencies with an expiration set, properly expire?
- [x] Does a report that is depended on by another report not get deleted despite reaching its expiration date?
~- [ ] Does a report that is depended on by a ReportQuery not get deleted despite reaching its expiration date?~
[We should add a test on the last item in another pass]
