### PR TITLE
test: Upgrade from metering version that contains the 4.5 many-to-many fix.

### DIFF
--- a/test/e2e/metering_upgrade_test.go
+++ b/test/e2e/metering_upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kube-reporting/metering-operator/test/deployframework"
 	"github.com/kube-reporting/metering-operator/test/reportingframework"
 	"github.com/kube-reporting/metering-operator/test/testhelpers"
 )
@@ -18,8 +19,9 @@ const (
 	// TODO: support upgrading from a custom registry image instead
 	// of defaulting to the redhat-operators CatalogSource and waiting
 	// for GA-ed channels to be exposed.
-	upgradeFromCatalogSource          = "redhat-operators"
+	upgradeFromCatalogSource          = "custom-metering-image"
 	upgradeFromCatalogSourceNamespace = "openshift-marketplace"
+	upgradeFromImage                  = "quay.io/tflannag/metering-index:4.5"
 )
 
 func testManualOLMUpgradeInstall(
@@ -57,6 +59,9 @@ func testManualOLMUpgradeInstall(
 
 	mc, err := testhelpers.DecodeMeteringConfigManifest(repoPath, testMeteringConfigManifestsPath, manifestFilename)
 	require.NoError(t, err, "failed to successfully decode the YAML MeteringConfig manifest")
+
+	_, err = deployframework.CreateCatalogSourceFromImage(df.Logger, df.OLMV1Alpha1Client, upgradeFromCatalogSource, upgradeFromCatalogSourceNamespace, upgradeFromImage)
+	require.NoError(t, err, "failed to create a custom catalogsource")
 
 	deployerCtx, err := df.NewDeployerCtx(
 		testFuncNamespace,


### PR DESCRIPTION
We're seeing consistent upgrade failures due to the 4.5 metering-ansible-operator version in the redhat-operators CatalogSource custom resource not containing the PVC-related many-to-many fix. As a result, upgrade tests will fail as the pre-upgrade tests are reporting errors due to metrics not being correctly important (namely due to the aforementioned many-to-many bug), but the actual upgrade and tests against that upgrade are succeeding.