### PR TITLE
hack: Fix array variable expansion in e2e.sh.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -18,7 +18,7 @@ function cleanup() {
         # Remove any testing labels that may have been added during tests
         echo "Removing any testing labels that were added to the cluster's nodes"
         nodes=( $(kubectl get nodes -l metering-node-testing-label="true" --no-headers | awk '{ print $1 }') )
-        for i in "${nodes[@]}"
+        for i in ${nodes[@]+"${nodes[@]}"}
         do
             kubectl label node "$i" metering-node-testing-label- 2>/dev/null
         done


### PR DESCRIPTION
I was seeing the following output pop up occasionally in CI runs:

```bash
The connection to the server api.ci-op-tf0ln7ck-1deb1.origin-ci-int-aws.dev.rhcloud.com:6443 was refused - did you specify the right host or port?
Removing namespaces with the 'name=metering-metering-testing-ns' label
No resources found
Removing any testing labels that were added to the cluster's nodes
No resources found.
hack/e2e.sh: line 11: nodes[@]: unbound variable
make: *** [e2e] Error 1
+ touch /tmp/shared/exit
```

We attempt to grab the list of nodes in a cluster and populate that list as an array:

```bash
        nodes=( $(kubectl get nodes -l metering-node-testing-label="true" --no-headers | awk '{ print $1 }') )
        for i in "${nodes[@]}"
        do
            kubectl label node "$i" metering-node-testing-label- 2>/dev/null
        done
```

This expansion was problematic, especially in the case pasted above where the cluster host was taken down, as we specify `set -u` at the top of the script which tells the bash shell to error on unset variables.

The proposed fix is outlined in these resources:
- https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
- https://gist.github.com/dimo414/2fb052d230654cc0c25e9e41a9651ebe