### PR TITLE
olm_deploy,test: Add tenancy to registry-related resources.

### DIFF
--- a/olm_deploy/manifests/deployment.yaml
+++ b/olm_deploy/manifests/deployment.yaml
@@ -4,15 +4,18 @@ metadata:
   name: metering-ansible-operator-registry
   labels:
     registry.operator.metering-ansible: "true"
+    tenant: ""
 spec:
   replicas: 1
   selector:
     matchLabels:
       registry.operator.metering-ansible: "true"
+      tenant: ""
   template:
     metadata:
       labels:
         registry.operator.metering-ansible: "true"
+        tenant: ""
       name: metering-ansible-operator-registry
     spec:
       initContainers:

--- a/olm_deploy/manifests/service.yaml
+++ b/olm_deploy/manifests/service.yaml
@@ -8,6 +8,7 @@ spec:
   type: ClusterIP
   selector:
     registry.operator.metering-ansible: "true"
+    tenant: ""
   ports:
   - name: grpc
     port: 50051


### PR DESCRIPTION
We're currently running into the problem where multiple metering e2e runs are conflicting with the registry-related resources we're spinning up for developers. In the case of the service object that gets created, we're only selecting on a single Pod label, and in the case where there's multiple registry deployments that all use the same label selector, we risk running e2e tests against a different version of metering than what we expected. This updates the static label selectors we use for the registry deployment and service, adding a `tenancy` label selector that we will populate at runtime after decoding the YAML manifest into a Go object.
