### PR TITLE
fix name - we build to reporting-operator binary not metering

### DIFF
--- a/cmd/reporting-operator/start.go
+++ b/cmd/reporting-operator/start.go
@@ -34,7 +34,7 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "metering",
+	Use:   "reporting-operator",
 	Short: "",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return cmd.Help()
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "starts the Metering operator",
+	Short: "starts the metering reporting operator",
 	Run:   startReporting,
 }
 


### PR DESCRIPTION
Current help indicated the command name was metering rather than reporting-operator which is the actual binary name