### PR TITLE
Dockerfile: Remove the inotify-tools yum package.

### DIFF
--- a/Dockerfile.metering-ansible-operator.okd
+++ b/Dockerfile.metering-ansible-operator.okd
@@ -6,7 +6,7 @@ FROM openshift/origin-cli:latest as cli
 FROM quay.io/openshift/origin-ansible-operator:4.6
 
 USER root
-RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools openssl" \
+RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which openssl" \
     && yum clean all && rm -rf /var/cache/yum/* \
     && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm  \
     && yum install --setopt=skip_missing_names_on_install=False -y \

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -8,7 +8,7 @@ FROM openshift/ose-ansible-operator:4.6
 USER root
 RUN set -x; \
     INSTALL_PKGS="curl bash ca-certificates \
-    less which inotify-tools tini \
+    less which tini \
     python-netaddr python2-botocore \
     python2-boto3 python2-openshift \
     python2-cryptography ansible openssl" \

--- a/Dockerfile.metering-ansible-operator.rhel8
+++ b/Dockerfile.metering-ansible-operator.rhel8
@@ -8,7 +8,7 @@ FROM openshift/ose-ansible-operator:4.6
 USER root
 RUN set -x; \
     INSTALL_PKGS="curl bash ca-certificates \
-    less which inotify-tools tini \
+    less which tini \
     python3-netaddr python3-botocore \
     python3-boto3 python3-openshift \
     python3-cryptography ansible openssl" \


### PR DESCRIPTION
This package was used to feed Ansible logs into the ansible sidecar container that was removed earlier this release cycle as the ansible-operator removed it from their base image (as inotify-tools isn't in UBI8).