### PR TITLE
Dockerfile: Remove the exec-entrypoint ansible-operator subcommand.

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -42,7 +42,7 @@ COPY manifests/deploy/openshift/olm/bundle /manifests
 
 USER 1001
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", "ansible", "--watches-file", "/opt/ansible/watches.yaml"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "--watches-file", "/opt/ansible/watches.yaml"]
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \

--- a/Dockerfile.metering-ansible-operator.rhel8
+++ b/Dockerfile.metering-ansible-operator.rhel8
@@ -32,7 +32,7 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", "ansible", "--watches-file", "/opt/ansible/watches.yaml"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "--watches-file", "/opt/ansible/watches.yaml"]
 
 USER 1001
 


### PR DESCRIPTION
It looks like the `exec-entrypoint` sub-command was removed from the ansible-operator during the 0.19.x release but a poor 4.6 rebase for ocp-operator-sdk resulted in that field still being used. Here is the updated version after that's been corrected downstream: https://github.com/openshift/ocp-release-operator-sdk/blob/master/release/ansible/bin/entrypoint#L4