### PR TITLE
hack,Makefile: Explicitly run any of the test/deployframework tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ e2e: $(DEPLOY_METERING_BIN_OUT)
 	hack/e2e.sh
 
 e2e-upgrade: $(DEPLOY_METERING_BIN_OUT)
-	EXTRA_TEST_FLAGS="-run TestMeteringUpgrades" ./hack/e2e.sh
+	$(MAKE) e2e EXTRA_TEST_FLAGS="-run TestMeteringUpgrades"
 
 e2e-local: reporting-operator-local metering-ansible-operator-docker-build
 	$(MAKE) e2e METERING_RUN_TESTS_LOCALLY=true METERING_OPERATOR_IMAGE_REPO=$(METERING_OPERATOR_IMAGE_REPO) METERING_OPERATOR_IMAGE_TAG=$(METERING_OPERATOR_IMAGE_TAG)

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -109,6 +109,12 @@ go test \
     ${EXTRA_TEST_FLAGS} \
     2>&1 | tee "$TEST_LOG_FILE_PATH" ; TEST_EXIT_CODE=${PIPESTATUS[0]}
 
+go test \
+    -timeout 30s \
+    -test.v \
+    "./test/deployframework" \
+    2>&1 | tee "$TEST_LOG_FILE_PATH" ; TEST_EXIT_CODE=${PIPESTATUS[0]}
+
 # if go-junit-report is installed, create a junit report also
 if command -v go-junit-report >/dev/null 2>&1; then
     go-junit-report < "$TEST_LOG_FILE_PATH" > "${TEST_JUNIT_REPORT_FILE_PATH}"


### PR DESCRIPTION
This test was being ignored as hack/e2e.sh was only running any top-level tests that were in the test/e2e directory.

There are probably cleaner ways to do this but they involve re-organizing the reportingframework/deployframework to be in the test/e2e path, or moving the second `go test ...` call to its own make target and letting the `make e2e` target call that make target so we ensure that we're running both of those tests in the openshift CI environment.

Closes #1379