### PR TITLE
Bug 1874652: Add the secretName property to the MeteringConfig CRD schema validation.

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/meteringconfig.crd.yaml
@@ -2050,6 +2050,13 @@ spec:
                                 type: string
                               username:
                                 type: string
+                              secretName:
+                                type: string
+                                description: |
+                                  secretName is a reference to an existing secret containing
+                                  the base64 encrypted username and password credentials that
+                                  will be used for hive metastore to authenticate to the database
+                                  instance metering is configured to use.
                           defaultFileFormat:
                             type: string
                           hadoopConfigSecretName:

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -2049,6 +2049,13 @@ spec:
                                 type: string
                               username:
                                 type: string
+                              secretName:
+                                type: string
+                                description: |
+                                  secretName is a reference to an existing secret containing
+                                  the base64 encrypted username and password credentials that
+                                  will be used for hive metastore to authenticate to the database
+                                  instance metering is configured to use.
                           defaultFileFormat:
                             type: string
                           hadoopConfigSecretName:

--- a/manifests/deploy/openshift/olm/bundle/4.6/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/meteringconfig.crd.yaml
@@ -2049,6 +2049,13 @@ spec:
                                 type: string
                               username:
                                 type: string
+                              secretName:
+                                type: string
+                                description: |
+                                  secretName is a reference to an existing secret containing
+                                  the base64 encrypted username and password credentials that
+                                  will be used for hive metastore to authenticate to the database
+                                  instance metering is configured to use.
                           defaultFileFormat:
                             type: string
                           hadoopConfigSecretName:

--- a/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
@@ -2049,6 +2049,13 @@ spec:
                                 type: string
                               username:
                                 type: string
+                              secretName:
+                                type: string
+                                description: |
+                                  secretName is a reference to an existing secret containing
+                                  the base64 encrypted username and password credentials that
+                                  will be used for hive metastore to authenticate to the database
+                                  instance metering is configured to use.
                           defaultFileFormat:
                             type: string
                           hadoopConfigSecretName:

--- a/manifests/deploy/upstream/olm/bundle/4.6/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/meteringconfig.crd.yaml
@@ -2049,6 +2049,13 @@ spec:
                                 type: string
                               username:
                                 type: string
+                              secretName:
+                                type: string
+                                description: |
+                                  secretName is a reference to an existing secret containing
+                                  the base64 encrypted username and password credentials that
+                                  will be used for hive metastore to authenticate to the database
+                                  instance metering is configured to use.
                           defaultFileFormat:
                             type: string
                           hadoopConfigSecretName:


### PR DESCRIPTION
The functionality for configuring the underlying Hive Metastore database to use a secret containing the username and password credentials for a mysql/postgresql instance was added early in the 4.6 release cycle so this isn't a regression from previous releases. When this feature was added, it looks like this field wasn't added as a property to the schema definition, which means that any user-provided MeteringConfig custom resource configuration that attempts to specify this secretName property will be rejected as it's considered an invalid schema definition (as the field is undefined) when using v1 CRDs.

These changes add the secretName property to the parent `db` object and runs `make metering-manifests` so the rendered YAML manifests are up-to-date.