### PR TITLE
Bug 1872425: Fix missing namespaces in the case where usage exists without request 

### DIFF
--- a/charts/openshift-metering/templates/openshift-reporting/report-queries/pod-cpu.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/report-queries/pod-cpu.yaml
@@ -371,13 +371,11 @@ spec:
       usage.pod_usage_cpu_core_seconds / capacity.total_cluster_capacity_cpu_core_seconds AS pod_cpu_usage_percent,
       request.pod_request_cpu_core_seconds / capacity.total_cluster_capacity_cpu_core_seconds AS pod_cpu_request_percent,
       capacity.total_cluster_capacity_cpu_core_seconds
-    FROM namespace_cpu_request as request
-    JOIN namespace_cpu_usage as usage
-      ON request.period_start = usage.period_start
-      AND request.period_end = usage.period_end
-      AND request.namespace = usage.namespace
+    FROM namespace_cpu_usage as usage
     JOIN cluster_cpu_capacity as capacity
-      ON capacity.period_start = request.period_start
-      AND capacity.period_end = request.period_end
-      AND capacity.period_start = usage.period_start
+      ON capacity.period_start = usage.period_start
       AND capacity.period_end = usage.period_end
+    LEFT JOIN namespace_cpu_request as request
+      ON usage.period_start = request.period_start
+      AND usage.period_end = request.period_end
+      AND usage.namespace = request.namespace

--- a/charts/openshift-metering/templates/openshift-reporting/report-queries/pod-memory.yaml
+++ b/charts/openshift-metering/templates/openshift-reporting/report-queries/pod-memory.yaml
@@ -371,13 +371,11 @@ spec:
       usage.pod_usage_memory_byte_seconds / capacity.total_cluster_capacity_memory_byte_seconds AS pod_memory_usage_percent,
       request.pod_request_memory_byte_seconds / capacity.total_cluster_capacity_memory_byte_seconds AS pod_memory_request_percent,
       capacity.total_cluster_capacity_memory_byte_seconds
-    FROM namespace_memory_request as request
-    JOIN namespace_memory_usage as usage
-      ON request.period_start = usage.period_start
-      AND request.period_end = usage.period_end
-      AND request.namespace = usage.namespace
+    FROM namespace_memory_usage as usage
     JOIN cluster_memory_capacity as capacity
-      ON capacity.period_start = request.period_start
-      AND capacity.period_end = request.period_end
-      AND capacity.period_start = usage.period_start
+      ON capacity.period_start = usage.period_start
       AND capacity.period_end = usage.period_end
+    LEFT JOIN namespace_memory_request as request
+      ON usage.period_start = request.period_start
+      AND usage.period_end = request.period_end
+      AND usage.namespace = request.namespace


### PR DESCRIPTION
This is a fix for Bug 1872425 where there were differences between the namespaces being listed between 2 namespace utilization reports. The discrepancy was caused by an improper JOIN which showed namespaces with usage but omitted namespaces without usage and request.