### PR TITLE
test/e2e: Fix the Prometheus store API endpoint

### DIFF
--- a/test/reportingframework/db.go
+++ b/test/reportingframework/db.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kube-reporting/metering-operator/pkg/operator/prestostore"
 )
 
-const prometheusDataSourceAPIEndpointPrefix = "/api/v1/datasources/prometheus/store/"
+const prometheusDataSourceAPIEndpointPrefix = "/api/v1/datasources/prometheus/store"
 
 // StoreDataSourceData is a reportingframework method responsible for making
 // the metering push API call to inject the list of @metrics prometheus metrics


### PR DESCRIPTION
Fix the trailing '/' delimiter in endpoint we build up to make POST requests against the reporting-operator API, injecting static json data into ReportDataSource database tables.

That trailing slash was problematic as we feed that variable into a fmt.Sprintf call in the form of `fmt.Sprintf("%s/%s/%s", ..., ..., ...)` which results in the following endpoint:
```
/api/v1/datasources/prometheus/store//metering-validhdfs-reportstaticinputdata
```

When we make the POST request to the API, we're getting back a 500 status code, indicating that the request body were sending may be empty. After some light investigation, it appears this is because of the endpoint we're passing to the helper function that wraps that POST call to the API.