### PR TITLE
Bug 1872080: Remove copy directive for the non-existent scripts directory

### DIFF
--- a/Dockerfile.metering-ansible-operator.rhel8
+++ b/Dockerfile.metering-ansible-operator.rhel8
@@ -27,7 +27,6 @@ ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering
 
 COPY images/metering-ansible-operator/roles/ ${HOME}/roles/
 COPY images/metering-ansible-operator/watches.yaml ${HOME}/watches.yaml
-COPY images/metering-ansible-operator/scripts ${HOME}/scripts
 COPY images/metering-ansible-operator/ansible.cfg /etc/ansible/ansible.cfg
 COPY charts/openshift-metering ${HELM_CHART_PATH}
 
@@ -38,8 +37,8 @@ ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", 
 USER 1001
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
-      io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
-      summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
-      io.openshift.tags="openshift" \
-      com.redhat.delivery.appregistry=true \
-      maintainer="<metering-team@redhat.com>"
+    io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+    summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+    io.openshift.tags="openshift" \
+    com.redhat.delivery.appregistry=true \
+    maintainer="<metering-team@redhat.com>"


### PR DESCRIPTION
Removes the COPY directive that attempts to copy the non-existent images/metering-ansible-operator/scripts path that was removed a couple of releases ago.