### PR TITLE
hack: Move the test/deployframework tests to the unit test script

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -109,12 +109,6 @@ go test \
     ${EXTRA_TEST_FLAGS} \
     2>&1 | tee "$TEST_LOG_FILE_PATH" ; TEST_EXIT_CODE=${PIPESTATUS[0]}
 
-go test \
-    -timeout 30s \
-    -test.v \
-    "./test/deployframework" \
-    2>&1 | tee "$TEST_LOG_FILE_PATH" ; TEST_EXIT_CODE=${PIPESTATUS[0]}
-
 # if go-junit-report is installed, create a junit report also
 if command -v go-junit-report >/dev/null 2>&1; then
     go-junit-report < "$TEST_LOG_FILE_PATH" > "${TEST_JUNIT_REPORT_FILE_PATH}"

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -13,8 +13,9 @@ TMP_DIR="$(mktemp -d)"
 trap "rm -rf $TMP_DIR" exit
 
 mkdir -p "$TEST_OUTPUT_DIR"
-go test -v -coverprofile="$COVERAGE_OUTFILE" ./pkg/... 2>&1 | tee "$TMP_DIR/metering-test-output.txt"
+go test -v -coverprofile="$COVERAGE_OUTFILE" ./test/deployframework/... ./pkg/... 2>&1 | tee "$TMP_DIR/metering-test-output.txt"
 if command -v go-junit-report >/dev/null 2>&1; then
     go-junit-report < "$TMP_DIR/metering-test-output.txt" > "${JUNIT_REPORT_OUTFILE}"
 fi
+
 go test -c -o bin/e2e-tests ./test/e2e


### PR DESCRIPTION
For now, the test/deployframework/... tests do not require a running cluster and can be moved outside of the e2e wrapper script into the list of paths the unit check is reponsible for running.

Fixes #1396