### PR TITLE
test/e2e: Reduce reporting-operator CPU requests and rename metering tests

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -161,7 +161,7 @@ func TestManualMeteringInstall(t *testing.T) {
 		MeteringConfigManifestFilename string
 	}{
 		{
-			Name:                      "InvalidHDFS-MissingStorageSpec",
+			Name:                      "HDFS-MissingStorageSpec",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
 			Skip:                      false,
@@ -180,7 +180,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "missing-storage.yaml",
 		},
 		{
-			Name:                      "ValidHDFS-ValidNodeSelector",
+			Name:                      "HDFS-ValidNodeSelector",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
 			// TODO: transistion this to a periodic test and
@@ -225,7 +225,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "node-selector-prometheus-importer-disabled.yaml",
 		},
 		{
-			Name:                      "ValidHDFS-ReportDynamicInputData",
+			Name:                      "HDFS-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
 			Skip:                      false,
@@ -249,7 +249,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-enabled.yaml",
 		},
 		{
-			Name:                      "ValidHDFS-ReportStaticInputData",
+			Name:                      "HDFS-ReportStaticInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
 			Skip:                      false,
@@ -281,7 +281,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-disabled.yaml",
 		},
 		{
-			Name:                      "ValidHDFS-MySQLDatabase",
+			Name:                      "HDFS-MySQLDatabase",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
 			// TODO: disable this for now as the mysql:5.7 image
@@ -346,10 +346,10 @@ func TestManualMeteringInstall(t *testing.T) {
 			MeteringConfigManifestFilename: "s3.yaml",
 		},
 		{
-			Name:                      "ValidateNFS-ReportDynamicInputData",
+			Name:                      "NFS-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
-			Skip:                      false,
+			Skip:                      !runAllInstallTests,
 			PreInstallFunc:            createNFSProvisioner,
 			InstallSubTests: []InstallTestCase{
 				{

--- a/test/e2e/manifests/meteringconfigs/nfs.yaml
+++ b/test/e2e/manifests/meteringconfigs/nfs.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       resources:
         requests:
-          cpu: 1
+          cpu: 500m
           memory: 250Mi
       config:
         logLevel: debug

--- a/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-disabled.yaml
+++ b/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-disabled.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       resources:
         requests:
-          cpu: 1
+          cpu: 500m
           memory: 250Mi
       config:
         logLevel: debug

--- a/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
+++ b/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       resources:
         requests:
-          cpu: 1
+          cpu: 500m
           memory: 250Mi
       config:
         logLevel: debug


### PR DESCRIPTION
With the migration to building the metering bundle and index images in CI, we needed to switch to a workflow that has smaller default AWS instance sizes than what we're use to running in CI, even when machine autoscaling has been enabled.

In order to schedule the reporting-operator Pods, we can limit the CPU requests which allows for the reporting-operator to fit inside of a recently scaled up machine.

This also renames some of the test/e2e/main_test.go test table names, which are used as a test namespace suffix as those names didn't make much sense in that context.