### PR TITLE
Bug 1881650: Ensure the volumeName label is not empty in the kube_persistentvolumeclaim_info metric

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -10,7 +10,7 @@ RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which inotify-tools ope
     && yum clean all && rm -rf /var/cache/yum/* \
     && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm  \
     && yum install --setopt=skip_missing_names_on_install=False -y \
-        $INSTALL_PKGS  \
+    $INSTALL_PKGS  \
     && yum clean all \
     && rm -rf /var/cache/yum
 
@@ -28,7 +28,7 @@ RUN ln -f -s /tini /usr/bin/tini
 # 1. botocore and boto3 are used by the aws-related modules (aws_s3)
 # 2. netaddr is needed to use the ipv4/ipv6 jinja filter
 # 3. cryptography is used by the openssl_* modules for TLS/authentication purposes
-RUN pip install --no-cache-dir --upgrade ansible~=2.9 openshift botocore boto3 cryptography netaddr
+RUN pip install --no-cache-dir --upgrade "ansible>=2.9,<2.10" openshift botocore boto3 cryptography netaddr
 
 ENV HOME /opt/ansible
 ENV HELM_CHART_PATH ${HOME}/charts/openshift-metering
@@ -46,7 +46,8 @@ USER 1001
 ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", "ansible", "--watches-file", "/opt/ansible/watches.yaml"]
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
-      io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
-      io.openshift.tags="openshift" \
-      com.redhat.delivery.appregistry=true \
-      maintainer="sd-operator-metering@redhat.com"
+    io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+    summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+    io.openshift.tags="openshift" \
+    com.redhat.delivery.appregistry=true \
+    maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.metering-ansible-operator.rhel
+++ b/Dockerfile.metering-ansible-operator.rhel
@@ -38,7 +38,8 @@ ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "exec-entrypoint", 
 USER 1001
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
-      io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
-      io.openshift.tags="openshift" \
-      com.redhat.delivery.appregistry=true \
-      maintainer="sd-operator-metering@redhat.com"
+    io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+    summary="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \
+    io.openshift.tags="openshift" \
+    com.redhat.delivery.appregistry=true \
+    maintainer="<metering-team@redhat.com>"

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -197,7 +197,7 @@ openshift-reporting:
             spec:
               prometheusMetricsImporter:
                 query: |
-                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+                  max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info{volumename!=""}) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
           - name: persistentvolumeclaim-usage-bytes
             spec:
               prometheusMetricsImporter:


### PR DESCRIPTION
Fix the `persistentvolumeclaim-request-bytes` ReportDataSource promQL query to ensure that the `volumeName` label is not empty. Otherwise, we risk a many-to-many error when joining the two metric series.