### PR TITLE
Updating ose-metering-ansible-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.metering-ansible-operator.rhel8
+++ b/Dockerfile.metering-ansible-operator.rhel8
@@ -1,9 +1,9 @@
 # need the helm-cli from the helm image
-FROM registry.svc.ci.openshift.org/ocp/4.6:metering-helm as helm
+FROM registry.svc.ci.openshift.org/ocp/4.7:metering-helm AS helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli as cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli AS cli
 # real base
-FROM registry.svc.ci.openshift.org/ocp/4.6:ansible-operator
+FROM registry.svc.ci.openshift.org/ocp/4.7:ansible-operator
 
 USER root
 RUN set -x; \


### PR DESCRIPTION
Updating ose-metering-ansible-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-metering-ansible-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
