### PR TITLE
Updating ose-metering-reporting-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.reporting-operator.rhel
+++ b/Dockerfile.reporting-operator.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS build
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS build
 
 COPY . /go/src/github.com/kube-reporting/metering-operator
 WORKDIR /go/src/github.com/kube-reporting/metering-operator
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/kube-reporting/metering-operator
 ENV GOCACHE='/tmp'
 RUN make reporting-operator-bin RUN_UPDATE_CODEGEN=false CHECK_GO_FILES=false
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 RUN yum install --setopt=skip_missing_names_on_install=False -y \
         ca-certificates bash


### PR DESCRIPTION
Updating ose-metering-reporting-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-metering-reporting-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.