### PR TITLE
Hive conf changes

### DIFF
--- a/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
+++ b/charts/openshift-metering/templates/hadoop/hadoop-scripts.yaml
@@ -9,7 +9,11 @@ data:
     cp -v -L -r -f /hadoop-starting-config/* /hadoop-config/
     cd /hadoop-config/
     faq '.configuration.property+=[{name: ("fs.azure.account.key." + env.AZURE_STORAGE_ACCOUNT_NAME + ".blob.core.windows.net"), value: env.AZURE_SECRET_ACCESS_KEY }]' core-site.xml > core-site.xml.temp
-    cp core-site.xml.temp core-site.xml
+    mv -f core-site.xml.temp core-site.xml
+    faq '.configuration.property+=[{name: ("hadoop.proxyuser.hadoop.hosts"), value: ("*")}]' core-site.xml > core-site.xml.temp
+    mv -f core-site.xml.temp core-site.xml
+    faq '.configuration.property+=[{name: ("hadoop.proxyuser.hadoop.groups"), value: ("*")}]' core-site.xml > core-site.xml.temp
+    mv -f core-site.xml.temp core-site.xml
     if [ -a /gcs-json/gcs-service-account.json ]; then
       faq '.configuration.property+=[{name: "fs.gs.auth.service.account.json.keyfile" , value: "/gcs-json/gcs-service-account.json" }]' core-site.xml > core-site.xml.temp.temp
       cp core-site.xml.temp.temp core-site.xml

--- a/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
@@ -107,6 +107,6 @@ data:
     export HIVE_LOGLEVEL="${HIVE_LOGLEVEL:-INFO}"
     export HADOOP_OPTS="${HADOOP_OPTS} ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"
     export HIVE_METASTORE_HADOOP_OPTS=" -Dhive.log.level=${HIVE_LOGLEVEL} "
-    export HIVE_OPTS="${HIVE_OPTS} --hiveconf hive.root.logger=${HIVE_LOGLEVEL},console "
+    export HIVE_OPTS="${HIVE_OPTS} "
 
     exec $@


### PR DESCRIPTION
As a test to fix Bug 1798741 we are trying switch Hadoop to the latest on the 3.3 branch and thus we also need a more recent Hive. With the latest 3.3.1 branch Hadoop, we pick up the bug fix for this issue: https://issues.apache.org/jira/browse/HADOOP-13230 which we hope solves the bucket cleanup issue we see in BZ 1798741.

This PR changes `hadoop-config/core-site.xml` and Hive startup flags for log specification for these newer versions of Hadoop and Hive.
