### PR TITLE
Bug 1890741: Fix the path to the CA trust bundle ConfigMap

### DIFF
--- a/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
+++ b/charts/openshift-metering/templates/reporting-operator/reporting-operator-deployment.yaml
@@ -386,8 +386,8 @@ spec:
           subPath: token
 {{- end }}
 {{- if and .Values.networking.useGlobalProxyNetworking .Values.networking.proxy.config.trusted_ca_bundle }}
-        - mountPath: /etc/pki/ca-trust/extracted/pem
-          name: reporting-operator-trusted-ca-bundle
+        - name: reporting-operator-trusted-ca-bundle
+          mountPath: /etc/pki/ca-trust/extracted/pem
           readOnly: true
 {{- end }}
 {{- if $operatorValues.spec.authProxy.enabled }}
@@ -454,8 +454,8 @@ spec:
           mountPath: /var/run/configmaps/service-ca-bundle
           readOnly: true
 {{- if and .Values.networking.useGlobalProxyNetworking .Values.networking.proxy.config.trusted_ca_bundle }}
-        - mountPath: /etc/pki/ca-trust/extracted/pem
-          name: reporting-operator-trusted-ca-bundle
+        - name: reporting-operator-trusted-ca-bundle
+          mountPath: /etc/pki/ca-trust/extracted/pem
           readOnly: true
 {{- end }}
 {{- if $operatorValues.spec.config.tls.api.enabled }}
@@ -478,7 +478,7 @@ spec:
           name: reporting-operator-trusted-ca-bundle
           items:
           - key: ca-bundle.crt
-            path: ca-bundle.crt
+            path: tls-ca-bundle.pem
 {{- end }}
       - name: reporting-operator-service-ca-bundle
         configMap:


### PR DESCRIPTION

# Overview of Changes

Update the charts/openshift-metering reporting-operator Deployment object, ensuring that the correct ConfigMap path is specified when the user CA bundle is being injected into the containers.

Going through the [certificate injection using Operators documentation](https://docs.openshift.com/container-platform/4.5/networking/configuring-a-custom-pki.html), we can see that the required key is `ca-bundle.crt` and the required path name is `tls-ca-bundle.pem`.

Before, and not using the required path name, resulted in the following invalid symbolic links being produced in the reporting-operator container(s):

```bash
bash-4.2$ ls -alt /etc/pki/tls
total 12
drwxr-xr-x. 1 root root    21 Sep 18 17:13 ..
drwxr-xr-x. 5 root root    81 Sep 18 17:12 .
lrwxrwxrwx. 1 root root    49 Sep 18 17:12 cert.pem -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
...
bash-4.2$ cat /etc/pki/tls/cert.pem
cat: /etc/pki/tls/cert.pem: No such file or directory
bash-4.2$

bash-4.2$ ls -alt /etc/pki/ca-trust/extracted/pem/
total 0
drwxrwsrwx. 3 root 1000600000 80 Oct 22 19:37 .
drwxr-sr-x. 2 root 1000600000 27 Oct 22 19:37 ..2020_10_22_19_37_25.110890324
lrwxrwxrwx. 1 root root       31 Oct 22 19:37 ..data -> ..2020_10_22_19_37_25.110890324
lrwxrwxrwx. 1 root root       20 Oct 22 19:37 ca-bundle.crt -> ..data/ca-bundle.crt
drwxr-xr-x. 5 root root       58 Sep 18 17:12 ..
bash-4.2$
```

Here, we can see that while a symbolic link has been established, it's referencing a file that does not exist. If we instead following the documentation linked above, correcting that path to the ConfigMap contents, that symbolic link is properly established.

## Reviewer Notes

- QE spun up a proxy-enabled 4.5 OCP cluster.
- The cluster/Proxy object was edit-ed to set a `spec.trustedCA` ConfigMap. That ConfigMap was manually created in the openshift-config namespace.
- Metering was installed using the redhat-operators metering-ocp 4.5 channel.
- Scaled the metering-operator Deployment to zero replicas.
- Directly edit-ed the reporting-operator Deployment, fixing the wrong path name to `tls-ca-bundle.pem`.
- Exec-ed into the newly built reporting-operator Pod. Verified that symbolic link has now been properly established and can successfully view the /etc/pki/ca-trusted/extracted/pem/tls-ca-bundle.pem contents.
- Validated that I was still able to generate and view Report results.