### PR TITLE
hack: Gather all ServiceAccount resources in the test metering namespace

### DIFF
--- a/hack/gather-test-install-artifacts.sh
+++ b/hack/gather-test-install-artifacts.sh
@@ -8,11 +8,15 @@ LOG_DIR="${LOG_DIR:=$PWD/must-gather}"
 POD_LOG_PATH=${POD_LOG_PATH:="${LOG_DIR}/pod_logs"}
 mkdir -p ${POD_LOG_PATH}/
 
+# General namespace resources
 resources=()
 resources+=(pods)
 resources+=(deployments)
 resources+=(statefulsets)
 resources+=(services)
+resources+=(serviceaccounts)
+
+# Metering-specific namespaced resources
 resources+=(hivetables)
 resources+=(prestotables)
 resources+=(storagelocations)


### PR DESCRIPTION
Updates the hack/gather-test-install-artifacts.sh bash script, adding the ServiceAccount resources to the namespace-scoped list of resources we're interested in gathering for an individual metering test installation.