### PR TITLE
hack,test: Gather the OLM registry resources during e2e runs

### DIFF
--- a/hack/gather-registry-artifacts.sh
+++ b/hack/gather-registry-artifacts.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -eou pipefail
+set -x
+
+CATALOG_SOURCE_NAMESPACE=${CATALOG_SOURCE_NAMESPACE:=openshift-marketplace}
+CATALOG_SOURCE_NAME=${CATALOG_SOURCE_NAME:=redhat-operators}
+
+OUTPUT_DIRECTORY=${OUTPUT_DIRECTORY:=$(mktemp -ud)/resources}
+mkdir -p ${OUTPUT_DIRECTORY}
+
+oc -n ${CATALOG_SOURCE_NAMESPACE} get catalogsources ${CATALOG_SOURCE_NAME} -o yaml > ${OUTPUT_DIRECTORY}/catalogsource.yaml
+oc -n ${CATALOG_SOURCE_NAMESPACE} get packagemanifests -l "catalog-namespace=${CATALOG_SOURCE_NAMESPACE},catalog=${CATALOG_SOURCE_NAME}" -o yaml > ${OUTPUT_DIRECTORY}/packagemanifests.yaml


### PR DESCRIPTION
Adds a hack script that's responsible for gathering the CatalogSource and the corresponding PackageManifest custom resources that were used to deploy a custom version of Metering.

Updates the test helpers, adding a function that calls that bash script is responsible for setting the correct environment variables based on the user-provided e2e flags. The main_test.go e2e driver will run this gather registry artifacts test helper function when the e2e suite has been instantiated without the `--run-dev-setup` flag.