### PR TITLE
Migrate to using helm 3.x for templating resources

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -25,12 +25,8 @@ COPY hack/scl-operator-courier.sh /usr/local/bin/operator-courier
 RUN chmod +x /usr/local/bin/operator-courier
 
 COPY --from=cli /usr/bin/oc /usr/bin/
-RUN ln -s /usr/bin/oc /usr/bin/kubectl
-
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
-
-RUN helm init --client-only --skip-refresh && helm repo remove stable || true
-
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN go get -u github.com/jstemmer/go-junit-report
 
 ENV GOCACHE='/tmp'

--- a/charts/metering-ansible-operator/templates/olm/art.yaml
+++ b/charts/metering-ansible-operator/templates/olm/art.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.olm.skipARTPackage }}
+{{ if (default .Values.olm.skipARTPackage true) }}
 updates:
   # files are relative to art.yaml
   - file: "{MAJOR}.{MINOR}/meteringoperator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml"

--- a/hack/create-metering-manifests.sh
+++ b/hack/create-metering-manifests.sh
@@ -41,43 +41,43 @@ CHART="$ROOT_DIR/charts/metering-ansible-operator"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/role.yaml" \
+    -s "templates/operator/role.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-role.yaml"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/rolebinding.yaml" \
+    -s "templates/operator/rolebinding.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-rolebinding.yaml"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/clusterrole.yaml" \
+    -s "templates/operator/clusterrole.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-clusterrole.yaml"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/clusterrolebinding.yaml" \
+    -s "templates/operator/clusterrolebinding.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-clusterrolebinding.yaml"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/deployment.yaml" \
+    -s "templates/operator/deployment.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-deployment.yaml"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/service-account.yaml" \
+    -s "templates/operator/service-account.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-service-account.yaml"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/operator/meteringconfig.yaml" \
+    -s "templates/operator/meteringconfig.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/meteringconfig.yaml"
 
@@ -86,7 +86,7 @@ ${HELM_BIN} template "$CHART" \
 TMP_CSV="$TMPDIR/metering.clusterserviceversion.yaml"
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/clusterserviceversion.yaml" \
+    -s "templates/olm/clusterserviceversion.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$TMP_CSV"
 
@@ -120,7 +120,7 @@ mv -f "$TMP_CSV" "$CSV_MANIFEST_DESTINATION"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/package.yaml" \
+    -s "templates/olm/package.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$PACKAGE_MANIFEST_DESTINATION"
 
@@ -128,7 +128,7 @@ ${HELM_BIN} template "$CHART" \
 # output is empty before redirecting output to a file
 HELM_ART_PKG_OUTPUT="$(${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/art.yaml" \
+    -s "templates/olm/art.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed")"
 
 if [[ -z "$HELM_ART_PKG_OUTPUT" ]]; then
@@ -139,68 +139,68 @@ fi
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/image-references" \
+    -s "templates/olm/image-references" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$IMAGE_REFERENCES_MANIFEST_DESTINATION"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/subscription.yaml" \
+    -s "templates/olm/subscription.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$SUBSCRIPTION_MANIFEST_DESTINATION"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/catalogsource.yaml" \
+    -s "templates/olm/catalogsource.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$CATALOGSOURCE_MANIFEST_DESTINATION"
 
 ${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-    -x "templates/olm/operatorgroup.yaml" \
+    -s "templates/olm/operatorgroup.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$OPERATORGROUP_MANIFEST_DESTINATION"
 
 for CRD_DIR in "$METERING_OPERATOR_OUTPUT_DIR" "$CSV_BUNDLE_DIR"; do
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/meteringconfig.crd.yaml" \
+        -s "templates/crds/meteringconfig.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/meteringconfig.crd.yaml"
 
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/report.crd.yaml" \
+        -s "templates/crds/report.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/report.crd.yaml"
 
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/reportdatasource.crd.yaml" \
+        -s "templates/crds/reportdatasource.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/reportdatasource.crd.yaml"
 
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/reportquery.crd.yaml" \
+        -s "templates/crds/reportquery.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/reportquery.crd.yaml"
 
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/hive.crd.yaml" \
+        -s "templates/crds/hive.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/hive.crd.yaml"
 
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/prestotable.crd.yaml" \
+        -s "templates/crds/prestotable.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/prestotable.crd.yaml"
 
     ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
-        -x "templates/crds/storagelocation.crd.yaml" \
+        -s "templates/crds/storagelocation.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/storagelocation.crd.yaml"
 done

--- a/hack/create-metering-manifests.sh
+++ b/hack/create-metering-manifests.sh
@@ -39,43 +39,43 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf $TMPDIR' EXIT SIGINT
 CHART="$ROOT_DIR/charts/metering-ansible-operator"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/role.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-role.yaml"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/rolebinding.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-rolebinding.yaml"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/clusterrole.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-clusterrole.yaml"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/clusterrolebinding.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-clusterrolebinding.yaml"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/deployment.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-deployment.yaml"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/service-account.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$METERING_OPERATOR_OUTPUT_DIR/metering-operator-service-account.yaml"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/operator/meteringconfig.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
@@ -84,7 +84,7 @@ helm template "$CHART" \
 # Render the CSV to a temporary location, so we can add the version into it's
 # filename after it's been rendered
 TMP_CSV="$TMPDIR/metering.clusterserviceversion.yaml"
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/clusterserviceversion.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
@@ -118,15 +118,15 @@ mkdir -p "$CSV_BUNDLE_DIR"
 # Rename the file with it's version in it, and move it to the final destination
 mv -f "$TMP_CSV" "$CSV_MANIFEST_DESTINATION"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/package.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$PACKAGE_MANIFEST_DESTINATION"
 
-# We don't always want to generate an ART package, so check if the helm template
+# We don't always want to generate an ART package, so check if the ${HELM_BIN} template
 # output is empty before redirecting output to a file
-HELM_ART_PKG_OUTPUT="$(helm template "$CHART" \
+HELM_ART_PKG_OUTPUT="$(${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/art.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed")"
@@ -137,68 +137,68 @@ else
     echo "$HELM_ART_PKG_OUTPUT" > "$ART_CONFIG_DESTINATION"
 fi
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/image-references" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$IMAGE_REFERENCES_MANIFEST_DESTINATION"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/subscription.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$SUBSCRIPTION_MANIFEST_DESTINATION"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/catalogsource.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$CATALOGSOURCE_MANIFEST_DESTINATION"
 
-helm template "$CHART" \
+${HELM_BIN} template "$CHART" \
     ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
     -x "templates/olm/operatorgroup.yaml" \
     | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
     > "$OPERATORGROUP_MANIFEST_DESTINATION"
 
 for CRD_DIR in "$METERING_OPERATOR_OUTPUT_DIR" "$CSV_BUNDLE_DIR"; do
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/meteringconfig.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/meteringconfig.crd.yaml"
 
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/report.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/report.crd.yaml"
 
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/reportdatasource.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/reportdatasource.crd.yaml"
 
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/reportquery.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/reportquery.crd.yaml"
 
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/hive.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/hive.crd.yaml"
 
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/prestotable.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \
         > "$CRD_DIR/prestotable.crd.yaml"
 
-    helm template "$CHART" \
+    ${HELM_BIN} template "$CHART" \
         ${VALUES_ARGS[@]+"${VALUES_ARGS[@]}"} \
         -x "templates/crds/storagelocation.crd.yaml" \
         | sed -f "$ROOT_DIR/hack/remove-helm-template-header.sed" \

--- a/hack/generate-metering-manifests.sh
+++ b/hack/generate-metering-manifests.sh
@@ -8,10 +8,10 @@ TMPDIR="$(mktemp -d)"
 trap "rm -rf $TMPDIR" EXIT
 
 msg "Generating Openshift Manifests"
-
 "$ROOT_DIR/hack/create-metering-manifests.sh" \
     "$OCP_INSTALLER_MANIFESTS_DIR" \
     "$OCP_OLM_MANIFESTS_DIR" \
+    "$ROOT_DIR/charts/metering-ansible-operator/values.yaml"
 
 msg "Generating Upstream Manifests"
 "$ROOT_DIR/hack/create-metering-manifests.sh" \

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -45,6 +45,7 @@ METERING_NAMESPACE=$(sanetize_namespace "${METERING_NAMESPACE:-metering}")
 : "${METERING_INSTALL_CLUSTERROLEBINDING:=true}"
 
 : "${FAQ_BIN:=faq}"
+: "${HELM_BIN:=helm}"
 : "${DEPLOY_REPORTING_OPERATOR_LOCAL:=false}"
 : "${DEPLOY_METERING_OPERATOR_LOCAL:=false}"
 : "${REPORTING_OPERATOR_PID_FILE:="/tmp/${METERING_NAMESPACE}-reporting-operator.pid"}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/deploy_resources.yml
@@ -2,7 +2,7 @@
 
 - name: Helm template resources
   block:
-  - shell: helm template {{ meteringconfig_chart_path }} --name {{ meta.name }} --namespace {{ meta.namespace}} -x {{ resource.template_file }} -f {{ values_file }}
+  - shell: helm template {{ meteringconfig_chart_path }} --namespace {{ meta.namespace}} -s {{ resource.template_file }} -f {{ values_file }}
     loop: "{{ resources }}"
     loop_control:
       loop_var: resource

--- a/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
@@ -278,4 +278,3 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
-

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -50,4 +50,3 @@ rules:
     - clusterroles
     verbs:
     - '*'
-

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrolebinding.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-clusterrolebinding.yaml
@@ -10,4 +10,3 @@ subjects:
 - kind: ServiceAccount
   name: metering-operator
   namespace: placeholder
-

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
@@ -71,11 +71,9 @@ spec:
           requests:
             cpu: 750m
             memory: 400Mi
-
       volumes:
         - name: runner
           emptyDir: {}
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       serviceAccount: metering-operator
-

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-role.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-role.yaml
@@ -109,4 +109,3 @@ rules:
     - routes
     verbs:
     - '*'
-

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-rolebinding.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-rolebinding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: metering-operator
-

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-service-account.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-service-account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: metering-operator
-

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.crd.yaml
@@ -2837,4 +2837,3 @@ spec:
                             type: string
                           tag:
                             type: string
-

--- a/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/meteringconfig.yaml
@@ -3,4 +3,3 @@ kind: MeteringConfig
 metadata:
   name: operator-metering
 spec: {}
-

--- a/manifests/deploy/openshift/metering-ansible-operator/prestotable.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/prestotable.crd.yaml
@@ -151,4 +151,3 @@ spec:
                       type: string
                     type:
                       type: string
-

--- a/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/report.crd.yaml
@@ -315,4 +315,3 @@ spec:
                       - "True"
                       - "False"
                       - "Unknown"
-

--- a/manifests/deploy/openshift/metering-ansible-operator/reportdatasource.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/reportdatasource.crd.yaml
@@ -177,4 +177,3 @@ spec:
                   newestImportedMetricTime:
                     type: string
                     format: date-time
-

--- a/manifests/deploy/openshift/metering-ansible-operator/reportquery.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/reportquery.crd.yaml
@@ -148,4 +148,3 @@ spec:
                 type: string
                 pattern: '[Ss][Ee][Ll][Ee][Cc][Tt]\s'
                 minLength: 1
-

--- a/manifests/deploy/openshift/metering-ansible-operator/storagelocation.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/storagelocation.crd.yaml
@@ -93,4 +93,3 @@ spec:
                     type: string
                   location:
                     type: string
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/hive.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/hive.crd.yaml
@@ -278,4 +278,3 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/image-references
+++ b/manifests/deploy/openshift/olm/bundle/4.7/image-references
@@ -31,4 +31,3 @@ spec:
       kind: DockerImage
       name: quay.io/openshift/origin-oauth-proxy:4.7
     name: oauth-proxy
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/meteringconfig.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/meteringconfig.crd.yaml
@@ -2837,4 +2837,3 @@ spec:
                             type: string
                           tag:
                             type: string
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -207,7 +207,7 @@ metadata:
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.7
-    createdAt: 2019-01-01T11:59:59Z
+    createdAt: "2019-01-01T11:59:59Z"
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
     operatorframework.io/cluster-monitoring: "true"
@@ -215,7 +215,6 @@ metadata:
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'
     repository: https://github.com/kube-reporting/metering-operator
     support: Red Hat, Inc.
-
 spec:
   displayName: Metering
   description: |
@@ -262,25 +261,19 @@ spec:
   maintainers:
     - email: sd-operator-metering@redhat.com
       name: Red Hat
-
   links:
     - name: Documentation
       url: https://docs.openshift.com/container-platform/4.7/metering/metering-about-metering.html
-
   provider:
     name: Red Hat
-
   icon:
     - base64data: PHN2ZyBpZD0iYmI5OWY3NGMtM2VkOS00OWU2LWE0OWQtNDI3ODA5NWU5ZWI4IiBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDcyMS4xNSA3MjEuMTUiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuYjdmMDIwYzgtMjFkMS00NWVmLWE0NTktNzJhNWE0MmE5MjJlIHsKICAgICAgICBmaWxsOiAjZGIzOTI3OwogICAgICB9CgogICAgICAuZjM0NTNmYmYtODk1My00NjE3LWJlNTEtMWZkZDJiOTdiMDBlIHsKICAgICAgICBmaWxsOiAjY2IzNjI4OwogICAgICB9CgogICAgICAuYjFhNGZjNTMtYWFlNS00ZWI5LTliN2ItYTAxYmMxYTU0ZmFjIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICB9CgogICAgICAuYTc4NTliZDQtYjA1My00YzVmLTk5MGQtYzRmNzFkNDgwZTM4IHsKICAgICAgICBmaWxsOiAjZTNlM2UyOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8dGl0bGU+UHJvZHVjdF9JY29uLVJlZF9IYXQtTWV0ZXJpbmctUkdCPC90aXRsZT4KICA8Y2lyY2xlIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIGN4PSIzNjAuNTc1IiBjeT0iMzYwLjU3NSIgcj0iMzU4LjU3NiIvPgogIDxwYXRoIGNsYXNzPSJmMzQ1M2ZiZi04OTUzLTQ2MTctYmU1MS0xZmRkMmI5N2IwMGUiIGQ9Ik02MTUuNTMsMTA4LjkxNiwxMDguNDY0LDYxNS45ODNjMTQwLjE0MywxMzguNjE3LDM2Ni4xMTEsMTM4LjE2NCw1MDUuNjcxLTEuNFM3NTQuMTQ5LDI0OS4wNTksNjE1LjUzLDEwOC45MTZaIi8+CiAgPHBhdGggY2xhc3M9ImIxYTRmYzUzLWFhZTUtNGViOS05YjdiLWEwMWJjMWE1NGZhYyIgZD0iTTM3MC4xMzEsMTYzLjkzMmwxNzAuMyw5OC4zMjFWNDU4LjlsLTE3MC4zLDk4LjMyMUwxOTkuODMzLDQ1OC45VjI2Mi4yNTNsMTcwLjMtOTguMzIxbTAtMjMuMDk0LTEwLDUuNzczLTE3MC4zLDk4LjMyMi0xMCw1Ljc3M1Y0NzAuNDQ0bDEwLDUuNzczLDE3MC4zLDk4LjMyMiwxMCw1Ljc3MywxMC01Ljc3MywxNzAuMy05OC4zMjIsMTAtNS43NzNWMjUwLjcwNmwtMTAtNS43NzMtMTcwLjMtOTguMzIyLTEwLTUuNzczWiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiMWE0ZmM1My1hYWU1LTRlYjktOWI3Yi1hMDFiYzFhNTRmYWMiIHBvaW50cz0iMzU0LjE2NyA1MTMuMjQyIDIyNi43NjggNDM5LjY4OCAyMjYuNzY4IDI5NS4yMjQgMzU0LjE2NyAzNjguNzc4IDM1NC4xNjcgNTEzLjI0MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJhNzg1OWJkNC1iMDUzLTRjNWYtOTkwZC1jNGY3MWQ0ODBlMzgiIHBvaW50cz0iMzg2LjAxNyA1MTMuMjQyIDUxMy40MTYgNDM5LjY4OCA1MTMuNDE2IDI5NS4yMjQgMzg2LjAxNyAzNjguNzc4IDM4Ni4wMTcgNTEzLjI0MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiMWE0ZmM1My1hYWU1LTRlYjktOWI3Yi1hMDFiYzFhNTRmYWMiIHBvaW50cz0iMjQyLjY5MyAyNjcuOTcyIDM3MC4wOTIgMTk0LjQxOCA0OTcuNDkxIDI2Ny45NzIgMzcwLjA5MiAzNDEuNTI2IDI0Mi42OTMgMjY3Ljk3MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMjg2LjQ4OCAyNjkuMTM0IDI5My4zMDQgMjY0LjczMiAzNzMuOTAxIDMxMS4yNjUgMzY3LjA4NSAzMTUuNjY3IDI4Ni40ODggMjY5LjEzNCIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzAwLjIyNSAyNjkuMTM0IDM0NS43OTIgMjQyLjA3NCAzNjAuNTgxIDI1MC42OTkgMzE1LjAxNCAyNzcuNzU4IDMwMC4yMjUgMjY5LjEzNCIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzIzLjAwOCAyODIuMTYgMzk4LjU2MyAyMzUuODY2IDQxMy4zNTIgMjQ0LjQ5IDMzNy43OTggMjkwLjc4NSAzMjMuMDA4IDI4Mi4xNiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzQ1Ljc5MiAyOTUuMTg3IDQwNi44NCAyNTkuMzQ3IDQyMS42MyAyNjcuOTcyIDM2MC41ODEgMzAzLjgxMSAzNDUuNzkyIDI5NS4xODciLz4KPC9zdmc+Cg==
       mediatype: image/svg+xml
-
   labels:
     operator-metering: "true"
-
   selector:
     matchLabels:
       operator-metering: "true"
-
   installModes:
   - supported: true
     type: OwnNamespace
@@ -290,7 +283,6 @@ spec:
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
-
   install:
     strategy: deployment
     spec:
@@ -344,7 +336,6 @@ spec:
             - clusterroles
             verbs:
             - '*'
-
       permissions:
         - serviceAccountName: metering-operator
           rules:
@@ -454,7 +445,6 @@ spec:
             - routes
             verbs:
             - '*'
-
       deployments:
         - name: metering-operator
           spec:
@@ -524,7 +514,6 @@ spec:
                     requests:
                       cpu: 750m
                       memory: 400Mi
-
                 volumes:
                   - name: runner
                     emptyDir: {}
@@ -574,4 +563,3 @@ spec:
       kind: HiveTable
       name: hivetables.metering.openshift.io
       version: v1
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/prestotable.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/prestotable.crd.yaml
@@ -151,4 +151,3 @@ spec:
                       type: string
                     type:
                       type: string
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/report.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/report.crd.yaml
@@ -315,4 +315,3 @@ spec:
                       - "True"
                       - "False"
                       - "Unknown"
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/reportdatasource.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/reportdatasource.crd.yaml
@@ -177,4 +177,3 @@ spec:
                   newestImportedMetricTime:
                     type: string
                     format: date-time
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/reportquery.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/reportquery.crd.yaml
@@ -148,4 +148,3 @@ spec:
                 type: string
                 pattern: '[Ss][Ee][Ll][Ee][Cc][Tt]\s'
                 minLength: 1
-

--- a/manifests/deploy/openshift/olm/bundle/4.7/storagelocation.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/storagelocation.crd.yaml
@@ -93,4 +93,3 @@ spec:
                     type: string
                   location:
                     type: string
-

--- a/manifests/deploy/openshift/olm/bundle/metering.package.yaml
+++ b/manifests/deploy/openshift/olm/bundle/metering.package.yaml
@@ -2,4 +2,3 @@ packageName: metering-ocp
 channels:
 - currentCSV: metering-operator.v4.7.0
   name: "4.7"
-

--- a/manifests/deploy/openshift/olm/metering.catalogsource.yaml
+++ b/manifests/deploy/openshift/olm/metering.catalogsource.yaml
@@ -8,4 +8,3 @@ spec:
   sourceType: internal
   publisher: metering
   displayName: Metering Operator Testing
-

--- a/manifests/deploy/openshift/olm/metering.operatorgroup.yaml
+++ b/manifests/deploy/openshift/olm/metering.operatorgroup.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-metering
-

--- a/manifests/deploy/openshift/olm/metering.subscription.yaml
+++ b/manifests/deploy/openshift/olm/metering.subscription.yaml
@@ -8,4 +8,3 @@ spec:
   name: metering-ocp
   source: metering-ocp-dev
   sourceNamespace: openshift-metering
-

--- a/manifests/deploy/upstream/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/hive.crd.yaml
@@ -278,4 +278,3 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
-

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrole.yaml
@@ -50,4 +50,3 @@ rules:
     - clusterroles
     verbs:
     - '*'
-

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrolebinding.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-clusterrolebinding.yaml
@@ -10,4 +10,3 @@ subjects:
 - kind: ServiceAccount
   name: metering-operator
   namespace: placeholder
-

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
@@ -69,11 +69,9 @@ spec:
           requests:
             cpu: 750m
             memory: 400Mi
-
       volumes:
         - name: runner
           emptyDir: {}
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       serviceAccount: metering-operator
-

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-role.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-role.yaml
@@ -109,4 +109,3 @@ rules:
     - routes
     verbs:
     - '*'
-

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-rolebinding.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-rolebinding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: metering-operator
-

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-service-account.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-service-account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: metering-operator
-

--- a/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.crd.yaml
@@ -2837,4 +2837,3 @@ spec:
                             type: string
                           tag:
                             type: string
-

--- a/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/meteringconfig.yaml
@@ -3,4 +3,3 @@ kind: MeteringConfig
 metadata:
   name: operator-metering
 spec: {}
-

--- a/manifests/deploy/upstream/metering-ansible-operator/prestotable.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/prestotable.crd.yaml
@@ -151,4 +151,3 @@ spec:
                       type: string
                     type:
                       type: string
-

--- a/manifests/deploy/upstream/metering-ansible-operator/report.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/report.crd.yaml
@@ -315,4 +315,3 @@ spec:
                       - "True"
                       - "False"
                       - "Unknown"
-

--- a/manifests/deploy/upstream/metering-ansible-operator/reportdatasource.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/reportdatasource.crd.yaml
@@ -177,4 +177,3 @@ spec:
                   newestImportedMetricTime:
                     type: string
                     format: date-time
-

--- a/manifests/deploy/upstream/metering-ansible-operator/reportquery.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/reportquery.crd.yaml
@@ -148,4 +148,3 @@ spec:
                 type: string
                 pattern: '[Ss][Ee][Ll][Ee][Cc][Tt]\s'
                 minLength: 1
-

--- a/manifests/deploy/upstream/metering-ansible-operator/storagelocation.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/storagelocation.crd.yaml
@@ -93,4 +93,3 @@ spec:
                     type: string
                   location:
                     type: string
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/hive.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/hive.crd.yaml
@@ -278,4 +278,3 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/image-references
+++ b/manifests/deploy/upstream/olm/bundle/4.7/image-references
@@ -27,4 +27,3 @@ spec:
       kind: DockerImage
       name: quay.io/coreos/metering-ghostunnel:release-4.7
     name: ghostunnel
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/meteringconfig.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/meteringconfig.crd.yaml
@@ -2837,4 +2837,3 @@ spec:
                             type: string
                           tag:
                             type: string
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -207,7 +207,7 @@ metadata:
     categories: OpenShift Optional, Monitoring
     certified: "false"
     containerImage: quay.io/coreos/metering-ansible-operator:4.7
-    createdAt: 2019-01-01T11:59:59Z
+    createdAt: "2019-01-01T11:59:59Z"
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster
     operatorframework.io/cluster-monitoring: "true"
@@ -215,7 +215,6 @@ metadata:
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'
     repository: https://github.com/kube-reporting/metering-operator
     support: Red Hat, Inc.
-
 spec:
   displayName: Metering
   description: |
@@ -262,25 +261,19 @@ spec:
   maintainers:
     - email: sd-operator-metering@redhat.com
       name: Red Hat
-
   links:
     - name: Documentation
       url: https://github.com/kube-reporting/metering-operator/blob/master/Documentation/index.md
-
   provider:
     name: Red Hat
-
   icon:
     - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTQ2cHgiIGhlaWdodD0iMTQ2cHgiIHZpZXdCb3g9IjAgMCAxNDYgMTQ2IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPHRpdGxlPkFydGJvYXJkPC90aXRsZT4KICAgIDxnIGlkPSJBcnRib2FyZCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGNpcmNsZSBpZD0iT3ZhbCIgc3Ryb2tlPSIjNDA4MDkxIiBzdHJva2Utd2lkdGg9IjQiIGZpbGw9IiMzQTQxNEEiIGN4PSI3MyIgY3k9IjczIiByPSI1NSI+PC9jaXJjbGU+CiAgICAgICAgPGcgaWQ9Ikdyb3VwLTIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2LjAwMDAwMCwgNDYuMDAwMDAwKSI+CiAgICAgICAgICAgIDxwb2x5bGluZSBpZD0iUGF0aC0yIiBzdHJva2U9IiNGQkNCN0UiIHN0cm9rZS13aWR0aD0iNCIgcG9pbnRzPSI3MC4wNzM3MjA4IDEyLjM4OTIzODMgNTYuODk3NDczNCAyNy42NjQwMjM3IDM4LjA0NzM2NyAtNS4yNjg5NjQ4NmUtMTQgLTcuMTA1NDI3MzZlLTE1IDUzLjE3MjMyNjggMTEuMzkwODgyOCA1My4xNzIzMjY4IDM4LjA0NzM2NyAxNi4wMjE1IDU2Ljg5NzQ3MzQgNDIuNjIyODgwNCA3MC4wNzM3MjA4IDI3LjY2NDAyMzciPjwvcG9seWxpbmU+CiAgICAgICAgICAgIDxnIGlkPSJHcm91cCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNjYuMDAwMDAwLCA3LjAwMDAwMCkiIGZpbGw9IiNGQkNCN0UiPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTUsMTAgQzcuNzYxNDIzNzUsMTAgMTAsNy43NjE0MjM3NSAxMCw1IEMxMCwyLjIzODU3NjI1IDcuNzYxNDIzNzUsMCA1LDAgQzIuMjM4NTc2MjUsMCAwLDIuMjM4NTc2MjUgMCw1IEMwLDcuNzYxNDIzNzUgMi4yMzg1NzYyNSwxMCA1LDEwIFoiIGlkPSJPdmFsIj48L3BhdGg+CiAgICAgICAgICAgICAgICA8Y2lyY2xlIGlkPSJPdmFsIiBjeD0iNSIgY3k9IjIwIiByPSI1Ij48L2NpcmNsZT4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+
       mediatype: image/svg+xml
-
   labels:
     operator-metering: "true"
-
   selector:
     matchLabels:
       operator-metering: "true"
-
   installModes:
   - supported: true
     type: OwnNamespace
@@ -290,7 +283,6 @@ spec:
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
-
   install:
     strategy: deployment
     spec:
@@ -344,7 +336,6 @@ spec:
             - clusterroles
             verbs:
             - '*'
-
       permissions:
         - serviceAccountName: metering-operator
           rules:
@@ -454,7 +445,6 @@ spec:
             - routes
             verbs:
             - '*'
-
       deployments:
         - name: metering-operator
           spec:
@@ -522,7 +512,6 @@ spec:
                     requests:
                       cpu: 750m
                       memory: 400Mi
-
                 volumes:
                   - name: runner
                     emptyDir: {}
@@ -572,4 +561,3 @@ spec:
       kind: HiveTable
       name: hivetables.metering.openshift.io
       version: v1
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/prestotable.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/prestotable.crd.yaml
@@ -151,4 +151,3 @@ spec:
                       type: string
                     type:
                       type: string
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/report.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/report.crd.yaml
@@ -315,4 +315,3 @@ spec:
                       - "True"
                       - "False"
                       - "Unknown"
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/reportdatasource.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/reportdatasource.crd.yaml
@@ -177,4 +177,3 @@ spec:
                   newestImportedMetricTime:
                     type: string
                     format: date-time
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/reportquery.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/reportquery.crd.yaml
@@ -148,4 +148,3 @@ spec:
                 type: string
                 pattern: '[Ss][Ee][Ll][Ee][Cc][Tt]\s'
                 minLength: 1
-

--- a/manifests/deploy/upstream/olm/bundle/4.7/storagelocation.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/storagelocation.crd.yaml
@@ -93,4 +93,3 @@ spec:
                     type: string
                   location:
                     type: string
-

--- a/manifests/deploy/upstream/olm/bundle/metering.package.yaml
+++ b/manifests/deploy/upstream/olm/bundle/metering.package.yaml
@@ -2,4 +2,3 @@ packageName: metering-upstream
 channels:
 - currentCSV: metering-operator-upstream.v4.7.0
   name: "4.7"
-

--- a/manifests/deploy/upstream/olm/metering.catalogsource.yaml
+++ b/manifests/deploy/upstream/olm/metering.catalogsource.yaml
@@ -8,4 +8,3 @@ spec:
   sourceType: internal
   publisher: metering
   displayName: Metering Operator Testing
-

--- a/manifests/deploy/upstream/olm/metering.operatorgroup.yaml
+++ b/manifests/deploy/upstream/olm/metering.operatorgroup.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   targetNamespaces:
   - metering
-

--- a/manifests/deploy/upstream/olm/metering.subscription.yaml
+++ b/manifests/deploy/upstream/olm/metering.subscription.yaml
@@ -8,4 +8,3 @@ spec:
   name: metering-upstream
   source: metering-upstream-dev
   sourceNamespace: metering
-

--- a/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-disabled.yaml
+++ b/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-disabled.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       resources:
         requests:
-          cpu: 500m
+          cpu: 1
           memory: 250Mi
       config:
         logLevel: debug

--- a/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
+++ b/test/e2e/manifests/meteringconfigs/prometheus-metrics-importer-enabled.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       resources:
         requests:
-          cpu: 500m
+          cpu: 1
           memory: 250Mi
       config:
         logLevel: debug


### PR DESCRIPTION
## Overview

Updates the metering-operator repository to use helm 3.x for it's templating needs. We're currently using an out-of-date helm version (e.g. 2.8.x) and we're running into situations where updating dependencies is a pain due to limitations in the `glide` package manager. Ideally, we would move off of helm entirely and use something like Ansible templates or jsonnet, but this is a stop-gap in the meantime.

## Notable Changes

### Updating the metering-ansible-operator Ansible role

Update the `deploy_resources.yaml` task file, which is responsible for templating helm charts into YAML manifests so we can pass that to the `k8s` Ansible module.

This migration from helm 2.x to helm 3.x is fairly trivial as we only utilized helm for it's templating and nothing deployment (i.e. tiller) facing.

Note on the changed flags:
- The global `--name` flag was removed.
- The `--execute` (`-x`) was renamed to `--show-only` (`-s`) and the functionality remains the same.

### Updating the YAML manifest bash scripts

Update the `hack/generate-metering-manifest.sh` bash script and always specify a `values.yaml` file location.

Before, we supported multi-value file situations, but that makes handling potentially empty templated files more difficult in the child `hack/create-metering-manifests` script.

Updates the `hack/create-metering-manifests.sh` bash script for general changes needed to get helm 3.x working with the existing YAML manifests.

- Deflated the top-level parameter handled to just exit early if there are fewer parameters than we expect from the call site.
- Changes how we handle potentially empty templated files. Now, with the `--show-only` flag, any templated files that are empty results in an error. Before, the expected behavior was that we would still attempt to template, but if stdout was empty, don't redirect that output to a file.

A quick note on the testing that was done locally:
- Spun up metering using a custom-built helm image that contains the helm release-3.0 branch.
- Edited the local MeteringConfig custom resource, replacing the storage configuration, and changed some of the reporting-operator custom parameters.