### PR TITLE
test/e2e: Add a post-install test that ensures the Metering leader election ConfigMap is present

### DIFF
--- a/test/e2e/ensure_leader_election_configmap_is_created_test.go
+++ b/test/e2e/ensure_leader_election_configmap_is_created_test.go
@@ -1,0 +1,24 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-reporting/metering-operator/test/reportingframework"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TODO: change this name once metering has migrated to using
+// the ansible-operator v1.x version.
+const leaderElectionConfigMapName = "metering-operator-lock"
+
+// testLeaderElctionConfigMapIsCreated is reponsible for querying for the metering operator
+// leader election lock ConfigMap. Note: this implementation is subject to change based on the
+// ansible-operator v1 migration. Currently, a ConfigMap is created using the `POD_NAME` environment
+// variable exposed using the k8s downward API. In the ansible-operator 1.x world, leader election
+// is determined using controller runtime's implementation.
+func testLeaderElectionConfigMapIsCreated(t *testing.T, rf *reportingframework.ReportingFramework) {
+	_, err := rf.KubeClient.CoreV1().ConfigMaps(rf.Namespace).Get(context.Background(), leaderElectionConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to query for the %s leader election ConfigMap", leaderElectionConfigMapName)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -278,18 +278,20 @@ func TestManualMeteringInstall(t *testing.T) {
 					TestFunc: testLeaderElectionEventIsCreated,
 				},
 				{
+					Name:     "testLeaderElectionConfigMapIsCreated",
+					TestFunc: testLeaderElectionConfigMapIsCreated,
+				},
+				{
 					Name:     "testFailedPrometheusQueryEvents",
 					TestFunc: testFailedPrometheusQueryEvents,
 				},
 				{
-					Name:         "testReportIsDeletedWhenNoDeps",
-					TestFunc:     testReportIsDeletedWhenNoDeps,
-					ExtraEnvVars: []string{},
+					Name:     "testReportIsDeletedWhenNoDeps",
+					TestFunc: testReportIsDeletedWhenNoDeps,
 				},
 				{
-					Name:         "testReportIsNotDeletedWhenReportDependsOnIt",
-					TestFunc:     testReportIsNotDeletedWhenReportDependsOnIt,
-					ExtraEnvVars: []string{},
+					Name:     "testReportIsNotDeletedWhenReportDependsOnIt",
+					TestFunc: testReportIsNotDeletedWhenReportDependsOnIt,
 				},
 			},
 			MeteringConfigManifestFilename: "prometheus-metrics-importer-disabled.yaml",


### PR DESCRIPTION
Add a new post-install test that ensures that a ConfigMap is present that is used to determine the Metering Operator leader election.

Update the test/e2e/main_test.go e2e entry-point function, adding this post-install function to the list of tests that will run against the static data input Metering installation.