### PR TITLE
Migrate to using the v1.x ansible-operator

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -3,7 +3,7 @@ FROM quay.io/openshift/origin-metering-helm:latest as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM quay.io/openshift/origin-cli:latest as cli
 # the base image is the ansible-operator's origin images
-FROM quay.io/operator-framework/ansible-operator:v0.19.4
+FROM quay.io/operator-framework/ansible-operator:v1.0.1
 
 USER root
 RUN set -x; INSTALL_PKGS="curl bash ca-certificates less which openssl" \
@@ -47,7 +47,7 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
 USER 1001
-ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "--watches-file", "/opt/ansible/watches.yaml"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "run", "--watches-file", "/opt/ansible/watches.yaml"]
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \

--- a/Dockerfile.metering-ansible-operator.rhel8
+++ b/Dockerfile.metering-ansible-operator.rhel8
@@ -34,9 +34,8 @@ COPY charts/openshift-metering ${HELM_CHART_PATH}
 
 COPY manifests/deploy/openshift/olm/bundle /manifests
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "--watches-file", "/opt/ansible/watches.yaml"]
-
 USER 1001
+ENTRYPOINT ["tini", "--", "/usr/local/bin/ansible-operator", "run", "--watches-file", "/opt/ansible/watches.yaml"]
 
 LABEL io.k8s.display-name="OpenShift metering-ansible-operator" \
     io.k8s.description="This is a component of OpenShift Container Platform and manages installation and configuration of all other metering components." \

--- a/bundle/manifests/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/bundle/manifests/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -467,24 +467,21 @@ spec:
                   image: "quay.io/openshift/origin-metering-ansible-operator:4.7"
                   imagePullPolicy: Always
                   args:
-                  - "--zap-level=info"
+                  - "--zap-log-level=info"
+                  - "--metrics-addr=:8383"
+                  - "--leader-election-id=metering-operator"
+                  - "--enable-leader-election=true"
                   env:
                   - name: ANSIBLE_DEBUG_LOGS
                     value: "True"
                   - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
                     value: "1"
-                  - name: OPERATOR_NAME
-                    value: "metering-operator"
                   - name: DISABLE_OCP_FEATURES
                     value: "false"
                   - name: WATCH_NAMESPACE
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.annotations['olm.targetNamespaces']
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
                   - name: METERING_ANSIBLE_OPERATOR_IMAGE
                     value: "quay.io/openshift/origin-metering-ansible-operator:4.7"
                   - name: METERING_REPORTING_OPERATOR_IMAGE

--- a/charts/metering-ansible-operator/templates/_helpers.tpl
+++ b/charts/metering-ansible-operator/templates/_helpers.tpl
@@ -28,14 +28,15 @@ template:
       image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
       imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
       args:
-      - "--zap-level=info"
+      - "--zap-log-level=info"
+      - "--metrics-addr=:{{ .Values.operator.metricsPort }}"
+      - "--leader-election-id={{ .Values.operator.name }}"
+      - "--enable-leader-election=true"
       env:
       - name: ANSIBLE_DEBUG_LOGS
         value: "True"
       - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
         value: "1"
-      - name: OPERATOR_NAME
-        value: "{{ .Values.operator.name }}"
       - name: DISABLE_OCP_FEATURES
         value: "{{ .Values.operator.disableOCPFeatures }}"
       - name: WATCH_NAMESPACE
@@ -50,10 +51,6 @@ template:
           fieldRef:
             fieldPath: metadata.namespace
 {{- end }}
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
 {{- range $index, $item := .Values.olm.imageTags }}
       - name: {{ $item.name | replace "-" "_" | upper | printf "%s_IMAGE" }}
         value: "{{ $item.from.name }}"

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -2,6 +2,7 @@ operator:
   name: metering-operator
 
   disableOCPFeatures: false
+  metricsPort: 8383
 
   reconcileIntervalSeconds: 30
   targetNamespace: ""

--- a/images/metering-ansible-operator/watches.yaml
+++ b/images/metering-ansible-operator/watches.yaml
@@ -6,3 +6,5 @@
   watchDependentResources: false
   reconcilePeriod: 5m
   manageStatus: false
+  vars:
+    meta: '{{ ansible_operator_meta }}'

--- a/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/metering-operator-deployment.yaml
@@ -24,24 +24,21 @@ spec:
         image: "quay.io/openshift/origin-metering-ansible-operator:4.7"
         imagePullPolicy: Always
         args:
-        - "--zap-level=info"
+        - "--zap-log-level=info"
+        - "--metrics-addr=:8383"
+        - "--leader-election-id=metering-operator"
+        - "--enable-leader-election=true"
         env:
         - name: ANSIBLE_DEBUG_LOGS
           value: "True"
         - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
           value: "1"
-        - name: OPERATOR_NAME
-          value: "metering-operator"
         - name: DISABLE_OCP_FEATURES
           value: "false"
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         - name: METERING_ANSIBLE_OPERATOR_IMAGE
           value: "quay.io/openshift/origin-metering-ansible-operator:4.7"
         - name: METERING_REPORTING_OPERATOR_IMAGE

--- a/manifests/deploy/openshift/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -467,24 +467,21 @@ spec:
                   image: "quay.io/openshift/origin-metering-ansible-operator:4.7"
                   imagePullPolicy: Always
                   args:
-                  - "--zap-level=info"
+                  - "--zap-log-level=info"
+                  - "--metrics-addr=:8383"
+                  - "--leader-election-id=metering-operator"
+                  - "--enable-leader-election=true"
                   env:
                   - name: ANSIBLE_DEBUG_LOGS
                     value: "True"
                   - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
                     value: "1"
-                  - name: OPERATOR_NAME
-                    value: "metering-operator"
                   - name: DISABLE_OCP_FEATURES
                     value: "false"
                   - name: WATCH_NAMESPACE
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.annotations['olm.targetNamespaces']
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
                   - name: METERING_ANSIBLE_OPERATOR_IMAGE
                     value: "quay.io/openshift/origin-metering-ansible-operator:4.7"
                   - name: METERING_REPORTING_OPERATOR_IMAGE

--- a/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/metering-operator-deployment.yaml
@@ -24,24 +24,21 @@ spec:
         image: "quay.io/coreos/metering-ansible-operator:release-4.7"
         imagePullPolicy: Always
         args:
-        - "--zap-level=info"
+        - "--zap-log-level=info"
+        - "--metrics-addr=:8383"
+        - "--leader-election-id=metering-operator"
+        - "--enable-leader-election=true"
         env:
         - name: ANSIBLE_DEBUG_LOGS
           value: "True"
         - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
           value: "1"
-        - name: OPERATOR_NAME
-          value: "metering-operator"
         - name: DISABLE_OCP_FEATURES
           value: "true"
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         - name: METERING_ANSIBLE_OPERATOR_IMAGE
           value: "quay.io/coreos/metering-ansible-operator:release-4.7"
         - name: METERING_REPORTING_OPERATOR_IMAGE

--- a/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -467,24 +467,21 @@ spec:
                   image: "quay.io/coreos/metering-ansible-operator:release-4.7"
                   imagePullPolicy: Always
                   args:
-                  - "--zap-level=info"
+                  - "--zap-log-level=info"
+                  - "--metrics-addr=:8383"
+                  - "--leader-election-id=metering-operator"
+                  - "--enable-leader-election=true"
                   env:
                   - name: ANSIBLE_DEBUG_LOGS
                     value: "True"
                   - name: ANSIBLE_VERBOSITY_METERINGCONFIG_METERING_OPENSHIFT_IO
                     value: "1"
-                  - name: OPERATOR_NAME
-                    value: "metering-operator"
                   - name: DISABLE_OCP_FEATURES
                     value: "true"
                   - name: WATCH_NAMESPACE
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.annotations['olm.targetNamespaces']
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
                   - name: METERING_ANSIBLE_OPERATOR_IMAGE
                     value: "quay.io/coreos/metering-ansible-operator:release-4.7"
                   - name: METERING_REPORTING_OPERATOR_IMAGE

--- a/test/e2e/ensure_leader_election_configmap_is_created_test.go
+++ b/test/e2e/ensure_leader_election_configmap_is_created_test.go
@@ -9,15 +9,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TODO: change this name once metering has migrated to using
-// the ansible-operator v1.x version.
-const leaderElectionConfigMapName = "metering-operator-lock"
+const leaderElectionConfigMapName = "metering-operator"
 
 // testLeaderElctionConfigMapIsCreated is reponsible for querying for the metering operator
 // leader election lock ConfigMap. Note: this implementation is subject to change based on the
-// ansible-operator v1 migration. Currently, a ConfigMap is created using the `POD_NAME` environment
-// variable exposed using the k8s downward API. In the ansible-operator 1.x world, leader election
-// is determined using controller runtime's implementation.
+// ansible-operator v1 migration. Before, a ConfigMap is created using the `POD_NAME` environment
+// variable exposed using the k8s downward API. Now, leader election is determined using
+// controller runtime's implementation.
 func testLeaderElectionConfigMapIsCreated(t *testing.T, rf *reportingframework.ReportingFramework) {
 	_, err := rf.KubeClient.CoreV1().ConfigMaps(rf.Namespace).Get(context.Background(), leaderElectionConfigMapName, metav1.GetOptions{})
 	require.NoError(t, err, "failed to query for the %s leader election ConfigMap", leaderElectionConfigMapName)


### PR DESCRIPTION
### Overview of Changes

Update the metering-ansible-operator to use the ansible-operator v1.x version. There are a few breaking changes between the 0.x and 1.x version of the operator-sdk, but we utilize very few of those CLI utilities which lower the number of changes necessary to migrate to this new major version.

#### Updates to the Dockerfile(s)

With the v1 binary, the ansible-operator now expects a `run` command:

```bash
bash-4.4$ /usr/local/bin/ansible-operator help
Usage:
  ansible-operator [command]

Available Commands:
  help        Help about any command
  run         Run the operator
  version     Prints the version of operator-sdk

Flags:
  -h, --help   help for ansible-operator

Use "ansible-operator [command] --help" for more information about a command.
```

#### Updates to the metering-ansible-operator Ansible Role

The watches.yaml file, which contains the API definition for resources that the Metering Operator is responsible for watching and ensure that the `meta` Ansible variable maps to `ansible_operator_meta`.

Before the `meta` variable was exposed through the ansible-operator and you would be able to pull information about the `MeteringConfig` custom resource that it's watching via `{{ meta.namespace }}` or `{{ meta.name }}`. Now, with the ansible-operator v1 version, that variable has been removed in favor of `ansible_operator_meta`. Explicitly mapping that variable to the `meta` Ansible variable ensures the same behavior we expect in previous ansible-operator versions.

#### Updates to the YAML manifests

Update the metering-ansible-operator Deployment and CSV helm charts to work with the ansible-operator v1 version.

A couple of things to note:
- The new default metrics port is port 8080 instead of port 8383 like in previous ansible-operator releases. Explicitly setting the `--metrics-addr=:8383` flag for the ansible-operator binary ensures the expected behavior.
- The `OPERATOR_NAME` environment variable has been deprecated which was used for leader election purposes. Now, we need to explicitly set the `--leader-election-id` flag to the `metering-operator` string.
- The `POD_NAME` environment variable is no longer needed. Before, that variable was exposed through the k8s downward API and used to create a leader election lease ConfigMap where the `$POD_NAME` was listed as the owner reference. In the ansible-operator v1 architecture, the controller runtime leader election implementation is used.
- The `--zap-level` flag has been renamed to `--zap-log-level`.
