### PR TITLE
Dockerfile: Add the opm CLI to interact with operator-registry and build indexes of operator content

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -3,17 +3,22 @@ FROM registry.svc.ci.openshift.org/ocp/4.7:metering-helm as helm
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM registry.svc.ci.openshift.org/ocp/4.7:cli as cli
 # need golang for the unit/vendor/verify CI checks
-FROM openshift/origin-release:golang-1.13
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7
 
 # go get faq via static Linux binary approach
 ARG LATEST_RELEASE=0.0.6
 RUN curl -Lo /usr/local/bin/faq https://github.com/jzelinskie/faq/releases/download/$LATEST_RELEASE/faq-linux-amd64
 RUN chmod +x /usr/local/bin/faq
 
+ARG OPM_RELEASE=v1.15.0
+RUN curl -Lo /usr/local/bin/opm https://github.com/operator-framework/operator-registry/releases/download/$OPM_RELEASE/linux-amd64-opm
+RUN chmod +x /usr/local/bin/opm
+
 # ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN INSTALL_PKGS="rh-python36" && \
-    yum clean all && rm -rf /var/cache/yum/* && \
+    yum clean all && \
+    rm -rf /var/cache/yum/* && \
     yum -y install centos-release-scl && \
     yum install --setopt=skip_missing_names_on_install=False -y $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Update the build_root container image that is used to run checks in CI. The `opm` binary will be used throughout our repository to keep the OLM manifests stored in the package manifest format in line with the new bundle packaging format.