### PR TITLE
charts,manifests: Fix the invalid metering image tag in the upstream CSV manifest

### DIFF
--- a/bundle/manifests/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/bundle/manifests/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -259,7 +259,7 @@ spec:
   minKubeVersion: "1.18.3"
   maturity: stable
   maintainers:
-    - email: sd-operator-metering@redhat.com
+    - email: metering-team@redhat.com
       name: Red Hat
   links:
     - name: Documentation

--- a/charts/metering-ansible-operator/upstream-values.yaml
+++ b/charts/metering-ansible-operator/upstream-values.yaml
@@ -96,7 +96,7 @@ olm:
 
     maintainers:
     - name: Red Hat
-      email: sd-operator-metering@redhat.com
+      email: metering-team@redhat.com
     provider:
       name: Red Hat
 

--- a/charts/metering-ansible-operator/upstream-values.yaml
+++ b/charts/metering-ansible-operator/upstream-values.yaml
@@ -106,7 +106,7 @@ olm:
       capabilities: Basic Install
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
-      containerImage: "quay.io/coreos/metering-ansible-operator:4.7"
+      containerImage: "quay.io/coreos/metering-ansible-operator:release-4.7"
 
   subscriptionName: metering
   subscriptionChannel: "4.7"

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -270,7 +270,7 @@ olm:
     maturity: stable
     maintainers:
     - name: Red Hat
-      email: sd-operator-metering@redhat.com
+      email: metering-team@redhat.com
     provider:
       name: Red Hat
     links:

--- a/manifests/deploy/openshift/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -259,7 +259,7 @@ spec:
   minKubeVersion: "1.18.3"
   maturity: stable
   maintainers:
-    - email: sd-operator-metering@redhat.com
+    - email: metering-team@redhat.com
       name: Red Hat
   links:
     - name: Documentation

--- a/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -259,7 +259,7 @@ spec:
   minKubeVersion: "1.18.3"
   maturity: stable
   maintainers:
-    - email: sd-operator-metering@redhat.com
+    - email: metering-team@redhat.com
       name: Red Hat
   links:
     - name: Documentation

--- a/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/meteringoperator.v4.7.0.clusterserviceversion.yaml
@@ -206,7 +206,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Monitoring
     certified: "false"
-    containerImage: quay.io/coreos/metering-ansible-operator:4.7
+    containerImage: quay.io/coreos/metering-ansible-operator:release-4.7
     createdAt: "2019-01-01T11:59:59Z"
     description: Chargeback and reporting tool to provide accountability for how resources
       are used across a cluster


### PR DESCRIPTION
There's no quay.io/coreos/metering-ansible-operator:4.7 image tag, but there is a release-4.7 one that got overridden by the PR that bumped all of the image tags to 4.7.