### PR TITLE
test/e2e: Avoid using the fatal logrus level in the main_test.go

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -130,7 +130,8 @@ func testMainWrapper(m *testing.M) int {
 	var registryProvisioned bool
 	catalogSourceName, catalogSourceNamespace, err = df.CreateCatalogSourceFromIndex(indexImage)
 	if err != nil {
-		df.Logger.Fatalf("Failed to create the CatalogSource custom resource using the %s index image: %v", indexImage, err)
+		df.Logger.Errorf("Failed to create the CatalogSource custom resource using the %s index image: %v", indexImage, err)
+		return 1
 	}
 	if !df.RunDevSetup {
 		var (
@@ -151,13 +152,15 @@ func testMainWrapper(m *testing.M) int {
 			}
 		}()
 		if len(errors) != 0 {
-			df.Logger.Fatalf(strings.Join(errors, "\n"))
+			df.Logger.Errorf(strings.Join(errors, "\n"))
+			return 1
 		}
 	}
 
 	err = df.WaitForPackageManifest(catalogSourceName, catalogSourceNamespace, subscriptionChannel)
 	if err != nil {
-		df.Logger.Fatalf("Failed to wait for the metering-ocp packagemanifest to become ready: %v", err)
+		df.Logger.Errorf("Failed to wait for the metering-ocp packagemanifest to become ready: %v", err)
+		return 1
 	}
 
 	return m.Run()


### PR DESCRIPTION
The logrus.Fatal logging level logs an entry at the fatal level and then calls os.Exit(1) after logging. This is problematic in the case of main_test.go where we expect that a custom defer function will be called if something problematic happens after creating the registry resources. If we instead log that error to the error log level and then return 1, we can continue getting the same behavior, but the defer function will still be ran.