### PR TITLE
hack,Dockerfile: Stop installing the operator-courier package

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -14,21 +14,6 @@ ARG OPM_RELEASE=v1.15.0
 RUN curl -Lo /usr/local/bin/opm https://github.com/operator-framework/operator-registry/releases/download/$OPM_RELEASE/linux-amd64-opm
 RUN chmod +x /usr/local/bin/opm
 
-# ensure fresh metadata rather than cached metadata in the base by running
-# yum clean all && rm -rf /var/yum/cache/* first
-RUN INSTALL_PKGS="rh-python36" && \
-    yum clean all && \
-    rm -rf /var/cache/yum/* && \
-    yum -y install centos-release-scl && \
-    yum install --setopt=skip_missing_names_on_install=False -y $INSTALL_PKGS && \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
-RUN scl enable rh-python36 'pip install operator-courier'
-
-COPY hack/scl-operator-courier.sh /usr/local/bin/operator-courier
-RUN chmod +x /usr/local/bin/operator-courier
-
 COPY --from=cli /usr/bin/oc /usr/bin/
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 RUN ln -s /usr/bin/oc /usr/bin/kubectl

--- a/hack/scl-operator-courier.sh
+++ b/hack/scl-operator-courier.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-scl enable rh-python36 "operator-courier $*"


### PR DESCRIPTION
Changes:

- hack: Remove the unused bash script that installs the `operator-courier` package using SCL.
- Dockerfile.src: Stop installing the operator-courier package. 