### PR TITLE
Bug 1898373: Fix the HiveTable status.partitions schema definition

### DIFF
--- a/bundle/manifests/hive.crd.yaml
+++ b/bundle/manifests/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true

--- a/charts/metering-ansible-operator/templates/crds/hive.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true

--- a/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true

--- a/manifests/deploy/openshift/olm/bundle/4.7/hive.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.7/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true

--- a/manifests/deploy/upstream/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true

--- a/manifests/deploy/upstream/olm/bundle/4.7/hive.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.7/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true


### PR DESCRIPTION
Update the charts/metering-ansible-operator/templates/crds/hive.crd.yaml HiveTable CRD schema definition, and ensuring that the status.partitions property can be nullable.

During the effort to migrate from v1beta1 to v1 apiextensions.k8s.io CRDs in the 4.6 release, all possible properties in the HiveTable CRD need to be defined in the schema definition, else the apiserver would prune those undefined fields. The `status.partitions` field was defined as an array of objects, which is problematic in the case of existing HiveTable custom resources that had `status.partitions: null` being set. During an upgrade from a supported release to the 4.6 channel, the upgrade failed as OLM couldn't apply the new HiveTable CRD version against the existing set of HiveTable custom resources defined in the metering namespace due to the following error:

```
error validating existing CRs against new CRD's schema: hivetables.metering.openshift.io: error validating custom resource against new schema &apiextensions.CustomResourceValidation{OpenAPIV3Schema:(*apiextensions.JSONSchemaProps)(0xc0058f6400)}: [].status.partitions: Invalid value: "null": status.partitions in body must be of type array: "null"
```

If we instead update that status field schema definition to allow that field to be nullable (e.g. `nullable: true` is specified) and preserve any unknown fields that get defined during a custom resource, we can retain backward compatibility with previous versions of the Metering Operator.

These changes were tested using the following steps:

- Built and pushed a bundle image containing the changes made in this PR and an index image containing that bundle.
- Created a custom CatalogSource containing a reference to that index image that was pushed to quay.
- Deployed a metering instance using the 4.4 redhat-operators CatalogSource.
- Waited until that instance has populated data in the ReportDataSource status.tableRef tables.
- Updated the subscription in the namespace where metering was deployed to reference the custom CatalogSource `metadata.name` and the `4.7` channel.
- Monitored the various OLM-related custom resources (e.g. CSV, InstallPlan, Subscription) to ensure that OLM had no problem with applying these changes to an existing, previous version of Metering.
