### PR TITLE
hack: Gather all the PackageManifests in a test cluster

### DIFF
--- a/hack/gather-registry-artifacts.sh
+++ b/hack/gather-registry-artifacts.sh
@@ -7,7 +7,8 @@ CATALOG_SOURCE_NAMESPACE=${CATALOG_SOURCE_NAMESPACE:=openshift-marketplace}
 CATALOG_SOURCE_NAME=${CATALOG_SOURCE_NAME:=redhat-operators}
 
 OUTPUT_DIRECTORY=${OUTPUT_DIRECTORY:=$(mktemp -ud)/resources}
-mkdir -p ${OUTPUT_DIRECTORY}
+mkdir -p "${OUTPUT_DIRECTORY}"
 
-oc -n ${CATALOG_SOURCE_NAMESPACE} get catalogsources ${CATALOG_SOURCE_NAME} -o yaml > ${OUTPUT_DIRECTORY}/catalogsource.yaml
-oc -n ${CATALOG_SOURCE_NAMESPACE} get packagemanifests -l "catalog-namespace=${CATALOG_SOURCE_NAMESPACE},catalog=${CATALOG_SOURCE_NAME}" -o yaml > ${OUTPUT_DIRECTORY}/packagemanifests.yaml
+oc -n ${CATALOG_SOURCE_NAMESPACE} get catalogsources ${CATALOG_SOURCE_NAME} -o yaml > "${OUTPUT_DIRECTORY}"/catalogsource.yaml
+oc -n ${CATALOG_SOURCE_NAMESPACE} get packagemanifests > "${OUTPUT_DIRECTORY}"/packagemanifests.yaml
+oc -n ${CATALOG_SOURCE_NAMESPACE} get packagemanifests -l "catalog-namespace=${CATALOG_SOURCE_NAMESPACE},catalog=${CATALOG_SOURCE_NAME}" -o yaml > "${OUTPUT_DIRECTORY}"/metering-ocp-packagemanifests.yaml


### PR DESCRIPTION
Update the hack/gather-registry-artifacts.sh bash script, and gather the overall list of PackageManifest custom resources that are stored in the openshift-marketplace namespace.

During an individual CI run, the e2e suite is responsible for creating a CatalogSource custom resource that references an index image that the ci-operator creates before a cluster is created. When the corresponding PackageManifest custom resource is not created from that CatalogSource, then querying for the "catalog-namespace=openshift-marketplace,catalog=metering-dev" label selector will return a list of zero indices so this would provide additional debugging measures to help determine if there's something wrong on the metering bundle side-of-things, or OLM side-of-things.