### PR TITLE
[release-4.6] Bug 1897379: Fix the HiveTable status.partitions schema definition

### DIFF
--- a/charts/metering-ansible-operator/templates/crds/hive.crd.yaml
+++ b/charts/metering-ansible-operator/templates/crds/hive.crd.yaml
@@ -268,13 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true

--- a/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/openshift/metering-ansible-operator/hive.crd.yaml
@@ -268,14 +268,7 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true
 

--- a/manifests/deploy/openshift/olm/bundle/4.6/hive.crd.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.6/hive.crd.yaml
@@ -268,14 +268,7 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true
 

--- a/manifests/deploy/upstream/metering-ansible-operator/hive.crd.yaml
+++ b/manifests/deploy/upstream/metering-ansible-operator/hive.crd.yaml
@@ -268,14 +268,7 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true
 

--- a/manifests/deploy/upstream/olm/bundle/4.6/hive.crd.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.6/hive.crd.yaml
@@ -268,14 +268,7 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true
 

--- a/olm_deploy/bundle/manifests/hive.crd.yaml
+++ b/olm_deploy/bundle/manifests/hive.crd.yaml
@@ -268,14 +268,6 @@ spec:
                 additionalProperties:
                   type: string
               partitions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    location:
-                      type: string
-                    partitionSpec:
-                      type: object
-                      additionalProperties:
-                        type: string
-
+                # https://bugzilla.redhat.com/show_bug.cgi?id=1897379
+                x-kubernetes-preserve-unknown-fields: true
+                nullable: true


### PR DESCRIPTION
---
Manual cherry-pick of #1443 
---

Update the charts/metering-ansible-operator/templates/crds/hive.crd.yaml HiveTable CRD schema definition, and ensuring that the status.partitions property can be nullable.

During the effort to migrate from v1beta1 to v1 apiextensions.k8s.io CRDs in the 4.6 release, all possible properties in the HiveTable CRD need to be defined in the schema definition, else the apiserver would prune those undefined fields. The `status.partitions` field was defined as an array of objects, which is problematic in the case of existing HiveTable custom resources that had `status.partitions: null` being set. During an upgrade from a supported release to the 4.6 channel, the upgrade failed as OLM couldn't apply the new HiveTable CRD version against the existing set of HiveTable custom resources defined in the metering namespace due to the following error:

```
error validating existing CRs agains new CRD's schema: hivetables.metering.openshift.io: error validating custom resource against new schema &apiextensions.CustomResourceValidation{OpenAPIV3Schema:(*apiextensions.JSONSchemaProps)(0xc0058f6400)}: [].status.partitions: Invalid value: "null": status.partitions in body must be of type array: "null"
```

If we instead update that status field schema definition to allow that field to be nullable (e.g. `nullable: true` is specified) and preserve any unknown fields that get defined during a custom resource, we can retain backwards compatibility with previous version of the Metering Operator.