### PR TITLE
Dockerfile,Makefile: Add a make target that verifies the metering bundle contents are valid

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -14,8 +14,13 @@ ARG OPM_RELEASE=v1.15.0
 RUN curl -Lo /usr/local/bin/opm https://github.com/operator-framework/operator-registry/releases/download/$OPM_RELEASE/linux-amd64-opm
 RUN chmod +x /usr/local/bin/opm
 
+ARG OPERATOR_SDK_RELEASE=v1.2.0
+RUN curl -Lo /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_RELEASE/operator-sdk-$OPERATOR_SDK_RELEASE-x86_64-linux-gnu
+RUN chmod +x /usr/local/bin/operator-sdk
+
 COPY --from=cli /usr/bin/oc /usr/bin/
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 RUN go get -u github.com/jstemmer/go-junit-report
 


### PR DESCRIPTION
Update the Dockerfile.src (build root Dockerfile for CI) and add the `operator-sdk binary` to the container image.

Update the Makefile and expose a `verify-bundle` target, which is responsible for running the `operator-sdk bundle validate ./bundle` command to validate the Metering bundle metadata/manifest contents.

Note: this validation of manifests for OLM consumption was previously covered by the `operator-courier` utility, but that utility doesn't support validating apiextensions.k8s.io/v1 CRD types so that check was removed.