### PR TITLE
Dockerfile: Bump the Golang version in the reporting-operator base image

### DIFF
--- a/Dockerfile.reporting-operator
+++ b/Dockerfile.reporting-operator
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.13 as build
+FROM openshift/origin-release:golang-1.15 as build
 
 COPY . /go/src/github.com/kube-reporting/metering-operator
 WORKDIR /go/src/github.com/kube-reporting/metering-operator


### PR DESCRIPTION
Align the Golang version used between the dev Dockerfile and the CI/ART Dockerfile (Dockerfile.reporting-operator.rhel).