### PR TITLE
pkg/operator: Minor tech debt improvements to the Reporting Operator packages

### DIFF
--- a/pkg/aws/manifest.go
+++ b/pkg/aws/manifest.go
@@ -39,7 +39,7 @@ type AdditionalArtifact struct {
 	Name         string `json:"name"`
 }
 
-// Paths returns the directories containing usage data. The result will be free of duplicates.
+// DataDirectory returns the directories containing usage data. The result will be free of duplicates.
 func (m Manifest) DataDirectory() string {
 	paths := m.paths()
 	pathsLen := len(paths)

--- a/pkg/operator/http.go
+++ b/pkg/operator/http.go
@@ -258,9 +258,10 @@ func (srv *server) getReport(logger log.FieldLogger, name, namespace, format str
 
 	if useNewFormat {
 		writeResultsResponseV2(logger, full, format, reportQuery.Name, reportQuery.Spec.Columns, results, w, r)
-	} else {
-		writeResultsResponseV1(logger, format, reportQuery.Name, reportQuery.Spec.Columns, results, w, r)
+		return
 	}
+
+	writeResultsResponseV1(logger, format, reportQuery.Name, reportQuery.Spec.Columns, results, w, r)
 }
 
 func writeResultsResponseAsCSV(logger log.FieldLogger, name string, columns []metering.ReportQueryColumn, results []presto.Row, w http.ResponseWriter, r *http.Request) {

--- a/pkg/operator/prestostore/importer.go
+++ b/pkg/operator/prestostore/importer.go
@@ -156,7 +156,7 @@ func (importer *PrometheusImporter) ImportFromLastTimestamp(ctx context.Context)
 		endTime = startTime.Add(cfg.MaxQueryRangeDuration)
 	}
 
-	importResults, err := ImportFromTimeRange(importer.logger, importer.clock, importer.promConn, importer.prometheusMetricsRepo, importer.metricsCollectors, ctx, startTime, endTime, cfg)
+	importResults, err := ImportFromTimeRange(ctx, importer.logger, importer.clock, importer.promConn, importer.prometheusMetricsRepo, importer.metricsCollectors, startTime, endTime, cfg)
 	if err != nil {
 		importer.logger.WithFields(logrus.Fields{"startTime": startTime, "endTime": endTime}).WithError(err).Error("error collecting metrics")
 		// at this point we cannot be sure what is in Presto and what

--- a/pkg/operator/prestostore/prometheusmetric.go
+++ b/pkg/operator/prestostore/prometheusmetric.go
@@ -89,6 +89,7 @@ type prometheusMetricRepo struct {
 	queryBufferPool *sync.Pool
 }
 
+// NewPrometheusMetricsRepo constructs an initialized prometheusMetricRepo instance.
 func NewPrometheusMetricsRepo(queryer db.Queryer, queryBufferPool *sync.Pool) *prometheusMetricRepo {
 	if queryBufferPool == nil {
 		queryBufferPool = &defaultQueryBufferPool
@@ -103,7 +104,7 @@ func (r *prometheusMetricRepo) StorePrometheusMetrics(ctx context.Context, table
 	queryBuf := r.queryBufferPool.Get().(*bytes.Buffer)
 	queryBuf.Reset()
 	defer r.queryBufferPool.Put(queryBuf)
-	return StorePrometheusMetricsWithBuffer(queryBuf, ctx, r.queryer, tableName, metrics)
+	return StorePrometheusMetricsWithBuffer(ctx, queryBuf, r.queryer, tableName, metrics)
 }
 
 func (r *prometheusMetricRepo) GetPrometheusMetrics(tableName string, start, end time.Time) ([]*PrometheusMetric, error) {
@@ -139,9 +140,9 @@ type PrometheusMetric struct {
 	Dt        string            `json:"dt"`
 }
 
-// storePrometheusMetricsWithBuffer handles storing Prometheus metrics into the
+// StorePrometheusMetricsWithBuffer handles storing Prometheus metrics into the
 // specified Presto table.
-func StorePrometheusMetricsWithBuffer(queryBuf *bytes.Buffer, ctx context.Context, queryer db.Queryer, tableName string, metrics []*PrometheusMetric) error {
+func StorePrometheusMetricsWithBuffer(ctx context.Context, queryBuf *bytes.Buffer, queryer db.Queryer, tableName string, metrics []*PrometheusMetric) error {
 	bufferCapacity := queryBuf.Cap()
 
 	insertStatementLength := len(presto.FormatInsertQuery(tableName, ""))

--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -823,6 +823,8 @@ func (op *defaultReportingOperator) runReport(logger log.FieldLogger, report *me
 	return nil
 }
 
+// isReportNotUsedAsInput is responsible for checking if the @report Report
+// is being used as an input to another Report or ReportQuery custom resource.
 // We check first for Reports depending on this Report, return if any, and then check ReportQueries depending on Report
 func isReportNotUsedAsInput(logger log.FieldLogger, report *metering.Report, op *defaultReportingOperator) bool {
 	// Consider Reports referencing this report in the namespace of this report

--- a/pkg/operator/reports_test.go
+++ b/pkg/operator/reports_test.go
@@ -464,14 +464,15 @@ func TestGetReportPeriod(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.expectPanic {
 				assert.Panics(t, func() { getReportPeriod(time.Now(), mockLogger, testCase.report) }, "expected the test case would panic, but it did not")
-			} else {
-				_, err := getReportPeriod(time.Now(), mockLogger, testCase.report)
-				if testCase.expectErr {
-					assert.Error(t, err, "expected that getting the report period  would return a non-nil error")
-				} else {
-					assert.Nil(t, err, "expected that getting the report period would return a nil error")
-				}
+				return
 			}
+
+			_, err := getReportPeriod(time.Now(), mockLogger, testCase.report)
+			if testCase.expectErr {
+				assert.Error(t, err, "expected that getting the report period  would return a non-nil error")
+				return
+			}
+			assert.Nil(t, err, "expected that getting the report period would return a nil error")
 		})
 	}
 }


### PR DESCRIPTION
List of Changes
- Update `pkg/operator/storagelocations.go`, deflating the updating logic that is stored in the op.handleStorageLocation method, into its own method.This way, we can handle the validation and update logic for any particular StorageLocation the reporting-operator is currently processing into a dedicated method, and reduce the responsibilities of the `op.handleStorageLocation` driver method to making any of the necessary API calls to the Kubernetes client.
- Update any of the comments for functions/methods that appear to have been refactored in the past, but the comment wasn't also updated.
- Update the ordering of parameters for any function/method that passes a `context.Context` to be the first parameter. This makes the Reporting Operator codebase a bit more consistent and aligns with the recommendation from Go that `context.Context` parameters should be first.
- Deflate (refactor) any unnecessary branching logic. Most of the if/else if/else branching structure can be deflated to just an if conditional and that improves readability quite a bit.