### PR TITLE
go.mod,vendor: Bump the Go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kube-reporting/metering-operator
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go v0.44.3 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # cloud.google.com/go v0.44.3
+## explicit
 cloud.google.com/go/compute/metadata
 # git.apache.org/thrift.git v0.0.0-20171203172758-327ebb6c2b6d => github.com/apache/thrift v0.0.0-20171203172758-327ebb6c2b6d
 git.apache.org/thrift.git/lib/go/thrift
@@ -14,16 +15,20 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.5.0
 github.com/Azure/go-autorest/tracing
 # github.com/Masterminds/semver v1.4.2
+## explicit
 github.com/Masterminds/semver
 # github.com/Masterminds/sprig v2.16.0+incompatible
+## explicit
 github.com/Masterminds/sprig
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
 # github.com/aokoli/goutils v1.0.1
+## explicit
 github.com/aokoli/goutils
 # github.com/aws/aws-sdk-go v1.28.2
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -67,10 +72,14 @@ github.com/aws/aws-sdk-go/service/s3/s3manager
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
+## explicit
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
+# github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20
+## explicit
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
@@ -80,11 +89,13 @@ github.com/docker/spdystream/spdy
 # github.com/emersion/go-sasl v0.0.0-20161116183048-7e096a0a6197
 github.com/emersion/go-sasl
 # github.com/emicklei/go-restful v2.12.0+incompatible
+## explicit
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.5.0+incompatible
 github.com/evanphx/json-patch
 # github.com/go-chi/chi v3.3.2+incompatible
+## explicit
 github.com/go-chi/chi
 github.com/go-chi/chi/middleware
 # github.com/go-openapi/jsonpointer v0.19.3
@@ -92,8 +103,10 @@ github.com/go-openapi/jsonpointer
 # github.com/go-openapi/jsonreference v0.19.3
 github.com/go-openapi/jsonreference
 # github.com/go-openapi/spec v0.19.7
+## explicit
 github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.8
+## explicit
 github.com/go-openapi/swag
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/proto
@@ -101,6 +114,7 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.3
+## explicit
 github.com/golang/mock/gomock
 github.com/golang/mock/mockgen
 github.com/golang/mock/mockgen/model
@@ -125,6 +139,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gophercloud/gophercloud v0.3.0
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/identity/v2/tenants
@@ -136,6 +151,7 @@ github.com/gophercloud/gophercloud/pagination
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/huandu/xstrings v1.3.0
+## explicit
 github.com/huandu/xstrings
 # github.com/imdario/mergo v0.3.8
 github.com/imdario/mergo
@@ -144,10 +160,12 @@ github.com/inconshreveable/mousetrap
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
 # github.com/json-iterator/go v1.1.9
+## explicit
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/mailru/easyjson v0.7.1
+## explicit
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
@@ -160,18 +178,23 @@ github.com/modern-go/reflect2
 # github.com/onsi/gomega v1.9.0
 github.com/onsi/gomega/gstruct/errors
 github.com/onsi/gomega/types
+# github.com/opencontainers/runtime-spec v1.0.0
+## explicit
 # github.com/openshift/api v0.0.0-20200605231317-fb2a6ca106ae
 github.com/openshift/api/route/v1
 # github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73
+## explicit
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
 # github.com/operator-framework/api v0.3.7
+## explicit
 github.com/operator-framework/api/pkg/lib/version
 github.com/operator-framework/api/pkg/operators
 github.com/operator-framework/api/pkg/operators/v1
 github.com/operator-framework/api/pkg/operators/v1alpha1
 github.com/operator-framework/api/pkg/operators/v2alpha1
 # github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200521062108-408ca95d458f
+## explicit
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/scheme
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha1
@@ -188,8 +211,10 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prestodb/presto-go-client v0.0.0-20180328163046-568bdb2f6dbc
+## explicit
 github.com/prestodb/presto-go-client/presto
 # github.com/prometheus/client_golang v1.2.1 => github.com/prometheus/client_golang v0.9.0-pre1
+## explicit
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/prometheus
@@ -197,6 +222,7 @@ github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.7.0
+## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
@@ -205,17 +231,23 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/robfig/cron v1.1.0
+## explicit
 github.com/robfig/cron
 # github.com/sirupsen/logrus v1.4.2
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/cobra v1.0.0
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/taozle/go-hive-driver v0.0.0-20181206100408-79951111cb07 => github.com/chancez/go-hive-driver v0.0.0-20190516203049-b3c680b33c4f
+## explicit
 github.com/taozle/go-hive-driver
 github.com/taozle/go-hive-driver/thriftlib
 # golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
@@ -226,6 +258,7 @@ golang.org/x/crypto/ssh/terminal
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -241,6 +274,7 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
@@ -255,6 +289,7 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200331202046-9d5940d49312
+## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter
@@ -324,6 +359,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.6 => k8s.io/api v0.18.6
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -365,12 +401,14 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.18.2 => k8s.io/apiextensions-apiserver v0.18.6
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 # k8s.io/apimachinery v0.18.6 => k8s.io/apimachinery v0.18.7-rc.0
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -419,6 +457,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v8.0.0+incompatible => k8s.io/client-go v0.18.6
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/kubernetes
@@ -503,6 +542,7 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/code-generator v0.18.6 => k8s.io/code-generator v0.18.9-rc.0
+## explicit
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/client-gen/args
@@ -537,6 +577,7 @@ k8s.io/code-generator/pkg/namer
 k8s.io/code-generator/pkg/util
 k8s.io/code-generator/third_party/forked/golang/reflect
 # k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12
+## explicit
 k8s.io/gengo/args
 k8s.io/gengo/examples/deepcopy-gen/generators
 k8s.io/gengo/examples/defaulter-gen/generators
@@ -548,6 +589,7 @@ k8s.io/gengo/namer
 k8s.io/gengo/parser
 k8s.io/gengo/types
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 k8s.io/kube-openapi/cmd/openapi-gen/args
@@ -567,3 +609,33 @@ sigs.k8s.io/controller-runtime/pkg/scheme
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# k8s.io/api => k8s.io/api v0.18.6
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6
+# k8s.io/apimachinery => k8s.io/apimachinery v0.18.7-rc.0
+# k8s.io/apiserver => k8s.io/apiserver v0.18.6
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.6
+# k8s.io/client-go => k8s.io/client-go v0.18.6
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.6
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.6
+# k8s.io/code-generator => k8s.io/code-generator v0.18.9-rc.0
+# k8s.io/component-base => k8s.io/component-base v0.18.6
+# k8s.io/cri-api => k8s.io/cri-api v0.18.9-rc.0
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.6
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.6
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.6
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.6
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.6
+# k8s.io/kubectl => k8s.io/kubectl v0.18.6
+# k8s.io/kubelet => k8s.io/kubelet v0.18.6
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.6
+# k8s.io/metrics => k8s.io/metrics v0.18.6
+# k8s.io/node-api => k8s.io/node-api v0.0.0-20191114112948-fde05759caf8
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.6
+# k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.18.6
+# k8s.io/sample-controller => k8s.io/sample-controller v0.18.6
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
+# github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
+# github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.0-pre1
+# github.com/taozle/go-hive-driver => github.com/chancez/go-hive-driver v0.0.0-20190516203049-b3c680b33c4f
+# sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.2
+# golang.org/x/text => golang.org/x/text v0.3.3


### PR DESCRIPTION
Update the Golang version listed in.mod and run `make vendor` to propagate changes to the vendored dependencies.