### PR TITLE
Dockerfile.src: Avoid using the latest Helm image tag

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -1,5 +1,5 @@
 # need helm CLI for final image
-FROM quay.io/openshift/origin-metering-helm:latest as helm
+FROM quay.io/openshift/origin-metering-helm:4.5 as helm
 
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli


### PR DESCRIPTION
Update the Dockerfile.src (build root Dockerfile for CI tests) and use a release-versioned Helm image tag instead of the `latest` tag.

This is needed as the Helm version has recently been bumped to use the 3.x versioning, which comes with some slight breaking changes to the templating logic.

Note: this commit needs to be force-merged in order to have these changes propagate to CI tests.