### PR TITLE
[release-4.5] Dockerfile: Avoid using the latest tag for the Helm image in CI

### DIFF
--- a/Dockerfile.metering-ansible-operator
+++ b/Dockerfile.metering-ansible-operator
@@ -1,5 +1,5 @@
 # need the helm-cli from the helm image
-FROM quay.io/openshift/origin-metering-helm:latest as helm
+FROM quay.io/openshift/origin-metering-helm:4.5 as helm
 # final image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM openshift/origin-cli:latest as cli
 # the base image is the ansible-operator's origin images


### PR DESCRIPTION
This is causing new 4.5 installations to fail in CI as the images are using the Helm 3.x version that was bumped during the 4.7 release cycle, but we expect that we're working with a helm 2.x version in previous releases.