### PR TITLE
Dockerfile: Avoid using docker.io base images

### DIFF
--- a/Dockerfile.reporting-operator
+++ b/Dockerfile.reporting-operator
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.13 as build
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 as build
 
 COPY . /go/src/github.com/kube-reporting/metering-operator
 WORKDIR /go/src/github.com/kube-reporting/metering-operator

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -1,10 +1,9 @@
 # need helm CLI for final image
-FROM quay.io/openshift/origin-metering-helm:4.5 as helm
-
+FROM registry.svc.ci.openshift.org/ocp/4.5:metering-helm as helm
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
-FROM openshift/origin-cli:latest as cli
-
-FROM openshift/origin-release:golang-1.13
+FROM registry.svc.ci.openshift.org/ocp/4.5:cli as cli
+# need golang for the unit/vendor/verify CI checks
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13
 
 # go get faq via static Linux binary approach
 ARG LATEST_RELEASE=0.0.6


### PR DESCRIPTION
Update any CI-related Dockerfile to avoid using any dockerhub.io images to reduce pull rate-limited errors.