### PR TITLE
Bug 1838802: Fix compatibility issues when using MySQL 8.0+ as the underlying Hive metastore database

### DIFF
--- a/Documentation/configuring-hive-metastore.md
+++ b/Documentation/configuring-hive-metastore.md
@@ -52,8 +52,6 @@ kubectl -n $METERING_NAMESPACE create secret generic <name of the secret> --from
 
 ### Using MySQL for the Hive Metastore database
 
-**Note**: Metering cannot work with more recent versions of MySQL, which is being tracking in [BZ #1838802](https://bugzilla.redhat.com/show_bug.cgi?id=1838802). Instead, use the 5.7 version which has been tested.
-
 ```yaml
 spec:
   hive:

--- a/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-metastore-statefulset.yaml
@@ -130,6 +130,8 @@ spec:
         env:
         - name: HIVE_LOGLEVEL
           value: {{ upper .Values.hive.spec.metastore.config.logLevel | quote}}
+        - name: HIVE_UNDERLYING_DATABASE
+          value: "{{ .Values.hive.spec.config.db.type }}"
 {{- if .Values.hive.spec.metastore.config.jvm.initialRAMPercentage }}
         - name: JVM_INITIAL_RAM_PERCENTAGE
           value: "{{ .Values.hive.spec.metastore.config.jvm.initialRAMPercentage }}"

--- a/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-scripts-configmap.yaml
@@ -109,4 +109,16 @@ data:
     export HIVE_METASTORE_HADOOP_OPTS=" -Dhive.log.level=${HIVE_LOGLEVEL} "
     export HIVE_OPTS="${HIVE_OPTS} --hiveconf hive.root.logger=${HIVE_LOGLEVEL},console "
 
+    SCHEMATOOL_BIN="${SCHEMATOOL_BIN:=${HIVE_HOME}/bin/schematool}"
+    # In the case of non-derby underlying databases been configured
+    # for Hive metastore, attempt to determine if there's already
+    # an initialized schema running the `schematool` CLI with the
+    # `-info` option. If that command fails, then we can make the
+    # reasonable assumption that schema doesn't already exist,
+    # and we can initialize it ourselves before starting Hive.
+    echo "Deploying Hive using ${HIVE_UNDERLYING_DATABASE} as the underlying database"
+    if [[ $HIVE_UNDERLYING_DATABASE != "derby" ]]; then
+      "${SCHEMATOOL_BIN}" -dbType "${HIVE_UNDERLYING_DATABASE}" -info || "${SCHEMATOOL_BIN}" -dbType "${HIVE_UNDERLYING_DATABASE}" -initSchema
+    fi
+
     exec $@

--- a/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
+++ b/charts/openshift-metering/templates/hive/hive-server-statefulset.yaml
@@ -158,6 +158,8 @@ spec:
         env:
         - name: HIVE_LOGLEVEL
           value: {{ upper .Values.hive.spec.server.config.logLevel | quote}}
+        - name: HIVE_UNDERLYING_DATABASE
+          value: "{{ .Values.hive.spec.config.db.type }}"
 {{- if .Values.hive.spec.server.config.jvm.initialRAMPercentage }}
         - name: JVM_INITIAL_RAM_PERCENTAGE
           value: "{{ .Values.hive.spec.server.config.jvm.initialRAMPercentage }}"

--- a/charts/openshift-metering/values.yaml
+++ b/charts/openshift-metering/values.yaml
@@ -690,6 +690,7 @@ hive:
 
         autoCreateMetastoreSchema: true
         enableMetastoreSchemaVerification: false
+        type: derby
 
       aws:
         accessKeyID: ""

--- a/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/defaults/main.yml
@@ -414,6 +414,7 @@ _hive_metastore_db_overrides:
         db:
           username: "{{ _hive_metastore_db_username | default('') }}"
           password: "{{ _hive_metastore_db_password | default('') }}"
+          type: "{{ _hive_metastore_db_type | default('derby') }}"
       metastore:
         storage:
           create: "{{ _hive_metastore_create_default_storage | default(true) }}"

--- a/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_metastore.yml
+++ b/images/metering-ansible-operator/roles/meteringconfig/tasks/configure_hive_metastore.yml
@@ -20,6 +20,28 @@
         message: "Configuring hive metastore"
         lastTransitionTime: "{{ now(utc=False).isoformat() + 'Z' }}"
 
+  - name: Determine the Hive underlying database
+    block:
+    - name: Split the hive.spec.config.db.url into an array
+      set_fact:
+        _url_array: "{{ _meteringconfig_hive_metastore_db_url.split(':') }}"
+
+    - name: Verify the JDBC URL is valid before parsing
+      assert:
+        that:
+        - '{{ _url_array[0] == "jdbc" }}'
+        - '{{ _url_array[1] in ["mysql", "postgresql", "derby"] }}'
+        msg: "Invalid JDBC URL {{ _meteringconfig_hive_metastore_db_url }} passed in the MeteringConfig.Spec"
+
+    # Note: the `schematool -dbType` option expects either `mysql`,
+    # `derby`, `oracle` and `postgres` as valid options. In the case
+    # of the JDBC URL, only `postgresql` is valid, so we need to do
+    # some re-mapping of naming if that is what has been specified
+    # in the hive.spec.config.db.url field in the MeteringConfig CR.
+    - name: Override the default hive metastore database type
+      set_fact:
+        _hive_metastore_db_type: "{{ 'postgres' if _url_array[1] == 'postgresql' else _url_array[1] }}"
+
   - name: Override the default hive.spec.metastore.storage.create option to false
     set_fact:
       _hive_metastore_create_default_storage: false
@@ -69,6 +91,7 @@
     _meteringconfig_hive_metastore_db_secretName: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.secretName') }}"
     _meteringconfig_hive_metastore_db_username: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.username') }}"
     _meteringconfig_hive_metastore_db_password: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.password') }}"
+    _meteringconfig_hive_metastore_db_url: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db.url') }}"
     _meteringconfig_hive_metastore_db_configuration: "{{ meteringconfig_spec_overrides | json_query('hive.spec.config.db') }}"
   no_log: false
   rescue:

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -303,13 +303,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			Name:                      "HDFS-MySQLDatabase",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
-			// TODO: disable this for now as the mysql:5.7 image
-			// stream was recently removed from 4.6 and there are
-			// some issues with using mariadb as a direct replacement
-			// as Hive server hangs during the create table call
-			// and requires a restart to work properly.
-			Skip:           true,
-			PreInstallFunc: createMySQLDatabase,
+			PreInstallFunc:            createMySQLDatabase,
 			InstallSubTests: []InstallTestCase{
 				{
 					Name:     "testReportingProducesData",

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -3,14 +3,15 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/kube-reporting/metering-operator/pkg/deploy"
-	"k8s.io/client-go/kubernetes"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kube-reporting/metering-operator/pkg/deploy"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kube-reporting/metering-operator/test/deployframework"
 	"github.com/kube-reporting/metering-operator/test/testhelpers"
@@ -357,7 +358,7 @@ func createMySQLDatabase(ctx *deployframework.DeployerCtx) error {
 		"oc",
 		"-n", mysqlNamespace,
 		"new-app",
-		"--image-stream", "mysql:5.7",
+		"--image-stream", "mysql:8.0",
 		"MYSQL_USER=testuser",
 		"MYSQL_PASSWORD=testpass",
 		"MYSQL_DATABASE=metastore",
@@ -365,7 +366,6 @@ func createMySQLDatabase(ctx *deployframework.DeployerCtx) error {
 	)
 	cmd.Stdout = ctx.LoggerOutFile
 	cmd.Stderr = ctx.LoggerOutFile
-
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("Failed to run the cmd: %v", err)


### PR DESCRIPTION
# Overview

Update the Hive metastore deployment to fix compatibility issues
when deploying metering using a non-mysql-5.7 version.

## Changes

Update the `configuring-hive-metastore.md`  documentation and 
remove the reference to the BZ mentioning metering integration 
issues with any non-mysql-5.7 versions.

Update the hive-scripts ConfigMap entrypoint.sh script, which gets
called in the Hive metastore and server StatefulSets and is responsible
for starting those containers.

In the case of derby (the default) databases, using this tool isn't
necessary and will cause issues when running it against an already
exists schema. This tool is needed in order to get metering working
again with MySQL and PostgreSQL versions.

Update the Hive metastore and server StatefulSets and expose an
additional environment variable, `$HIVE_UNDERLYING_DATABASE` that
defaults to `derby`. This environment variable will be used in the
hive-scripts ConfigMap's entrypoint.sh bash script to run schematool
against the correct `-dbType ${HIVE_UNDERLYING_DATABASE`.

Update the Ansible role's `configure_hive_metastore.yaml` task file to
override the `_meteringconfig_hive_metastore_db_url` helper variable.
That helper variable, which is set to the `hive.spec.config.db.url`
configuration and will be overriden with any value that we set in that
task file before the MeteringConfig values have been finalized.

When we're handling postgres resources, we need to remap what we pull
from the JDBC URL as `postgresql` isn't a valid `schematool -dbType`
option, but `postgres` is so use the value from the split URL array
unless we're configuring a postgres database for Hive metastore.

## Testing Notes

The mysql database instance was created using `oc new-app` 
using the following command:

```bash
oc create namespace tflannag
oc -n tflannag new-app --image-stream mysql:8.0 \
    -e MYSQL_USER=testuser=tflannag \
    -e MYSQL_PASSWORD=testpass \
    -e MYSQL_DATABASE=metastore \
    -l db=mysql
```

Once that deployment has been created, the following MeteringConfig
custom resource was used:

```yaml
apiVersion: metering.openshift.io/v1
kind: MeteringConfig
metadata:
  name: "operator-metering"
  annotations:
    "ansible.operator-sdk/verbosity": "1"
spec:
  unsupportedFeatures:
    enableHDFS: true

  storage:
    type: "hive"
    hive:
      type: "hdfs"
      hdfs:
        namenode: "hdfs-namenode-0.hdfs-namenode:9820"

  hive:
    spec:
      config:
        db:
          driver: com.mysql.jdbc.Driver
          username: tflannag
          password: testpass
          url: jdbc:mysql://mysql.tflannag.svc.cluster.local:3306/metastore
```

The changes in this PR were tested using a custom 
metering-ansible-operator image that contains the
requisite helm chart and Ansible fixes and deployed
manually using the deploy-metering CLI:

```bash
./bin/deploy-metering install --namespace tflannag --meteringconfig mc.yaml --repo <custom quay repo> --tag <custom quay tag>
```
