### PR TITLE
Bug 1838845: Fix Hive metastore deployment with using PostgeSQL as the underlying database

### DIFF
--- a/Documentation/configuring-hive-metastore.md
+++ b/Documentation/configuring-hive-metastore.md
@@ -67,8 +67,6 @@ You can pass additional JDBC parameters using the `spec.hive.spec.config.db.url`
 
 ## Using PostgreSQL for the Hive Metastore database
 
-**Note**:  Metering cannot work with more recent versions of PostgreSQL, which is being tracking in [BZ #1838845](https://bugzilla.redhat.com/show_bug.cgi?id=1838845).
-
 ```yaml
 spec:
   hive:
@@ -78,6 +76,7 @@ spec:
           url: "jdbc:postgresql://postgresql.example.com:5432/hive_metastore"
           driver: "org.postgresql.Driver"
           secretName: "REPLACEME"
+          autoCreateMetastoreSchema: false
 ```
 
 You can pass additional JDBC parameters using the `url`, for more details see [the PostgreSQL JDBC driver documentation](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters).

--- a/charts/openshift-metering/templates/hive/hive-configmap.yaml
+++ b/charts/openshift-metering/templates/hive/hive-configmap.yaml
@@ -13,6 +13,16 @@ data:
         <name>hive.server2.use.SSL</name>
         <value>false</value>
       </property>
+{{- if eq .Values.hive.spec.config.db.type "postgres" -}}
+      <property>
+        <name>hive.metastore.transactional.event.listeners</name>
+        <value></value>
+      </property>
+      <property>
+        <name>hive.metastore.event.listeners</name>
+        <value>org.apache.hive.hcatalog.listener.DbNotificationListener</value>
+      </property>
+{{- end }}
       <property>
         <name>hive.server2.authentication</name>
         <value>NOSASL</value>

--- a/test/e2e/inspect_hive_site_xml_test.go
+++ b/test/e2e/inspect_hive_site_xml_test.go
@@ -1,0 +1,46 @@
+package e2e
+
+import (
+	"context"
+	"encoding/xml"
+	"testing"
+
+	"github.com/kube-reporting/metering-operator/test/reportingframework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type config struct {
+	Property []property `xml:"property"`
+}
+
+type property struct {
+	Name  string `xml:"name"`
+	Value string `xml:"value"`
+}
+
+const configmapName = "hive-config"
+
+func testEnsurePostgresParametersAreMissing(t *testing.T, rf *reportingframework.ReportingFramework) {
+	cm, err := rf.KubeClient.CoreV1().ConfigMaps(rf.Namespace).Get(context.Background(), configmapName, metav1.GetOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	config := config{}
+	err = xml.Unmarshal([]byte(cm.Data["hive-site.xml"]), &config)
+	require.NoError(t, err, "unmarshing the hive-site.xml should produce no error")
+
+	blocklist := []string{
+		"hive.metastore.transactional.event.listeners",
+		"hive.metastore.event.listeners",
+	}
+	for _, property := range config.Property {
+		for _, block := range blocklist {
+			if property.Name == block {
+				assert.NoError(t, err, "expected the %s parameter would not be present in hive-site.xml", property.Name)
+			}
+		}
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -320,6 +320,10 @@ func TestManualMeteringInstall(t *testing.T) {
 					Name:     "testFailedPrometheusQueryEvents",
 					TestFunc: testFailedPrometheusQueryEvents,
 				},
+				{
+					Name:     "testEnsurePostgresParametersAreMissing",
+					TestFunc: testEnsurePostgresParametersAreMissing,
+				},
 			},
 			MeteringConfigManifestFilename: "mysql.yaml",
 		},


### PR DESCRIPTION
# Overview

In the pre-GA (4.2) days, we supported configuring a PostgreSQL database for usage as the underlying database for the Hive metastore and server deployments. Since GA, using this functionality resulted in no Prometheus metrics being inserting into tables in Hive. This was caused by the Hive components hanging (e.g. reaching a deadlock state) when attempting to create the default `ReportDataSource` metric importer tables.

This builds off of #1463 which introduces the `$HIVE_UNDERLYING_DATABASE` environment variable and using `schematool` to do the schema initialization for non-derby databases.

## Changes

- Update the `configuring-hive-metastore.md`  documentation and remove the reference to the BZ mentioning metering integration issues with any Postgres version.
- Update the `configuring-hive-metastore.md` documentation and document that we should be setting `hive.spec.config.db.autoCreateMetastoreSchema: false` when using postgresql metering deployments.
- Updates the hive-site.xml ConfigMap configuration and exposes the `hive.metastore.*,event.listeners` parameters, which helped resolve issues where Hive metastore/server were reaching deadlock when attempting to create tables in Postgres. This properties are only added in the case that we're using `postgres` as the underlying Hive metastore database. That `postgres` value is parsed from the `hive.spec.config.db.url` parameter, which users set in the `MeteringConfig` CR, and re-mapped from `postgresql` to `postgres` in the `configuring_hive_metastore.yaml` Ansible task file.
- Adds a quick e2e subtest that ensures those `hive.metastore.*.event.listeners` aren't present in the hive-config ConfigMap data section where we store the `hive-site.xml` configuration for non-postgresql metering deployments. 

## Testing Notes

The postgresql database instance was created using `oc new-app` using the following command:

```bash
oc create namespace tflannag
oc -n tflannag new-app --image-stream postgresql:10 \
    -e POSTGRESQL_USER=tflannag \
    -e POSTGRESQL_PASSWORD=testpass \
    -e POSTGRESQL_DATABASE=metastore \
    -l db=postgres
```

Once that deployment has been created, the following MeteringConfig custom resource was used:

```yaml
apiVersion: metering.openshift.io/v1
kind: MeteringConfig
metadata:
  name: "operator-metering"
  annotations:
    "ansible.operator-sdk/verbosity": "1"
spec:
  unsupportedFeatures:
    enableHDFS: true

  storage:
    type: "hive"
    hive:
      type: "hdfs"
      hdfs:
        namenode: "hdfs-namenode-0.hdfs-namenode:9820"

  hive:
    spec:
      config:
        db:
          driver: org.postgresql.Driver
          username: tflannag
          password: testpass
          url: jdbc:postgresql://postgresql.tflannag.svc.cluster.local:5432/metastore?logUnclosedConnections=true
          autoCreateMetastoreSchema: false
```

The changes in this PR were tested using a custom metering-ansible-operator image that contains the requisite helm chart and Ansible fixes and deployed manually using the deploy-metering CLI:

```bash
./bin/deploy-metering install --namespace tflannag --meteringconfig mc.yaml --repo <custom quay repo> --tag <custom quay tag>
```
