### PR TITLE
test: Fix the Report expiration subtest handler functions

### DIFF
--- a/test/e2e/report_dynamic_input_data_test.go
+++ b/test/e2e/report_dynamic_input_data_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
+	meteringv1 "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
 	"github.com/kube-reporting/metering-operator/pkg/operator/reporting"
 	"github.com/kube-reporting/metering-operator/test/reportingframework"
 )
@@ -20,9 +20,9 @@ var (
 
 func testReportingProducesData(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
 	// cron schedule to run every minute
-	cronSchedule := &metering.ReportSchedule{
-		Period: metering.ReportPeriodCron,
-		Cron: &metering.ReportScheduleCron{
+	cronSchedule := &meteringv1.ReportSchedule{
+		Period: meteringv1.ReportPeriodCron,
+		Cron: &meteringv1.ReportScheduleCron{
 			Expression: "*/1 * * * *",
 		},
 	}
@@ -90,8 +90,8 @@ func testReportingProducesData(t *testing.T, testReportingFramework *reportingfr
 type reportProducesDataTestCase struct {
 	name          string
 	queryName     string
-	schedule      *metering.ReportSchedule
-	newReportFunc func(name, queryName string, schedule *metering.ReportSchedule, start, end *time.Time, expiration *metav1.Duration) *metering.Report
+	schedule      *meteringv1.ReportSchedule
+	newReportFunc func(name, queryName string, schedule *meteringv1.ReportSchedule, start, end *time.Time, expiration *metav1.Duration) *meteringv1.Report
 	skip          bool
 	parallel      bool
 }
@@ -125,7 +125,7 @@ func testReportsProduceData(t *testing.T, testReportingFramework *reportingframe
 			var reportStart time.Time
 			// for each datasource, wait until it's EarliestImportedMetricTime is set
 			for _, ds := range dependencies.ReportDataSources {
-				_, err := testReportingFramework.WaitForMeteringReportDataSource(t, ds.Name, 5*time.Second, 5*time.Minute, func(dataSource *metering.ReportDataSource) (bool, error) {
+				_, err := testReportingFramework.WaitForMeteringReportDataSource(t, ds.Name, 5*time.Second, 5*time.Minute, func(dataSource *meteringv1.ReportDataSource) (bool, error) {
 					if dataSource.Spec.PrometheusMetricsImporter == nil {
 						return true, nil
 					}

--- a/test/e2e/report_dynamic_input_data_test.go
+++ b/test/e2e/report_dynamic_input_data_test.go
@@ -1,16 +1,10 @@
 package e2e
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"github.com/kube-reporting/metering-operator/test/testhelpers"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"strings"
 	"testing"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,140 +164,4 @@ func testReportsProduceData(t *testing.T, testReportingFramework *reportingframe
 			assert.NotEmpty(t, reportResults, "reports should return at least 1 row")
 		})
 	}
-}
-
-func testReportIsDeletedWhenNoDeps(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
-	reportName := "report-should-delete"
-	// cron schedule to run every minute
-	cronSchedule := &metering.ReportSchedule{
-		Period: metering.ReportPeriodCron,
-		Cron: &metering.ReportScheduleCron{
-			Expression: "*/1 * * * *",
-		},
-	}
-	var foundOnce bool
-	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
-	// If a report is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
-	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
-	waitTimeWhileCheckDeletion := 4 * time.Minute
-
-	report := testReportingFramework.NewSimpleReport(
-		reportName,
-		"namespace-memory-request",
-		cronSchedule,
-		nil,
-		nil,
-		expiration,
-	)
-	t.Logf("creating report %s and waiting %s to finish", report.Name, waitTimeWhileCheckDeletion)
-	createErr := testReportingFramework.CreateMeteringReport(report)
-	assert.NoError(t, createErr, "creating report should produce no error")
-
-	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
-		_, err := testReportingFramework.GetMeteringReport(reportName)
-		// `foundOnce` provides a latch that allows us to wait for report creation then exit on deletion
-		if err == nil {
-			foundOnce = true
-		}
-		if err != nil {
-			if foundOnce && apierrors.IsNotFound(err) {
-				return true, errors.New("report was deleted after being created")
-			}
-		}
-		// if we're exiting due to timeout, it's a fail
-		return false, nil
-	})
-	if err != nil {
-		assert.Contains(t, err.Error(), "was deleted", "report should have been deleted by retention period being reached")
-	}
-}
-
-func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
-	testQueryName := "namespace-cpu-usage"
-	subReportName := "subreport-should-not-delete"
-	// cron schedule to run every minute
-	cronSchedule := &metering.ReportSchedule{
-		Period: metering.ReportPeriodCron,
-		Cron: &metering.ReportScheduleCron{
-			Expression: "*/1 * * * *",
-		},
-	}
-	var foundOnce bool
-	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
-	// If a subReport is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
-	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
-	waitTimeWhileCheckDeletion := 4 * time.Minute
-
-	subReport := testReportingFramework.NewSimpleReport(
-		subReportName,
-		testQueryName,
-		cronSchedule,
-		nil,
-		nil,
-		expiration,
-	)
-	t.Logf("creating subReport %s and waiting %s to finish", subReport.Name, waitTimeWhileCheckDeletion)
-
-	createErr := testReportingFramework.CreateMeteringReport(subReport)
-	assert.NoError(t, createErr, "creating subreport should produce no error")
-
-	newDefault := func(s string) *json.RawMessage {
-		v := json.RawMessage(s)
-		return &v
-	}
-
-	report := testhelpers.NewReport(
-		"report-depends-on-subreport",
-		testReportingFramework.Namespace,
-		testQueryName,
-		[]metering.ReportQueryInputValue{
-			metering.ReportQueryInputValue{
-				Name:  "Report",
-				Value: newDefault(`"` + subReportName + `"`),
-			},
-		},
-		nil,
-		nil,
-		metering.ReportStatus{},
-		cronSchedule,
-		false,
-		nil,
-	)
-
-	createErr = testReportingFramework.CreateMeteringReport(report)
-	assert.NoError(t, createErr, "creating report should produce no error")
-
-	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
-		_, err := testReportingFramework.GetMeteringReport(subReportName)
-		// `foundOnce` provides a latch that allows us to wait for subReport creation then exit on deletion
-		if err == nil {
-			foundOnce = true
-		}
-		if err != nil {
-			if foundOnce && apierrors.IsNotFound(err) {
-				return true, errors.New("subReport was deleted after being created")
-			}
-		}
-		// if we're exiting due to timeout, it's correct, because the subReport should not be deleted
-		return false, nil
-	})
-	assert.Contains(t,
-		err.Error(),
-		"timed out waiting",
-		"should have timed out waiting on subReport expiration as subReport should not have been deleted",
-	)
-	listOptions := metav1.ListOptions{}
-	events, err := testReportingFramework.KubeClient.CoreV1().Events(testReportingFramework.Namespace).List(
-		context.Background(),
-		listOptions,
-	)
-	require.NoError(t, err, "failed to list the events in the test namespace")
-	var found bool
-	for _, event := range events.Items {
-		if strings.Contains(event.InvolvedObject.Name, "subreport-should-not-delete") {
-			found = true
-		}
-	}
-
-	assert.True(t, found, "expected to find an event related to Report not deleted because of dependencies")
 }

--- a/test/e2e/report_expiration_tests.go
+++ b/test/e2e/report_expiration_tests.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
+	meteringv1 "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
 	"github.com/kube-reporting/metering-operator/test/reportingframework"
 	"github.com/kube-reporting/metering-operator/test/testhelpers"
 )
@@ -23,9 +23,9 @@ import (
 func testReportIsDeletedWhenNoDeps(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
 	reportName := "report-should-delete"
 	// cron schedule to run every minute
-	cronSchedule := &metering.ReportSchedule{
-		Period: metering.ReportPeriodCron,
-		Cron: &metering.ReportScheduleCron{
+	cronSchedule := &meteringv1.ReportSchedule{
+		Period: meteringv1.ReportPeriodCron,
+		Cron: &meteringv1.ReportScheduleCron{
 			Expression: "*/1 * * * *",
 		},
 	}
@@ -70,9 +70,9 @@ func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFram
 	testQueryName := "namespace-cpu-usage"
 	subReportName := "subreport-should-not-delete"
 	// cron schedule to run every minute
-	cronSchedule := &metering.ReportSchedule{
-		Period: metering.ReportPeriodCron,
-		Cron: &metering.ReportScheduleCron{
+	cronSchedule := &meteringv1.ReportSchedule{
+		Period: meteringv1.ReportPeriodCron,
+		Cron: &meteringv1.ReportScheduleCron{
 			Expression: "*/1 * * * *",
 		},
 	}
@@ -104,15 +104,15 @@ func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFram
 		"report-depends-on-subreport",
 		testReportingFramework.Namespace,
 		testQueryName,
-		[]metering.ReportQueryInputValue{
-			metering.ReportQueryInputValue{
+		[]meteringv1.ReportQueryInputValue{
+			meteringv1.ReportQueryInputValue{
 				Name:  "Report",
 				Value: newDefault(`"` + subReportName + `"`),
 			},
 		},
 		nil,
 		nil,
-		metering.ReportStatus{},
+		meteringv1.ReportStatus{},
 		cronSchedule,
 		false,
 		nil,

--- a/test/e2e/report_expiration_tests.go
+++ b/test/e2e/report_expiration_tests.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -14,51 +15,90 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 
 	meteringv1 "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
 	"github.com/kube-reporting/metering-operator/test/reportingframework"
 	"github.com/kube-reporting/metering-operator/test/testhelpers"
 )
 
-func testReportIsDeletedWhenNoDeps(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
-	reportName := "report-should-delete"
-	// cron schedule to run every minute
-	cronSchedule := &meteringv1.ReportSchedule{
+var (
+	// If a report is in dependency unmet state it won't be deleted and
+	// it can take awhile for import to happen. 4 minutes seems to be enough
+	// time for that setup, and the delete, to reliably happen.
+	waitTimeWhileCheckDeletion = 4 * time.Minute
+	// Create a 30s time duration as input for a Report expiration period.
+	expiration = &metav1.Duration{Duration: 30.0 * time.Second}
+	// Use a one minute cron schedule as input for schedule Reports.
+	cronSchedule = &meteringv1.ReportSchedule{
 		Period: meteringv1.ReportPeriodCron,
 		Cron: &meteringv1.ReportScheduleCron{
 			Expression: "*/1 * * * *",
 		},
 	}
+	// Use the `namespace-cpu-usage` ReportQuery for the Report
+	// expiration tests.
+	reportQueryName = "namespace-cpu-usage"
+
+	emptyReportStatus   = meteringv1.ReportStatus{}
+	emptyReportSchedule = meteringv1.ReportSchedule{}
+)
+
+// newDefault is a helper function that translates
+// a string into the JSON representation of that string.
+func newDefault(s string) *json.RawMessage {
+	v := json.RawMessage(s)
+	return &v
+}
+
+// ensureEventExists is a helper function that lists all the events
+// in a namespace and checks whether an event has been created
+func ensureEventExists(client kubernetes.Interface, name, namespace string) error {
+	events, err := client.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	var found bool
+	for _, event := range events.Items {
+		if strings.Contains(event.InvolvedObject.Name, name) {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("failed to find the %s involved object in the %s namespace list of events", name, namespace)
+	}
+
+	return nil
+}
+
+// testReportIsDeletedWhenNoDeps ensures that creating a scheduled
+// Report with a configured expiration and no other Report/ReportQuery
+// dependencies will be deleting by the reporting-operator before the
+// poll timeout period.
+func testReportIsDeletedWhenNoDeps(t *testing.T, rf *reportingframework.ReportingFramework) {
+	reportName := "e2e-report-with-expiration-should-delete"
+
+	t.Logf("Creating the %s run-once Report and waiting %v to finish", reportName, waitTimeWhileCheckDeletion)
+	report := rf.NewSimpleReport(reportName, reportQueryName, cronSchedule, nil, nil, expiration)
+	err := rf.CreateMeteringReport(report)
+	require.NoError(t, err, "creating a report that has a configured expiration should produce no error")
+
 	var foundOnce bool
-	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
-	// If a report is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
-	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
-	waitTimeWhileCheckDeletion := 4 * time.Minute
-
-	report := testReportingFramework.NewSimpleReport(
-		reportName,
-		"namespace-memory-request",
-		cronSchedule,
-		nil,
-		nil,
-		expiration,
-	)
-	t.Logf("creating report %s and waiting %s to finish", report.Name, waitTimeWhileCheckDeletion)
-	createErr := testReportingFramework.CreateMeteringReport(report)
-	assert.NoError(t, createErr, "creating report should produce no error")
-
-	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
-		_, err := testReportingFramework.GetMeteringReport(reportName)
-		// `foundOnce` provides a latch that allows us to wait for report creation then exit on deletion
-		if err == nil {
-			foundOnce = true
+	err = wait.Poll(5*time.Second, waitTimeWhileCheckDeletion, func() (bool, error) {
+		_, err := rf.GetMeteringReport(report.Name)
+		if apierrors.IsNotFound(err) {
+			if !foundOnce {
+				return false, nil
+			}
+			t.Logf("The %s Report has been deleted", report.Name)
+			return true, errors.New("report was deleted after being created")
 		}
 		if err != nil {
-			if foundOnce && apierrors.IsNotFound(err) {
-				return true, errors.New("report was deleted after being created")
-			}
+			return false, err
 		}
-		// if we're exiting due to timeout, it's a fail
+
+		foundOnce = true
 		return false, nil
 	})
 	if err != nil {
@@ -66,72 +106,61 @@ func testReportIsDeletedWhenNoDeps(t *testing.T, testReportingFramework *reporti
 	}
 }
 
-func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
-	testQueryName := "namespace-cpu-usage"
-	subReportName := "subreport-should-not-delete"
-	// cron schedule to run every minute
-	cronSchedule := &meteringv1.ReportSchedule{
-		Period: meteringv1.ReportPeriodCron,
-		Cron: &meteringv1.ReportScheduleCron{
-			Expression: "*/1 * * * *",
+// testReportIsNotDeletedWhenReportDependsOnIt ensures that a Report
+// that has been configured with a retention period will not be deleted
+// when another Report references it as an input, i.e. depends on it.
+func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, rf *reportingframework.ReportingFramework) {
+	now := time.Now()
+	t1 := now.UTC().AddDate(0, 0, -1)
+	t2 := now.UTC()
+	testSubReportName := "subreport-cpu-usage-run-immediately-expiration-report"
+
+	t.Logf("Creating the %s sub-Report and waiting %v to finish", testSubReportName, waitTimeWhileCheckDeletion)
+	subReport := testhelpers.NewReport(testSubReportName, rf.Namespace, reportQueryName, nil, &t1, &t2, emptyReportStatus, nil, true, expiration)
+	err := rf.CreateMeteringReport(subReport)
+	require.NoError(t, err, "creating a cron schedule report with a 30s expiration should produce no error")
+
+	// TODO: should verify the status as a valid report
+	testReportQueryName := fmt.Sprintf("custom-%s-%s-rq", namespacePrefix, reportQueryName)
+	inputReportQueryName := strings.ReplaceAll(subReport.Name, "-", "")
+	rq := testhelpers.NewReportQuery(testReportQueryName, rf.Namespace, []meteringv1.ReportQueryColumn{{Name: "foo", Type: "double"}})
+	rq.Spec.Inputs = []meteringv1.ReportQueryInputDefinition{
+		{
+			Name:     inputReportQueryName,
+			Type:     "Report",
+			Required: true,
+			Default:  newDefault(`"` + subReport.Name + `"`),
 		},
 	}
+	rq.Spec.Query = "SELECT 1"
+	t.Logf("Creating the %s aggregate ReportQuery from the %s Report", testReportQueryName, subReport.Name)
+	_, err = rf.MeteringClient.ReportQueries(rf.Namespace).Create(context.Background(), rq, metav1.CreateOptions{})
+	require.NoError(t, err, "creating a custom ReportQuery from a sub-report should produce no error")
+
+	rollupReportName := "report-depends-on-subreport"
+	rollupReportInputs := []meteringv1.ReportQueryInputValue{
+		{
+			Name:  strings.ReplaceAll(subReport.Name, "-", ""),
+			Value: newDefault(`"` + subReport.Name + `"`),
+		},
+	}
+	report := testhelpers.NewReport(rollupReportName, rf.Namespace, testReportQueryName, rollupReportInputs, nil, nil, emptyReportStatus, cronSchedule, false, nil)
+
+	t.Logf("Creating the %s rollup Report from the %s aggregate ReportQuery", rollupReportName, testReportQueryName)
+	err = rf.CreateMeteringReport(report)
+	assert.NoError(t, err, "creating a rollup report should produce no error", rollupReportName)
+
 	var foundOnce bool
-	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
-	// If a subReport is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
-	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
-	waitTimeWhileCheckDeletion := 4 * time.Minute
-
-	subReport := testReportingFramework.NewSimpleReport(
-		subReportName,
-		testQueryName,
-		cronSchedule,
-		nil,
-		nil,
-		expiration,
-	)
-	t.Logf("creating subReport %s and waiting %s to finish", subReport.Name, waitTimeWhileCheckDeletion)
-
-	createErr := testReportingFramework.CreateMeteringReport(subReport)
-	assert.NoError(t, createErr, "creating subreport should produce no error")
-
-	newDefault := func(s string) *json.RawMessage {
-		v := json.RawMessage(s)
-		return &v
-	}
-
-	report := testhelpers.NewReport(
-		"report-depends-on-subreport",
-		testReportingFramework.Namespace,
-		testQueryName,
-		[]meteringv1.ReportQueryInputValue{
-			meteringv1.ReportQueryInputValue{
-				Name:  "Report",
-				Value: newDefault(`"` + subReportName + `"`),
-			},
-		},
-		nil,
-		nil,
-		meteringv1.ReportStatus{},
-		cronSchedule,
-		false,
-		nil,
-	)
-
-	createErr = testReportingFramework.CreateMeteringReport(report)
-	assert.NoError(t, createErr, "creating report should produce no error")
-
-	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
-		_, err := testReportingFramework.GetMeteringReport(subReportName)
-		// `foundOnce` provides a latch that allows us to wait for subReport creation then exit on deletion
-		if err == nil {
+	err = wait.Poll(5*time.Second, waitTimeWhileCheckDeletion, func() (bool, error) {
+		_, err := rf.GetMeteringReport(subReport.Name)
+		if apierrors.IsAlreadyExists(err) {
+			t.Logf("The %s Report has been created", subReport.Name)
 			foundOnce = true
 		}
-		if err != nil {
-			if foundOnce && apierrors.IsNotFound(err) {
-				return true, errors.New("subReport was deleted after being created")
-			}
+		if foundOnce && apierrors.IsNotFound(err) {
+			return true, errors.New("subReport was deleted after being created")
 		}
+
 		// if we're exiting due to timeout, it's correct, because the subReport should not be deleted
 		return false, nil
 	})
@@ -140,18 +169,7 @@ func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFram
 		"timed out waiting",
 		"should have timed out waiting on subReport expiration as subReport should not have been deleted",
 	)
-	listOptions := metav1.ListOptions{}
-	events, err := testReportingFramework.KubeClient.CoreV1().Events(testReportingFramework.Namespace).List(
-		context.Background(),
-		listOptions,
-	)
-	require.NoError(t, err, "failed to list the events in the test namespace")
-	var found bool
-	for _, event := range events.Items {
-		if strings.Contains(event.InvolvedObject.Name, "subreport-should-not-delete") {
-			found = true
-		}
-	}
 
-	assert.True(t, found, "expected to find an event related to Report not deleted because of dependencies")
+	err = ensureEventExists(rf.KubeClient, subReport.Name, rf.Namespace)
+	require.NoError(t, err, "expected to find an event related to Report not deleted because of dependencies")
 }

--- a/test/e2e/report_expiration_tests.go
+++ b/test/e2e/report_expiration_tests.go
@@ -1,0 +1,157 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	metering "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1"
+	"github.com/kube-reporting/metering-operator/test/reportingframework"
+	"github.com/kube-reporting/metering-operator/test/testhelpers"
+)
+
+func testReportIsDeletedWhenNoDeps(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
+	reportName := "report-should-delete"
+	// cron schedule to run every minute
+	cronSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron: &metering.ReportScheduleCron{
+			Expression: "*/1 * * * *",
+		},
+	}
+	var foundOnce bool
+	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
+	// If a report is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
+	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
+	waitTimeWhileCheckDeletion := 4 * time.Minute
+
+	report := testReportingFramework.NewSimpleReport(
+		reportName,
+		"namespace-memory-request",
+		cronSchedule,
+		nil,
+		nil,
+		expiration,
+	)
+	t.Logf("creating report %s and waiting %s to finish", report.Name, waitTimeWhileCheckDeletion)
+	createErr := testReportingFramework.CreateMeteringReport(report)
+	assert.NoError(t, createErr, "creating report should produce no error")
+
+	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
+		_, err := testReportingFramework.GetMeteringReport(reportName)
+		// `foundOnce` provides a latch that allows us to wait for report creation then exit on deletion
+		if err == nil {
+			foundOnce = true
+		}
+		if err != nil {
+			if foundOnce && apierrors.IsNotFound(err) {
+				return true, errors.New("report was deleted after being created")
+			}
+		}
+		// if we're exiting due to timeout, it's a fail
+		return false, nil
+	})
+	if err != nil {
+		assert.Contains(t, err.Error(), "was deleted", "report should have been deleted by retention period being reached")
+	}
+}
+
+func testReportIsNotDeletedWhenReportDependsOnIt(t *testing.T, testReportingFramework *reportingframework.ReportingFramework) {
+	testQueryName := "namespace-cpu-usage"
+	subReportName := "subreport-should-not-delete"
+	// cron schedule to run every minute
+	cronSchedule := &metering.ReportSchedule{
+		Period: metering.ReportPeriodCron,
+		Cron: &metering.ReportScheduleCron{
+			Expression: "*/1 * * * *",
+		},
+	}
+	var foundOnce bool
+	expiration := &metav1.Duration{Duration: 30.0 * time.Second}
+	// If a subReport is in dependency unmet state it won't be deleted and it can take awhile for import to happen.
+	// 4 minutes seems to be enough time for that setup, and the delete, to reliably happen.
+	waitTimeWhileCheckDeletion := 4 * time.Minute
+
+	subReport := testReportingFramework.NewSimpleReport(
+		subReportName,
+		testQueryName,
+		cronSchedule,
+		nil,
+		nil,
+		expiration,
+	)
+	t.Logf("creating subReport %s and waiting %s to finish", subReport.Name, waitTimeWhileCheckDeletion)
+
+	createErr := testReportingFramework.CreateMeteringReport(subReport)
+	assert.NoError(t, createErr, "creating subreport should produce no error")
+
+	newDefault := func(s string) *json.RawMessage {
+		v := json.RawMessage(s)
+		return &v
+	}
+
+	report := testhelpers.NewReport(
+		"report-depends-on-subreport",
+		testReportingFramework.Namespace,
+		testQueryName,
+		[]metering.ReportQueryInputValue{
+			metering.ReportQueryInputValue{
+				Name:  "Report",
+				Value: newDefault(`"` + subReportName + `"`),
+			},
+		},
+		nil,
+		nil,
+		metering.ReportStatus{},
+		cronSchedule,
+		false,
+		nil,
+	)
+
+	createErr = testReportingFramework.CreateMeteringReport(report)
+	assert.NoError(t, createErr, "creating report should produce no error")
+
+	err := wait.Poll(time.Second*5, waitTimeWhileCheckDeletion, func() (bool, error) {
+		_, err := testReportingFramework.GetMeteringReport(subReportName)
+		// `foundOnce` provides a latch that allows us to wait for subReport creation then exit on deletion
+		if err == nil {
+			foundOnce = true
+		}
+		if err != nil {
+			if foundOnce && apierrors.IsNotFound(err) {
+				return true, errors.New("subReport was deleted after being created")
+			}
+		}
+		// if we're exiting due to timeout, it's correct, because the subReport should not be deleted
+		return false, nil
+	})
+	assert.Contains(t,
+		err.Error(),
+		"timed out waiting",
+		"should have timed out waiting on subReport expiration as subReport should not have been deleted",
+	)
+	listOptions := metav1.ListOptions{}
+	events, err := testReportingFramework.KubeClient.CoreV1().Events(testReportingFramework.Namespace).List(
+		context.Background(),
+		listOptions,
+	)
+	require.NoError(t, err, "failed to list the events in the test namespace")
+	var found bool
+	for _, event := range events.Items {
+		if strings.Contains(event.InvolvedObject.Name, "subreport-should-not-delete") {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "expected to find an event related to Report not deleted because of dependencies")
+}

--- a/test/reportingframework/report.go
+++ b/test/reportingframework/report.go
@@ -23,6 +23,20 @@ import (
 	meteringUtil "github.com/kube-reporting/metering-operator/pkg/apis/metering/v1/util"
 )
 
+// CreateReportQuery is a helper method that creates the
+// @rq ReportQuery using the interal Meteringv1 clientset.
+func (rf *ReportingFramework) CreateReportQuery(rq *metering.ReportQuery) error {
+	_, err := rf.MeteringClient.ReportQueries(rf.Namespace).Create(context.Background(), rq, metav1.CreateOptions{})
+	return err
+}
+
+// CreateReportQueryWithContext is a helper method that creates the
+// @rq ReportQuery using context provided to the interal Meteringv1 clientset.
+func (rf *ReportingFramework) CreateReportQueryWithContext(ctx context.Context, rq *metering.ReportQuery) error {
+	_, err := rf.MeteringClient.ReportQueries(rf.Namespace).Create(ctx, rq, metav1.CreateOptions{})
+	return err
+}
+
 func (rf *ReportingFramework) CreateMeteringReport(report *metering.Report) error {
 	_, err := rf.MeteringClient.Reports(rf.Namespace).Create(context.Background(), report, metav1.CreateOptions{})
 	return err


### PR DESCRIPTION
Update these report expiration subtest functions that are responsible
for testing the expiration functionality. Before, some of these report
objects that were created were flat out invalid, especially in the case
of the testing the rollup report scenarios.

In the case of the testing rollup reports, we need to create a
reportquery custom resource that acts as the aggregate query and sits
between the sub-report and the aggregate report. Then, we can list that
sub-report as an input to the aggregate report while still referencing a
valid reportquery custom resource.