### PR TITLE
Bug 1926984: Avoid requeueing an expired Report

### DIFF
--- a/pkg/operator/reports.go
+++ b/pkg/operator/reports.go
@@ -414,11 +414,8 @@ func (op *defaultReportingOperator) handleExpiredReport(logger log.FieldLogger, 
 // the period has elapsed.
 func (op *defaultReportingOperator) runReport(logger log.FieldLogger, report *metering.Report) error {
 	// check if the report we're currently processing is considered
-	// "expired". If true, exit early and requeue that object so
-	// op.syncReport calls the proper handler for this resource.
+	// "expired". If true, exit early.
 	if reportExpired := isReportExpired(logger, report, time.Now()); reportExpired {
-		logger.Infof("requeueing report that has reached its expiration date during the op.runReport method")
-		op.enqueueReport(report)
 		return nil
 	}
 


### PR DESCRIPTION
Update the Report handler and avoid requeueing a Report that is
reporting an `expired` status. Before, this would result in the
reporting-operator hot looping as this Report custom resource would
continue to get queued up.

Instead, if we're encountering a Report that
has reached its expiration date, then we should avoid processing it in
the Report handler function and let the call site determine how to
process that Report further in the next cycle.