### PR TITLE
test/e2e: Deflate the MySQL e2e test

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -391,6 +392,8 @@ func TestManualMeteringInstall(t *testing.T) {
 		if testCase.Skip {
 			continue
 		}
+
+		time.Sleep(3 * time.Second)
 
 		t.Run(testCase.Name, func(t *testing.T) {
 			// If we call t.Parallel() here, the top-level test will

--- a/test/e2e/manifests/meteringconfigs/mysql.yaml
+++ b/test/e2e/manifests/meteringconfigs/mysql.yaml
@@ -60,6 +60,7 @@ spec:
           username: testuser
           password: testpass
           url: jdbc:mysql://mysql.mysql.svc.cluster.local:3306/metastore
+
   hadoop:
     spec:
       hdfs:


### PR DESCRIPTION
We're currently seeing metering e2e runs fail as OLM can't create the
metering installation due to conflict errors when updating resources
(typically CRDs), so this _attempts_ to try and space those go routines
out.