### PR TITLE
[release-4.6] Dockerfile: Avoid using dockerhub images in the testing root image

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -3,7 +3,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.6:metering-helm as helm
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
 FROM registry.svc.ci.openshift.org/ocp/4.6:cli as cli
 # need golang for the unit/vendor/verify CI checks
-FROM openshift/origin-release:golang-1.13
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13
 
 # go get faq via static Linux binary approach
 ARG LATEST_RELEASE=0.0.6


### PR DESCRIPTION
Update the Golang base image we pull from to use the one from the
registry.svc.ci.openshift.org registry due to rate limiting when pulling
from dockerhub.