### PR TITLE
test: Handle failed InstallPlans during e2e installations

### DIFF
--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -87,6 +87,10 @@ func (df *DeployFramework) NewDeployerCtx(
 	subscriptionChannel,
 	outputPath string,
 	extraLocalEnvVars []string,
+	deleteNamespace,
+	deleteCRD,
+	deleteCRB,
+	deletePVC bool,
 	spec metering.MeteringConfigSpec,
 ) (*DeployerCtx, error) {
 	cfg, err := df.NewDeployerConfig(
@@ -98,6 +102,10 @@ func (df *DeployFramework) NewDeployerCtx(
 		catalogSourceName,
 		catalogSourceNamespace,
 		subscriptionChannel,
+		deleteNamespace,
+		deleteCRD,
+		deleteCRB,
+		deletePVC,
 		spec,
 	)
 	if err != nil {
@@ -113,7 +121,7 @@ func (df *DeployFramework) NewDeployerCtx(
 		return nil, fmt.Errorf("failed to successfully stat the %s path to the hack script directory: %v", hackScriptDir, err)
 	}
 
-	targetPodCount := defaultTargetPods
+	targetPodCount := DefaultTargetPods
 	if df.RunLocal {
 		var replicas int32
 
@@ -212,10 +220,14 @@ func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.Rep
 			InitialDelay:  initialDelay,
 			TimeoutPeriod: waitingForPodsTimeoutPeriod,
 			Client:        ctx.Client,
+			OLMClient:     ctx.OLMV1Alpha1Client,
 			Logger:        ctx.Logger.WithField("component", "podWaiter"),
 		}
-		err = pw.WaitForPods(ctx.Namespace, ctx.TargetPodsCount)
+		err := pw.WaitForPods(ctx.Namespace, ctx.TargetPodsCount)
 		if err != nil {
+			if err == ErrInstallPlanFailed {
+				return nil, ErrInstallPlanFailed
+			}
 			return nil, fmt.Errorf("error waiting for metering pods to become ready: %v", err)
 		}
 
@@ -308,9 +320,9 @@ func (ctx *DeployerCtx) Upgrade(catalogSourceName, catalogSourceNamespace, upgra
 	}
 
 	start := time.Now()
-	err = UpdateExistingSubscription(ctx.Logger, ctx.OLMV1Alpha1Client, defaultSubscriptionName, ctx.Namespace, catalogSourceName, catalogSourceNamespace, upgradeChannel)
+	err = UpdateExistingSubscription(ctx.Logger, ctx.OLMV1Alpha1Client, DefaultSubscriptionName, ctx.Namespace, catalogSourceName, catalogSourceNamespace, upgradeChannel)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upgrade the existing %s Subscription: %v", defaultSubscriptionName, err)
+		return nil, fmt.Errorf("failed to upgrade the existing %s Subscription: %v", DefaultSubscriptionName, err)
 	}
 
 	err = WaitForMeteringOperatorDeployment(ctx.Logger, ctx.Client, meteringOperatorDeploymentName, ctx.Namespace)

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -34,13 +34,16 @@ const (
 	meteringconfigMetadataName          = "operator-metering"
 	reportingOperatorServiceAccountName = "reporting-operator"
 
-	defaultTargetPods        = 7
-	defaultPlatform          = "openshift"
-	defaultDeleteNamespace   = true
-	defaultDeleteCRB         = true
-	defaultSubscriptionName  = "metering-ocp"
-	defaultCatalogSourceName = "metering-dev-catalogsource"
-	defaultPackageName       = "metering-ocp"
+	DefaultTargetPods        = 7
+	DefaultPlatform          = "openshift"
+	DefaultSubscriptionName  = "metering-ocp"
+	DefaultCatalogSourceName = "metering-dev-catalogsource"
+	DefaultPackageName       = "metering-ocp"
+
+	DefaultDeleteNamespace = true
+	DefaultDeleteCRB       = true
+	DefaultDeletePVC       = true
+	DefaultDeleteCRD       = false
 
 	manifestsDeployDir = "manifests/deploy"
 	olmManifestsDir    = "olm_deploy/manifests/"
@@ -113,7 +116,7 @@ func New(logger logrus.FieldLogger, runLocal, runDevSetup bool, nsPrefix, repoDi
 		return nil, fmt.Errorf("failed to stat the %s path to the manifest/deploy directory: %v", manifestsDir, err)
 	}
 
-	operatorResources, err := deploy.ReadMeteringAnsibleOperatorManifests(manifestsDir, defaultPlatform)
+	operatorResources, err := deploy.ReadMeteringAnsibleOperatorManifests(manifestsDir, DefaultPlatform)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize objects from manifests: %v", err)
 	}
@@ -149,6 +152,10 @@ func (df *DeployFramework) NewDeployerConfig(
 	catalogSourceName,
 	catalogSourceNamespace,
 	subscriptionChannel string,
+	deleteNamespace,
+	deleteCRDs,
+	deleteCRBs,
+	deletePVCs bool,
 	spec metering.MeteringConfigSpec,
 ) (*deploy.Config, error) {
 	meteringConfig := &metering.MeteringConfig{
@@ -195,11 +202,13 @@ func (df *DeployFramework) NewDeployerConfig(
 		Namespace:              namespace,
 		Repo:                   meteringOperatorImageRepo,
 		Tag:                    meteringOperatorImageTag,
-		Platform:               defaultPlatform,
-		DeleteNamespace:        defaultDeleteNamespace,
-		DeleteCRBs:             defaultDeleteCRB,
-		SubscriptionName:       defaultSubscriptionName,
-		PackageName:            defaultPackageName,
+		Platform:               DefaultPlatform,
+		DeleteNamespace:        deleteNamespace,
+		DeleteCRDs:             deleteCRDs,
+		DeleteCRBs:             deleteCRBs,
+		DeletePVCs:             deletePVCs,
+		SubscriptionName:       DefaultSubscriptionName,
+		PackageName:            DefaultPackageName,
 		CatalogSourceName:      catalogSourceName,
 		CatalogSourceNamespace: catalogSourceNamespace,
 		Channel:                subscriptionChannel,

--- a/test/deployframework/framework_test.go
+++ b/test/deployframework/framework_test.go
@@ -26,21 +26,36 @@ func TestNewDeployerConfig(t *testing.T) {
 	testCatalogSourceNamespace := "marketplace"
 	testSubscriptionChannel := "v0.0.1"
 
-	cfg, err := df.NewDeployerConfig(testNamespace, testMeteringOpRepo, testMeteringOpTag, testReportingOpRepo, testReportingOpTag, testCatalogSourceName, testCatalogSourceNamespace, testSubscriptionChannel, spec)
+	cfg, err := df.NewDeployerConfig(
+		testNamespace,
+		testMeteringOpRepo,
+		testMeteringOpTag,
+		testReportingOpRepo,
+		testReportingOpTag,
+		testCatalogSourceName,
+		testCatalogSourceNamespace,
+		testSubscriptionChannel,
+		DefaultDeleteNamespace,
+		DefaultDeleteCRD,
+		DefaultDeleteCRB,
+		DefaultDeletePVC,
+		spec)
 	require.NoError(t, err)
 
 	expectedCfg := &deploy.Config{
 		Namespace:              testNamespace,
 		Repo:                   testMeteringOpRepo,
 		Tag:                    testMeteringOpTag,
-		Platform:               defaultPlatform,
-		SubscriptionName:       defaultSubscriptionName,
-		PackageName:            defaultPackageName,
+		Platform:               DefaultPlatform,
+		SubscriptionName:       DefaultSubscriptionName,
+		PackageName:            DefaultPackageName,
 		CatalogSourceName:      testCatalogSourceName,
 		CatalogSourceNamespace: testCatalogSourceNamespace,
 		Channel:                testSubscriptionChannel,
-		DeleteCRBs:             defaultDeleteCRB,
-		DeleteNamespace:        defaultDeleteNamespace,
+		DeleteNamespace:        DefaultDeleteNamespace,
+		DeleteCRDs:             DefaultDeleteCRD,
+		DeleteCRBs:             DefaultDeleteCRB,
+		DeletePVCs:             DefaultDeletePVC,
 		ExtraNamespaceLabels: map[string]string{
 			"name": fmt.Sprintf("%s-%s", df.NamespacePrefix, testNamespaceLabel),
 		},

--- a/test/deployframework/registry.go
+++ b/test/deployframework/registry.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (df *DeployFramework) CreateCatalogSourceFromIndex(indexImage string) (string, string, error) {
-	catalogSourceName := df.NamespacePrefix + "-" + defaultCatalogSourceName
+	catalogSourceName := df.NamespacePrefix + "-" + DefaultCatalogSourceName
 
 	catalogSource, err := df.OLMV1Alpha1Client.CatalogSources(registryDeployNamespace).Get(context.TODO(), catalogSourceName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -76,7 +76,7 @@ func (df *DeployFramework) CreateRegistryResources(registryImage, meteringOperat
 	}
 
 	var catalogSource *olmv1alpha1.CatalogSource
-	catalogSourceName := df.NamespacePrefix + "-" + defaultCatalogSourceName
+	catalogSourceName := df.NamespacePrefix + "-" + DefaultCatalogSourceName
 
 	catalogSource, err = df.OLMV1Alpha1Client.CatalogSources(registryDeployNamespace).Get(context.TODO(), catalogSourceName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -387,8 +387,9 @@ func TestManualMeteringInstall(t *testing.T) {
 			Name:                      "NFS-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
-			Skip:                      !testing.Short(),
-			PreInstallFunc:            createNFSProvisioner,
+			Skip:                      false,
+			// Skip:                      !testing.Short(),
+			PreInstallFunc: createNFSProvisioner,
 			InstallSubTests: []InstallTestCase{
 				{
 					Name:     "testReportingProducesData",
@@ -459,7 +460,6 @@ func TestMeteringUpgrades(t *testing.T) {
 			PurgeReports:              true,
 			PurgeReportDataSources:    true,
 			Skip:                      false,
-			ExpectInstallErrMsg:       []string{},
 			InstallSubTest: InstallTestCase{
 				Name:     "testReportingProducesData",
 				TestFunc: testReportingProducesData,

--- a/test/e2e/metering_upgrade_test.go
+++ b/test/e2e/metering_upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kube-reporting/metering-operator/test/deployframework"
 	"github.com/kube-reporting/metering-operator/test/reportingframework"
 	"github.com/kube-reporting/metering-operator/test/testhelpers"
 )
@@ -66,6 +67,10 @@ func testManualOLMUpgradeInstall(
 		upgradeFromSubscriptionChannel,
 		preUpgradeTestOutputDir,
 		testInstallFunction.ExtraEnvVars,
+		deployframework.DefaultDeleteNamespace,
+		deployframework.DefaultDeleteCRD,
+		deployframework.DefaultDeleteCRB,
+		deployframework.DefaultDeletePVC,
 		mc.Spec,
 	)
 	require.NoError(t, err, "creating a new deployer context should produce no error")


### PR DESCRIPTION
Update the e2e package to deal with InstallPlan failures that we have no
control over. Currently, OLM will mark an InstallPlan as failed when it
encounters any errors, regardless of the context around that error.

In the context of metering, we're seeing more and more e2e flakes
centered around installations not being able to be installed due to
failed InstallPlan resources. These failed installations are typically
due to CRD conflicts being returned from the apiserver and OLM not
handling that error correctly and the result is metering can't be
installed.

We can workaround this by detecting any failed InstallPlan resources
that we know are due to conflicting resource versions and attempt to
re-install metering in the applicable test handlers.