### PR TITLE
Avoid hardcoding deploy config deletion values

### DIFF
--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -83,7 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&deployManifestsDir, "deploy-manifests-dir", "manifests/deploy", "The absolute/relative path to the metering manifest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR.")
 
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
-	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
+	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRBs, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")
@@ -92,7 +92,7 @@ func init() {
 	// are both using the same flagset. We could switch to an installCmd and uninstallCmd, and
 	// have a --olm sub-command configuration so we could share flags between install/uninstall.
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
-	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
+	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRBs, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -66,7 +66,7 @@ type Config struct {
 	SkipMeteringDeployment   bool
 	RunMeteringOperatorLocal bool
 	DeleteCRDs               bool
-	DeleteCRB                bool
+	DeleteCRBs               bool
 	DeleteNamespace          bool
 	DeletePVCs               bool
 	DeleteAll                bool
@@ -139,7 +139,7 @@ func NewDeployer(
 	if deploy.config.DeleteAll {
 		deploy.config.DeletePVCs = true
 		deploy.config.DeleteNamespace = true
-		deploy.config.DeleteCRB = true
+		deploy.config.DeleteCRBs = true
 		deploy.config.DeleteCRDs = true
 	}
 	if deploy.config.Namespace == "" {
@@ -220,7 +220,7 @@ func (deploy *Deployer) UninstallOLM() error {
 			return fmt.Errorf("failed to uninstall the %s metering namespace: %v", deploy.config.Namespace, err)
 		}
 	}
-	if deploy.config.DeleteCRB {
+	if deploy.config.DeleteCRBs {
 		err = deploy.uninstallReportingOperatorClusterRole()
 		if err != nil {
 			return fmt.Errorf("failed to delete the reporting-operator ClusterRole resources: %v", err)

--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -131,7 +131,7 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 		return fmt.Errorf("failed to delete the metering role binding: %v", err)
 	}
 
-	if deploy.config.DeleteCRB {
+	if deploy.config.DeleteCRBs {
 		err = deploy.uninstallMeteringClusterRole()
 		if err != nil {
 			return fmt.Errorf("failed to delete the metering cluster role: %v", err)

--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -87,6 +87,10 @@ func (df *DeployFramework) NewDeployerCtx(
 	subscriptionChannel,
 	outputPath string,
 	extraLocalEnvVars []string,
+	deleteNamespace,
+	deleteCRD,
+	deleteCRB,
+	deletePVC bool,
 	spec metering.MeteringConfigSpec,
 ) (*DeployerCtx, error) {
 	cfg, err := df.NewDeployerConfig(
@@ -98,6 +102,10 @@ func (df *DeployFramework) NewDeployerCtx(
 		catalogSourceName,
 		catalogSourceNamespace,
 		subscriptionChannel,
+		deleteNamespace,
+		deleteCRD,
+		deleteCRB,
+		deletePVC,
 		spec,
 	)
 	if err != nil {

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -36,11 +36,14 @@ const (
 
 	defaultTargetPods        = 7
 	defaultPlatform          = "openshift"
-	defaultDeleteNamespace   = true
-	defaultDeleteCRB         = true
 	defaultSubscriptionName  = "metering-ocp"
 	defaultCatalogSourceName = "metering-dev-catalogsource"
 	defaultPackageName       = "metering-ocp"
+
+	DefaultDeleteNamespace = true
+	DefaultDeleteCRB       = true
+	DefaultDeletePVC       = true
+	DefaultDeleteCRD       = false
 
 	manifestsDeployDir = "manifests/deploy"
 	olmManifestsDir    = "olm_deploy/manifests/"
@@ -149,6 +152,10 @@ func (df *DeployFramework) NewDeployerConfig(
 	catalogSourceName,
 	catalogSourceNamespace,
 	subscriptionChannel string,
+	deleteNamespace,
+	deleteCRDs,
+	deleteCRBs,
+	deletePVCs bool,
 	spec metering.MeteringConfigSpec,
 ) (*deploy.Config, error) {
 	meteringConfig := &metering.MeteringConfig{
@@ -196,8 +203,10 @@ func (df *DeployFramework) NewDeployerConfig(
 		Repo:                   meteringOperatorImageRepo,
 		Tag:                    meteringOperatorImageTag,
 		Platform:               defaultPlatform,
-		DeleteNamespace:        defaultDeleteNamespace,
-		DeleteCRB:              defaultDeleteCRB,
+		DeleteNamespace:        deleteNamespace,
+		DeleteCRDs:             deleteCRDs,
+		DeleteCRBs:             deleteCRBs,
+		DeletePVCs:             deletePVCs,
 		SubscriptionName:       defaultSubscriptionName,
 		PackageName:            defaultPackageName,
 		CatalogSourceName:      catalogSourceName,

--- a/test/deployframework/framework_test.go
+++ b/test/deployframework/framework_test.go
@@ -26,7 +26,20 @@ func TestNewDeployerConfig(t *testing.T) {
 	testCatalogSourceNamespace := "marketplace"
 	testSubscriptionChannel := "v0.0.1"
 
-	cfg, err := df.NewDeployerConfig(testNamespace, testMeteringOpRepo, testMeteringOpTag, testReportingOpRepo, testReportingOpTag, testCatalogSourceName, testCatalogSourceNamespace, testSubscriptionChannel, spec)
+	cfg, err := df.NewDeployerConfig(
+		testNamespace,
+		testMeteringOpRepo,
+		testMeteringOpTag,
+		testReportingOpRepo,
+		testReportingOpTag,
+		testCatalogSourceName,
+		testCatalogSourceNamespace,
+		testSubscriptionChannel,
+		DefaultDeleteNamespace,
+		DefaultDeleteCRD,
+		DefaultDeleteCRB,
+		DefaultDeletePVC,
+		spec)
 	require.NoError(t, err)
 
 	expectedCfg := &deploy.Config{
@@ -39,8 +52,10 @@ func TestNewDeployerConfig(t *testing.T) {
 		CatalogSourceName:      testCatalogSourceName,
 		CatalogSourceNamespace: testCatalogSourceNamespace,
 		Channel:                testSubscriptionChannel,
-		DeleteCRB:              defaultDeleteCRB,
-		DeleteNamespace:        defaultDeleteNamespace,
+		DeleteNamespace:        DefaultDeleteNamespace,
+		DeleteCRDs:             DefaultDeleteCRD,
+		DeleteCRBs:             DefaultDeleteCRB,
+		DeletePVCs:             DefaultDeletePVC,
 		ExtraNamespaceLabels: map[string]string{
 			"name": fmt.Sprintf("%s-%s", df.NamespacePrefix, testNamespaceLabel),
 		},

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -79,6 +79,10 @@ func testManualMeteringInstall(
 		subscriptionChannel,
 		testCaseOutputBaseDir,
 		envVars,
+		deployframework.DefaultDeleteNamespace,
+		deployframework.DefaultDeleteCRD,
+		deployframework.DefaultDeleteCRB,
+		deployframework.DefaultDeletePVC,
 		mc.Spec,
 	)
 	require.NoError(t, err, "creating a new deployer context should produce no error")

--- a/test/e2e/metering_upgrade_test.go
+++ b/test/e2e/metering_upgrade_test.go
@@ -74,6 +74,10 @@ func testManualOLMUpgradeInstall(
 		upgradeFromSubscriptionChannel,
 		preUpgradeTestOutputDir,
 		testInstallFunction.ExtraEnvVars,
+		deployframework.DefaultDeleteNamespace,
+		deployframework.DefaultDeleteCRD,
+		deployframework.DefaultDeleteCRB,
+		deployframework.DefaultDeletePVC,
 		mc.Spec,
 	)
 	require.NoError(t, err, "creating a new deployer context should produce no error")


### PR DESCRIPTION
Update the test e2e and deployframework packages and support explicitly
setting the delete* deploy config parameters while instantiating
deployer context instances. Previously, any new instances used the
default value and we had no flexibility with how we may set these values
after creating a new object.

There are no getter or setter methods in the deploy package that help us
set new values for that unexported field. We may want to invest in
creating a simple interface instead and use variadics, or something
along that line.