### PR TITLE
test/e2e: Ensure all e2e test namespaces use correct label

### DIFF
--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -10,18 +10,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kube-reporting/metering-operator/pkg/deploy"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/kube-reporting/metering-operator/test/deployframework"
-	"github.com/kube-reporting/metering-operator/test/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	corev1 "k8s.io/api/core/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kube-reporting/metering-operator/pkg/deploy"
+	"github.com/kube-reporting/metering-operator/test/deployframework"
+	"github.com/kube-reporting/metering-operator/test/testhelpers"
 )
 
 const (
@@ -90,15 +91,12 @@ func testManualMeteringInstall(
 	}
 
 	rf, err := deployerCtx.Setup(deployerCtx.Deployer.InstallOLM, expectInstallErr)
-
 	canSafelyRunTest := testhelpers.AssertCanSafelyRunReportingTests(t, err, expectInstallErr, expectInstallErrMsg)
 	if canSafelyRunTest {
 		for _, installFunc := range testInstallFunctions {
 			installFunc := installFunc
 			t := t
 
-			// namespace got deleted early when running t.Parallel()
-			// so re-running without that specified
 			t.Run(installFunc.Name, func(t *testing.T) {
 				installFunc.TestFunc(t, rf)
 			})
@@ -111,15 +109,41 @@ func testManualMeteringInstall(
 	assert.NoError(t, err, "capturing logs and uninstalling metering should produce no error")
 }
 
-func createNFSProvisioner(ctx *deployframework.DeployerCtx) error {
-	//Waiting for Metering pods
-	ctx.TargetPodsCount = nonHDFSTargetPodCount
+// createTestingNamespace is a helper function that is responsible
+// for creating a namespace with the @namespace metadata.name and
+// contains the `name: "<namespace_prefix>-metering-testing-ns` label.
+// During the teardown function of the hack/e2e.sh script, we search for any
+// namespaces that match that label. Note: manually running the e2e suite
+// specifying a list of go test flags does not ensure proper cleanup.
+func createTestingNamespace(client kubernetes.Interface, namespace string) (*corev1.Namespace, error) {
+	ns, err := client.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if apierrors.IsNotFound(err) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Labels: map[string]string{
+					"name": namespacePrefix + "-" + testingNamespaceLabel,
+				},
+			},
+		}
+		_, err = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		if err != nil {
+			return ns, nil
+		}
+	}
+	return ns, nil
+}
 
+func createNFSProvisioner(ctx *deployframework.DeployerCtx) error {
 	_, err := createTestingNamespace(ctx.Client, nfsTestingNamespace)
 	if err != nil {
 		return err
 	}
 
+	ctx.TargetPodsCount = nonHDFSTargetPodCount
 	files := map[string]string{
 		"pod":          "server.yaml",
 		"service":      "service.yaml",
@@ -128,6 +152,7 @@ func createNFSProvisioner(ctx *deployframework.DeployerCtx) error {
 	server := &corev1.Pod{}
 	service := &corev1.Service{}
 	storageClass := &storagev1beta1.StorageClass{}
+
 	for name, file := range files {
 		absFile := filepath.Join(repoPath, testNFSManifestPath, file)
 		switch name {
@@ -181,7 +206,6 @@ func createNFSProvisioner(ctx *deployframework.DeployerCtx) error {
 	nfsFile := "persistentvolume.yaml"
 	nfsPv := &corev1.PersistentVolume{}
 	absFile := filepath.Join(repoPath, testNFSManifestPath, nfsFile)
-	//decode pvc
 	if err := deploy.DecodeYAMLManifestToObject(absFile, nfsPv); err != nil {
 		return err
 	}
@@ -194,28 +218,6 @@ func createNFSProvisioner(ctx *deployframework.DeployerCtx) error {
 	return nil
 }
 
-func createTestingNamespace(client kubernetes.Interface, namespace string) (*corev1.Namespace, error) {
-	ns, err := client.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-	if apierrors.IsNotFound(err) {
-		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-				Labels: map[string]string{
-					"name": namespace + "-" + testingNamespaceLabel,
-				},
-			},
-		}
-		_, err = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-		if err != nil {
-			return ns, nil
-		}
-	}
-	return ns, nil
-}
-
 func s3InstallFunc(ctx *deployframework.DeployerCtx) error {
 	// The default ctx.TargetPodsCount value assumes that HDFS
 	// is being used a storage backend, so we need to decrement
@@ -223,28 +225,10 @@ func s3InstallFunc(ctx *deployframework.DeployerCtx) error {
 	// for Pods that will not be created by the metering-ansible-operator
 	ctx.TargetPodsCount = nonHDFSTargetPodCount
 
-	// Before we can create the AWS credentials secret in the ctx.Namespace, we need to ensure
-	// that namespace has been created before attempting to query for a resource that does not exist.
-	_, err := ctx.Client.CoreV1().Namespaces().Get(context.Background(), ctx.Namespace, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil
+	_, err := createTestingNamespace(ctx.Client, ctx.Namespace)
+	if err != nil {
+		return err
 	}
-	if apierrors.IsNotFound(err) {
-		n := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ctx.Namespace,
-				Labels: map[string]string{
-					"name": ctx.Namespace + "-" + testingNamespaceLabel,
-				},
-			},
-		}
-		_, err = ctx.Client.CoreV1().Namespaces().Create(context.Background(), n, metav1.CreateOptions{})
-		if err != nil {
-			return err
-		}
-		ctx.Logger.Debugf("Created the %s namespace", ctx.Namespace)
-	}
-
 	// Attempt to mirror the AWS credentials used to provision the IPI-based AWS cluster
 	// from the kube-system namespace, to the ctx.Namespace that the test context is configured
 	// to use. In the case where this secret containing the base64-encrypted access key id and
@@ -334,24 +318,9 @@ func createMySQLDatabase(ctx *deployframework.DeployerCtx) error {
 		mysqlNamespace     = "mysql"
 		mysqlLabelSelector = "db=mysql"
 	)
-	_, err := ctx.Client.CoreV1().Namespaces().Get(context.Background(), mysqlNamespace, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil
-	}
-	if apierrors.IsNotFound(err) {
-		n := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mysqlNamespace,
-				Labels: map[string]string{
-					"name": ctx.Namespace + "-" + testingNamespaceLabel,
-				},
-			},
-		}
-		_, err = ctx.Client.CoreV1().Namespaces().Create(context.Background(), n, metav1.CreateOptions{})
-		if err != nil {
-			return err
-		}
-		ctx.Logger.Debugf("Created the %s namespace", mysqlNamespace)
+	_, err := createTestingNamespace(ctx.Client, mysqlNamespace)
+	if err != nil {
+		return err
 	}
 
 	cmd := exec.Command(


### PR DESCRIPTION
Update the MySQL and NFS pre-installation functions to use the correct
namespace label in the form of `name: <namespace_prefix>-metering-testin-ns`.
During the teardown function of the hack/e2e.sh bash script, which
serves as the entrypoint to the e2e suite, we search for any namespaces
that match that label, and attempt to delete them unless the e2e suite
has been run in developer mode.

Previously, the namespaces that were created as a result of these MySQL
and NFS pre-installation functions create a `name` label containing the
actual namespace, and not the prefix supplied to the e2e suite, in the
context of an individual install. This led to those namespaces not being
properly purged at the cleanup call site.

Other changes in this commit include:

- Aligning the grouping of package imports with the rest of the e2e
  package(s).
- Updating the other pre-installation functions to use that
  createTestingNamespace helper function.
- Minor cleanup of unnecessary commits, re-organizing functions, etc.