### PR TITLE
test/e2e: Require no error when creating the test output directory

### DIFF
--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -51,7 +51,7 @@ func testManualMeteringInstall(
 	// create a directory used to store the @testCaseName container and resource logs
 	testCaseOutputBaseDir := filepath.Join(testOutputPath, testCaseName)
 	err := os.Mkdir(testCaseOutputBaseDir, 0777)
-	assert.NoError(t, err, "creating the test case output directory should produce no error")
+	require.NoError(t, err, "creating the test case output directory should produce no error")
 
 	testFuncNamespace := fmt.Sprintf("%s-%s", namespacePrefix, strings.ToLower(testCaseName))
 	if len(testFuncNamespace) > kubeNamespaceCharLimit {


### PR DESCRIPTION
Update the error check when attempting to create the test output
directory for an individual test to use the require package instead of
assert.

In the metering-upgrade-aws test handler, we already use require instead
of assert so this is aligning both of those handlers.