### PR TITLE
pkg/deploy: Export the Deployer fields

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -101,13 +101,13 @@ type OperatorResources struct {
 // to provision and remove all the metering resources, and a customized
 // deployment configuration.
 type Deployer struct {
-	config            Config
-	logger            logrus.FieldLogger
-	client            kubernetes.Interface
-	apiExtClient      apiextclientv1.CustomResourceDefinitionsGetter
-	meteringClient    meteringclient.MeteringV1Interface
-	olmV1Client       olmclientv1.OperatorsV1Interface
-	olmV1Alpha1Client olmclientv1alpha1.OperatorsV1alpha1Interface
+	Config            Config
+	Logger            logrus.FieldLogger
+	Client            kubernetes.Interface
+	APIExtClient      apiextclientv1.CustomResourceDefinitionsGetter
+	MeteringClient    meteringclient.MeteringV1Interface
+	OLMV1Client       olmclientv1.OperatorsV1Interface
+	OLMV1Alpha1Client olmclientv1alpha1.OperatorsV1alpha1Interface
 }
 
 // NewDeployer creates a new reference to a deploy structure, and then calls helper
@@ -124,25 +124,25 @@ func NewDeployer(
 	olmV1Alpha1Client olmclientv1alpha1.OperatorsV1alpha1Interface,
 ) (*Deployer, error) {
 	deploy := &Deployer{
-		client:            client,
-		apiExtClient:      apiextClient,
-		meteringClient:    meteringClient,
-		olmV1Client:       olmV1Client,
-		olmV1Alpha1Client: olmV1Alpha1Client,
-		logger:            logger,
-		config:            cfg,
+		Client:            client,
+		APIExtClient:      apiextClient,
+		MeteringClient:    meteringClient,
+		OLMV1Client:       olmV1Client,
+		OLMV1Alpha1Client: olmV1Alpha1Client,
+		Logger:            logger,
+		Config:            cfg,
 	}
 
-	deploy.logger.Infof("Metering Deploy Namespace: %s", deploy.config.Namespace)
-	deploy.logger.Infof("Metering Deploy Platform: %s", deploy.config.Platform)
+	deploy.Logger.Infof("Metering Deploy Namespace: %s", deploy.Config.Namespace)
+	deploy.Logger.Infof("Metering Deploy Platform: %s", deploy.Config.Platform)
 
-	if deploy.config.DeleteAll {
-		deploy.config.DeletePVCs = true
-		deploy.config.DeleteNamespace = true
-		deploy.config.DeleteCRB = true
-		deploy.config.DeleteCRDs = true
+	if deploy.Config.DeleteAll {
+		deploy.Config.DeletePVCs = true
+		deploy.Config.DeleteNamespace = true
+		deploy.Config.DeleteCRB = true
+		deploy.Config.DeleteCRDs = true
 	}
-	if deploy.config.Namespace == "" {
+	if deploy.Config.Namespace == "" {
 		return deploy, fmt.Errorf("failed to set $METERING_NAMESPACE or --namespace flag")
 	}
 
@@ -155,7 +155,7 @@ func NewDeployer(
 func (deploy *Deployer) InstallOLM() error {
 	err := deploy.installNamespace()
 	if err != nil {
-		return fmt.Errorf("failed to create the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to create the %s namespace: %v", deploy.Config.Namespace, err)
 	}
 
 	err = deploy.installMeteringOperatorGroup()
@@ -202,25 +202,25 @@ func (deploy *Deployer) UninstallOLM() error {
 		return fmt.Errorf("failed to uninstall the metering OperatorGroup: %v", err)
 	}
 
-	if deploy.config.DeletePVCs {
+	if deploy.Config.DeletePVCs {
 		err = deploy.uninstallMeteringPVCs()
 		if err != nil {
 			return fmt.Errorf("failed to uninstall the Metering PVCs: %v", err)
 		}
 	}
-	if deploy.config.DeleteCRDs {
+	if deploy.Config.DeleteCRDs {
 		err = deploy.uninstallMeteringCRDs()
 		if err != nil {
 			return fmt.Errorf("failed to uninstall the metering-related CRDs: %v", err)
 		}
 	}
-	if deploy.config.DeleteNamespace {
+	if deploy.Config.DeleteNamespace {
 		err = deploy.uninstallNamespace()
 		if err != nil {
-			return fmt.Errorf("failed to uninstall the %s metering namespace: %v", deploy.config.Namespace, err)
+			return fmt.Errorf("failed to uninstall the %s metering namespace: %v", deploy.Config.Namespace, err)
 		}
 	}
-	if deploy.config.DeleteCRB {
+	if deploy.Config.DeleteCRB {
 		err = deploy.uninstallReportingOperatorClusterRole()
 		if err != nil {
 			return fmt.Errorf("failed to delete the reporting-operator ClusterRole resources: %v", err)
@@ -239,7 +239,7 @@ func (deploy *Deployer) UninstallOLM() error {
 func (deploy *Deployer) Install() error {
 	err := deploy.installNamespace()
 	if err != nil {
-		return fmt.Errorf("failed to create the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to create the %s namespace: %v", deploy.Config.Namespace, err)
 	}
 
 	err = deploy.installMeteringCRDs()
@@ -247,7 +247,7 @@ func (deploy *Deployer) Install() error {
 		return fmt.Errorf("failed to create the Metering CRDs: %v", err)
 	}
 
-	if !deploy.config.SkipMeteringDeployment {
+	if !deploy.Config.SkipMeteringDeployment {
 		err = deploy.installMeteringResources()
 		if err != nil {
 			return fmt.Errorf("failed to create the metering resources: %v", err)
@@ -276,22 +276,22 @@ func (deploy *Deployer) Uninstall() error {
 		return fmt.Errorf("failed to delete the metering resources: %v", err)
 	}
 
-	if deploy.config.DeleteCRDs {
+	if deploy.Config.DeleteCRDs {
 		err = deploy.uninstallMeteringCRDs()
 		if err != nil {
 			return fmt.Errorf("failed to delete the Metering CRDs: %v", err)
 		}
 	} else {
-		deploy.logger.Infof("Skipped deleting the metering CRDs")
+		deploy.Logger.Infof("Skipped deleting the metering CRDs")
 	}
 
-	if deploy.config.DeleteNamespace {
+	if deploy.Config.DeleteNamespace {
 		err = deploy.uninstallNamespace()
 		if err != nil {
-			return fmt.Errorf("failed to delete the %s namespace: %v", deploy.config.Namespace, err)
+			return fmt.Errorf("failed to delete the %s namespace: %v", deploy.Config.Namespace, err)
 		}
 	} else {
-		deploy.logger.Infof("Skipped deleting the %s namespace", deploy.config.Namespace)
+		deploy.Logger.Infof("Skipped deleting the %s namespace", deploy.Config.Namespace)
 	}
 
 	return nil

--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -10,62 +10,62 @@ import (
 )
 
 func (deploy *Deployer) uninstallNamespace() error {
-	err := deploy.client.CoreV1().Namespaces().Delete(context.TODO(), deploy.config.Namespace, metav1.DeleteOptions{})
+	err := deploy.Client.CoreV1().Namespaces().Delete(context.TODO(), deploy.Config.Namespace, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s namespace doesn't exist", deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s namespace doesn't exist", deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s namespace", deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s namespace", deploy.Config.Namespace)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringConfig() error {
-	err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Delete(context.TODO(), deploy.config.MeteringConfig.Name, metav1.DeleteOptions{})
+	err := deploy.MeteringClient.MeteringConfigs(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.MeteringConfig.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The MeteringConfig resource doesn't exist")
+		deploy.Logger.Warnf("The MeteringConfig resource doesn't exist")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the MeteringConfig resource")
+	deploy.Logger.Infof("Deleted the MeteringConfig resource")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringOperatorGroup() error {
-	err := deploy.olmV1Client.OperatorGroups(deploy.config.Namespace).Delete(context.TODO(), deploy.config.Namespace, metav1.DeleteOptions{})
+	err := deploy.OLMV1Client.OperatorGroups(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.Namespace, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering OperatorGroup resource does not exist")
+		deploy.Logger.Warnf("The metering OperatorGroup resource does not exist")
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to delete the metering OperatorGroup resource: %v", err)
 	}
-	deploy.logger.Infof("Deleted the metering OperatorGroup resource")
+	deploy.Logger.Infof("Deleted the metering OperatorGroup resource")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringSubscription() error {
-	_, err := deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Get(context.TODO(), deploy.config.SubscriptionName, metav1.GetOptions{})
+	_, err := deploy.OLMV1Alpha1Client.Subscriptions(deploy.Config.Namespace).Get(context.TODO(), deploy.Config.SubscriptionName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering Subscription in the %s namespace does not exist", deploy.config.SubscriptionName, deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s metering Subscription in the %s namespace does not exist", deploy.Config.SubscriptionName, deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
 
-	err = deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Delete(context.TODO(), deploy.config.SubscriptionName, metav1.DeleteOptions{})
+	err = deploy.OLMV1Alpha1Client.Subscriptions(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.SubscriptionName, metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete the %s metering Subscription in the %s namespace: %v", deploy.config.SubscriptionName, deploy.config.Namespace, err)
+		return fmt.Errorf("failed to delete the %s metering Subscription in the %s namespace: %v", deploy.Config.SubscriptionName, deploy.Config.Namespace, err)
 	}
-	deploy.logger.Infof("Deleted the %s metering Subscription resource in the %s namespace", deploy.config.SubscriptionName, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering Subscription resource in the %s namespace", deploy.Config.SubscriptionName, deploy.Config.Namespace)
 
 	return nil
 }
@@ -75,9 +75,9 @@ func (deploy *Deployer) uninstallMeteringCSV() error {
 	// what the CSV's name is beforehand without exposing more configurable flags.
 	// in the case where the subscription resource does not already exist, exit early
 	// and hope that the user is re-running the olm-uninstall command.
-	sub, err := deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Get(context.TODO(), deploy.config.SubscriptionName, metav1.GetOptions{})
+	sub, err := deploy.OLMV1Alpha1Client.Subscriptions(deploy.Config.Namespace).Get(context.TODO(), deploy.Config.SubscriptionName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering Subscription does not exist")
+		deploy.Logger.Warnf("The metering Subscription does not exist")
 		return nil
 	}
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -85,27 +85,27 @@ func (deploy *Deployer) uninstallMeteringCSV() error {
 	}
 
 	if sub.Status.CurrentCSV == "" {
-		deploy.logger.Warnf("Failed to get the 'status.currentCSV' stored in the %s metering Subscription resource", deploy.config.SubscriptionName)
+		deploy.Logger.Warnf("Failed to get the 'status.currentCSV' stored in the %s metering Subscription resource", deploy.Config.SubscriptionName)
 		return nil
 	}
 
 	csvName := sub.Status.CurrentCSV
-	deploy.logger.Infof("Found an existing metering subscription, attempting to delete the %s CSV", csvName)
+	deploy.Logger.Infof("Found an existing metering subscription, attempting to delete the %s CSV", csvName)
 
-	csv, err := deploy.olmV1Alpha1Client.ClusterServiceVersions(deploy.config.Namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
+	csv, err := deploy.OLMV1Alpha1Client.ClusterServiceVersions(deploy.Config.Namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering CSV resource does not exist", csvName)
+		deploy.Logger.Warnf("The %s metering CSV resource does not exist", csvName)
 		return nil
 	}
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
-	err = deploy.olmV1Alpha1Client.ClusterServiceVersions(deploy.config.Namespace).Delete(context.TODO(), csv.Name, metav1.DeleteOptions{})
+	err = deploy.OLMV1Alpha1Client.ClusterServiceVersions(deploy.Config.Namespace).Delete(context.TODO(), csv.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete the %s metering CSV resource: %v", csvName, err)
 	}
-	deploy.logger.Infof("Deleted the %s metering CSV resource in the %s namespace", csvName, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering CSV resource in the %s namespace", csvName, deploy.Config.Namespace)
 
 	return nil
 }
@@ -131,7 +131,7 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 		return fmt.Errorf("failed to delete the metering role binding: %v", err)
 	}
 
-	if deploy.config.DeleteCRB {
+	if deploy.Config.DeleteCRB {
 		err = deploy.uninstallMeteringClusterRole()
 		if err != nil {
 			return fmt.Errorf("failed to delete the metering cluster role: %v", err)
@@ -151,16 +151,16 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 			return fmt.Errorf("failed to delete the reporting-operator ClusterRoleBinding resources: %v", err)
 		}
 	} else {
-		deploy.logger.Infof("Skipped deleting the metering cluster role resources")
+		deploy.Logger.Infof("Skipped deleting the metering cluster role resources")
 	}
 
-	if deploy.config.DeletePVCs {
+	if deploy.Config.DeletePVCs {
 		err = deploy.uninstallMeteringPVCs()
 		if err != nil {
 			return fmt.Errorf("failed to delete the metering PVCs: %v", err)
 		}
 	} else {
-		deploy.logger.Infof("Skipped deleting the metering PVCs")
+		deploy.Logger.Infof("Skipped deleting the metering PVCs")
 	}
 
 	return nil
@@ -175,118 +175,118 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 // so we need to explicitly delete them during cleanup.
 func (deploy *Deployer) uninstallMeteringPVCs() error {
 	// Attempt to get a list of PVCs that match the hdfs or hive labels
-	pvcs, err := deploy.client.CoreV1().PersistentVolumeClaims(deploy.config.Namespace).List(context.TODO(), metav1.ListOptions{
+	pvcs, err := deploy.Client.CoreV1().PersistentVolumeClaims(deploy.Config.Namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app=hdfs",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list all the metering PVCs in the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to list all the metering PVCs in the %s namespace: %v", deploy.Config.Namespace, err)
 	}
 	if len(pvcs.Items) == 0 {
-		deploy.logger.Warnf("The HDFS PVCs don't exist")
+		deploy.Logger.Warnf("The HDFS PVCs don't exist")
 		return nil
 	}
 
 	for _, pvc := range pvcs.Items {
-		err = deploy.client.CoreV1().PersistentVolumeClaims(deploy.config.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+		err = deploy.Client.CoreV1().PersistentVolumeClaims(deploy.Config.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
-			deploy.logger.Warnf("The %s PVC does not exist", pvc.Name)
+			deploy.Logger.Warnf("The %s PVC does not exist", pvc.Name)
 			continue
 		}
 		if err != nil {
 			// TODO: we should be returning an array of errors instead of a single err
 			return fmt.Errorf("failed to delete the %s PVC: %v", pvc.Name, err)
 		}
-		deploy.logger.Infof("Deleted the %s PVC in the %s namespace", pvc.Name, deploy.config.Namespace)
+		deploy.Logger.Infof("Deleted the %s PVC in the %s namespace", pvc.Name, deploy.Config.Namespace)
 	}
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringDeployment() error {
-	err := deploy.client.AppsV1().Deployments(deploy.config.Namespace).Delete(context.TODO(), deploy.config.OperatorResources.Deployment.Name, metav1.DeleteOptions{})
+	err := deploy.Client.AppsV1().Deployments(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.OperatorResources.Deployment.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering deployment doesn't exist")
+		deploy.Logger.Warnf("The metering deployment doesn't exist")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the metering deployment")
+	deploy.Logger.Infof("Deleted the metering deployment")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringServiceAccount() error {
-	err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Delete(context.TODO(), deploy.config.OperatorResources.ServiceAccount.Name, metav1.DeleteOptions{})
+	err := deploy.Client.CoreV1().ServiceAccounts(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.OperatorResources.ServiceAccount.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering service account doesn't exist")
+		deploy.Logger.Warnf("The metering service account doesn't exist")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the metering serviceaccount")
+	deploy.Logger.Infof("Deleted the metering serviceaccount")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringRoleBinding() error {
-	res := deploy.config.OperatorResources.RoleBinding
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.RoleBinding
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().RoleBindings(deploy.config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().RoleBindings(deploy.Config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering RoleBinding resource in the %s namespace doesn't exist", res.Name, deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s metering RoleBinding resource in the %s namespace doesn't exist", res.Name, deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering RoleBinding resource in the %s namespace", res.Name, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering RoleBinding resource in the %s namespace", res.Name, deploy.Config.Namespace)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringRole() error {
-	res := deploy.config.OperatorResources.Role
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.Role
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().Roles(deploy.config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().Roles(deploy.Config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering Role resource in the %s namespace doesn't exist", res.Name, deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s metering Role resource in the %s namespace doesn't exist", res.Name, deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering Role resource in the %s namespace", res.Name, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering Role resource in the %s namespace", res.Name, deploy.Config.Namespace)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringClusterRole() error {
-	res := deploy.config.OperatorResources.ClusterRole
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.ClusterRole
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().ClusterRoles().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().ClusterRoles().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering ClusterRole resource doesn't exist", res.Name)
+		deploy.Logger.Warnf("The %s metering ClusterRole resource doesn't exist", res.Name)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering ClusterRole resource", res.Name)
+	deploy.Logger.Infof("Deleted the %s metering ClusterRole resource", res.Name)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
-	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.Config.Namespace)
 
 	// Attempt to delete all of the ClusterRoles that the metering-ansible-operator
 	// creates for the reporting-operator
-	crs, err := deploy.client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
+	crs, err := deploy.Client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
@@ -294,17 +294,17 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
 	}
 
 	if len(crs.Items) == 0 {
-		deploy.logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRole resources")
+		deploy.Logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRole resources")
 		return nil
 	}
 
 	var errArr []string
 	for _, cr := range crs.Items {
-		err = deploy.client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
+		err = deploy.Client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
 		if err != nil {
 			errArr = append(errArr, fmt.Sprintf("failed to delete the %s ClusterRole resource: %v", cr.Name, err))
 		}
-		deploy.logger.Infof("Deleted the %s ClusterRole resource", cr.Name)
+		deploy.Logger.Infof("Deleted the %s ClusterRole resource", cr.Name)
 	}
 
 	if len(errArr) != 0 {
@@ -315,27 +315,27 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
 }
 
 func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
-	res := deploy.config.OperatorResources.ClusterRoleBinding
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.ClusterRoleBinding
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering ClusterRoleBinding resource doesn't exist", res.Name)
+		deploy.Logger.Warnf("The %s metering ClusterRoleBinding resource doesn't exist", res.Name)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering ClusterRoleBinding resource", res.Name)
+	deploy.Logger.Infof("Deleted the %s metering ClusterRoleBinding resource", res.Name)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
-	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.Config.Namespace)
 
 	// attempt to delete any of the clusterroles the reporting-operator creates
-	crbs, err := deploy.client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
+	crbs, err := deploy.Client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
@@ -343,17 +343,17 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
 	}
 
 	if len(crbs.Items) == 0 {
-		deploy.logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRoleBinding resources")
+		deploy.Logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRoleBinding resources")
 		return nil
 	}
 
 	var errArr []string
 	for _, crb := range crbs.Items {
-		err = deploy.client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{})
+		err = deploy.Client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{})
 		if err != nil {
 			errArr = append(errArr, fmt.Sprintf("failed to delete the %s ClusterRoleBinding resource: %v", crb.Name, err))
 		}
-		deploy.logger.Infof("Deleted the %s ClusterRoleBinding resource", crb.Name)
+		deploy.Logger.Infof("Deleted the %s ClusterRoleBinding resource", crb.Name)
 	}
 	if len(errArr) != 0 {
 		return fmt.Errorf(strings.Join(errArr, "\n"))
@@ -363,7 +363,7 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
 }
 
 func (deploy *Deployer) uninstallMeteringCRDs() error {
-	for _, crd := range deploy.config.OperatorResources.CRDs {
+	for _, crd := range deploy.Config.OperatorResources.CRDs {
 		err := deploy.uninstallMeteringCRD(crd)
 		if err != nil {
 			return err
@@ -374,15 +374,15 @@ func (deploy *Deployer) uninstallMeteringCRDs() error {
 }
 
 func (deploy *Deployer) uninstallMeteringCRD(resource CRD) error {
-	err := deploy.apiExtClient.CustomResourceDefinitions().Delete(context.TODO(), resource.Name, metav1.DeleteOptions{})
+	err := deploy.APIExtClient.CustomResourceDefinitions().Delete(context.TODO(), resource.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s CRD doesn't exist", resource.Name)
+		deploy.Logger.Warnf("The %s CRD doesn't exist", resource.Name)
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to remove the %s CRD: %v", resource.Name, err)
 	}
-	deploy.logger.Infof("Deleted the %s CRD", resource.Name)
+	deploy.Logger.Infof("Deleted the %s CRD", resource.Name)
 
 	return nil
 }


### PR DESCRIPTION
Update all of the `Deployer` structure fields and export those fields.
We don't have much of a need to have these fields unexported, and
updating any of the `Config` field structure values is impossible
without constructing a new instance.