### PR TITLE
test/e2e: Add a top-level test that tests invalid MeteringConfig manifests

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"github.com/kube-reporting/metering-operator/test/deployframework"
@@ -171,6 +174,49 @@ type InstallTestCase struct {
 }
 
 type PreInstallFunc func(ctx *deployframework.DeployerCtx) error
+
+func TestInvalidMeteringConfigs(t *testing.T) {
+	namespace := fmt.Sprintf("%s-invalid-meteringconfigs", namespacePrefix)
+	ns, err := createTestingNamespace(df.Client, namespace)
+	require.NoError(t, err, "failed to successfully create the %s testing namespace", namespace)
+	require.NotEmpty(t, ns.Name, "expected the testing namespace would not be nil")
+
+	tt := []struct {
+		Name                           string
+		ExpectInstallErrMsg            []string
+		MeteringConfigManifestFileName string
+	}{
+		{
+			Name: "missing-storage-spec",
+			ExpectInstallErrMsg: []string{
+				"spec.storage in body is required|spec.storage: Required value",
+			},
+			MeteringConfigManifestFileName: "missing-storage.yaml",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t := t
+
+		mc, err := testhelpers.DecodeMeteringConfigManifest(repoPath, testMeteringConfigManifestsPath, tc.MeteringConfigManifestFileName)
+		require.NoError(t, err, "failed to successfully decode the YAML MeteringConfig manifest")
+
+		_, err = df.MeteringClient.MeteringConfigs(ns.Name).Create(context.Background(), mc, metav1.CreateOptions{})
+		testhelpers.AssertErrorContainsErrorMsgs(t, err, tc.ExpectInstallErrMsg)
+	}
+
+	// In the case that `make e2e-dev` has been specified, avoid
+	// deleting the testing namespace used to validate the MC's.
+	if runDevSetup {
+		return
+	}
+
+	// May need to account for apierrors.IsNotFound(err) just to reduce
+	// any potential e2e flakes and return w/o an error
+	err = df.Client.CoreV1().Namespaces().Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "failed to delete the %s testing namespace", ns.Name)
+}
 
 func TestManualMeteringInstall(t *testing.T) {
 	testInstallConfigs := []struct {

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -116,12 +116,13 @@ func testManualMeteringInstall(
 // namespaces that match that label. Note: manually running the e2e suite
 // specifying a list of go test flags does not ensure proper cleanup.
 func createTestingNamespace(client kubernetes.Interface, namespace string) (*corev1.Namespace, error) {
+	var ns *corev1.Namespace
 	ns, err := client.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 	if apierrors.IsNotFound(err) {
-		ns := &corev1.Namespace{
+		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 				Labels: map[string]string{
@@ -129,9 +130,9 @@ func createTestingNamespace(client kubernetes.Interface, namespace string) (*cor
 				},
 			},
 		}
-		_, err = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		ns, err = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		if err != nil {
-			return ns, nil
+			return nil, err
 		}
 	}
 	return ns, nil


### PR DESCRIPTION
Add an additional top-level that ensures that invalid MeteringConfig
custom resources report an error when attempting to create those custom
resources against the current set of CRDs. Also, validate that the errors
returned from the client-go .Create interface match what we expect.