### PR TITLE
test: Remove safeguards in e2e test handlers when expecting errors

### DIFF
--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -176,7 +176,7 @@ func (ctx *DeployerCtx) NewLocalCtx() *LocalCtx {
 // Setup handles the process of deploying metering, and waiting for all the necessary
 // resources to become ready in order to proceeed with running the reporting tests.
 // This returns an initialized reportingframework object, or an error if there is any.
-func (ctx *DeployerCtx) Setup(installFunc func() error, expectInstallErr bool) (*reportingframework.ReportingFramework, error) {
+func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.ReportingFramework, error) {
 	var (
 		installErrMsg    string
 		routeBearerToken string
@@ -187,13 +187,9 @@ func (ctx *DeployerCtx) Setup(installFunc func() error, expectInstallErr bool) (
 	// that error message until after the reportingframework has been constructed.
 	err := installFunc()
 	if err != nil {
-		installErr = true
 		installErrMsg = fmt.Sprintf("failed to install metering: %v", err)
 		ctx.Logger.Infof(installErrMsg)
-
-		if !expectInstallErr {
-			return nil, fmt.Errorf(installErrMsg)
-		}
+		return nil, fmt.Errorf(installErrMsg)
 	}
 
 	if !installErr {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -178,8 +178,6 @@ func TestManualMeteringInstall(t *testing.T) {
 		MeteringOperatorImageRepo      string
 		MeteringOperatorImageTag       string
 		Skip                           bool
-		ExpectInstallErr               bool
-		ExpectInstallErrMsg            []string
 		InstallSubTests                []InstallTestCase
 		PreInstallFunc                 PreInstallFunc
 		MeteringConfigManifestFilename string
@@ -388,8 +386,6 @@ func TestManualMeteringInstall(t *testing.T) {
 				catalogSourceNamespace,
 				subscriptionChannel,
 				testOutputPath,
-				testCase.ExpectInstallErrMsg,
-				testCase.ExpectInstallErr,
 				testCase.PreInstallFunc,
 				testCase.InstallSubTests,
 			)

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -44,8 +44,6 @@ func testManualMeteringInstall(
 	catalogSourceNamespace,
 	subscriptionChannel,
 	testOutputPath string,
-	expectInstallErrMsg []string,
-	expectInstallErr bool,
 	preInstallFunc PreInstallFunc,
 	testInstallFunctions []InstallTestCase,
 ) {
@@ -90,19 +88,18 @@ func testManualMeteringInstall(
 		require.NoError(t, err, "expected no error while running any pre-install functions")
 	}
 
-	rf, err := deployerCtx.Setup(deployerCtx.Deployer.InstallOLM, expectInstallErr)
-	canSafelyRunTest := testhelpers.AssertCanSafelyRunReportingTests(t, err, expectInstallErr, expectInstallErrMsg)
-	if canSafelyRunTest {
-		for _, installFunc := range testInstallFunctions {
-			installFunc := installFunc
-			t := t
+	rf, err := deployerCtx.Setup(deployerCtx.Deployer.InstallOLM)
+	require.NoError(t, err, "expected there would be no error while installing metering")
 
-			t.Run(installFunc.Name, func(t *testing.T) {
-				installFunc.TestFunc(t, rf)
-			})
+	for _, installFunc := range testInstallFunctions {
+		installFunc := installFunc
+		t := t
 
-			deployerCtx.Logger.Infof("The %s test has finished running", installFunc.Name)
-		}
+		t.Run(installFunc.Name, func(t *testing.T) {
+			installFunc.TestFunc(t, rf)
+		})
+
+		deployerCtx.Logger.Infof("The %s test has finished running", installFunc.Name)
 	}
 
 	err = deployerCtx.Teardown(deployerCtx.Deployer.UninstallOLM)

--- a/test/e2e/metering_upgrade_test.go
+++ b/test/e2e/metering_upgrade_test.go
@@ -75,14 +75,8 @@ func testManualOLMUpgradeInstall(
 		canSafelyRunTest bool
 		rf               *reportingframework.ReportingFramework
 	)
-	rf, err = deployerCtx.Setup(deployerCtx.Deployer.InstallOLM, expectInstallErr)
-	if canSafelyRunTest = testhelpers.AssertCanSafelyRunReportingTests(t, err, expectInstallErr, expectInstallErrMsg); !canSafelyRunTest {
-		// if we encounter an unexpected Setup error, fail this test case
-		// early and gather the metering and OLM resource logs we care about.
-		err = deployerCtx.MustGatherMeteringResources(gatherTestArtifactsScript)
-		assert.NoError(t, err, "gathering metering resources should produce no error")
-		t.Fatal("Exiting test case early as the pre-upgrade tests failed")
-	}
+	rf, err = deployerCtx.Setup(deployerCtx.Deployer.InstallOLM)
+	require.NoError(t, err, "failed to successfully the pre-upgrade metering installation")
 
 	preUpgradeTestName := fmt.Sprintf("pre-upgrade-%s", testInstallFunction.Name)
 	t.Run(preUpgradeTestName, func(t *testing.T) {


### PR DESCRIPTION
Update the deployframework and e2e packages and remove all of the
safeguards around checking if installations are safe to run post-install
tests against. Remove any expectErr or expectErrMsgs type properties
from the main test handler and just always exit early if there's an
error during the Setup method.