### PR TITLE
test/e2e: Reduce number of metering e2e tests per-run

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -259,10 +259,6 @@ func TestManualMeteringInstall(t *testing.T) {
 					TestFunc: testMeteringAnsibleOperatorMetricsWork,
 				},
 				{
-					Name:     "testPrometheusConnectorWorks",
-					TestFunc: testPrometheusConnectorWorks,
-				},
-				{
 					Name:     "testReportingOperatorServiceCABundleExists",
 					TestFunc: testReportingOperatorServiceCABundleExists,
 				},

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -240,7 +240,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			// any new machine. The result is the new machines that get
 			// provisioned, don't have this custom node label we added in
 			// the preInstallFunc closure.
-			Skip:           true,
+			Skip:           !testing.Short(),
 			PreInstallFunc: customNodeSelectorFunc,
 			InstallSubTests: []InstallTestCase{
 				{
@@ -387,9 +387,8 @@ func TestManualMeteringInstall(t *testing.T) {
 			Name:                      "NFS-ReportDynamicInputData",
 			MeteringOperatorImageRepo: meteringOperatorImageRepo,
 			MeteringOperatorImageTag:  meteringOperatorImageTag,
-			Skip:                      false,
-			// Skip:                      !testing.Short(),
-			PreInstallFunc: createNFSProvisioner,
+			Skip:                      !testing.Short(),
+			PreInstallFunc:            createNFSProvisioner,
 			InstallSubTests: []InstallTestCase{
 				{
 					Name:     "testReportingProducesData",


### PR DESCRIPTION
Update the main testing package and mark the NFS and node selector e2e test to be gated on the `testing.Short()` value we derive from the hack/e2e.sh bash script (entry point to the e2e suite).

Remove the Prometheus connector post-install test from the list of valid tests as we removed that functionality from the Operator.