### PR TITLE
test/e2e: Fix failed InstallPlan handling in test setup code

### DIFF
--- a/test/deployframework/registry.go
+++ b/test/deployframework/registry.go
@@ -191,6 +191,9 @@ func (df *DeployFramework) WaitForPackageManifest(name, namespace, subscriptionC
 				}
 			}
 		}
+		if !ready {
+			df.Logger.Warnf("The metering-ocp packagemanifest is present but the %s channel is not present", subscriptionChannel)
+		}
 
 		return ready, nil
 	})

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -95,6 +95,8 @@ func testManualMeteringInstall(
 	rf, err := deployerCtx.Setup(deployerCtx.Deployer.InstallOLM)
 	if err != nil {
 		if err != deployframework.ErrInstallPlanFailed {
+			gatherErr := deployerCtx.MustGatherMeteringResources(gatherTestArtifactsScript)
+			assert.NoError(t, gatherErr, "gathering metering resources should produce no error")
 			require.NoError(t, err, "expected installing metering would produce no error")
 		}
 		t.Logf("Recreating the %s metering installation as a failed InstallPlan has been detected", deployerCtx.Namespace)

--- a/test/e2e/metering_manual_install_test.go
+++ b/test/e2e/metering_manual_install_test.go
@@ -99,6 +99,9 @@ func testManualMeteringInstall(
 		}
 		t.Logf("Recreating the %s metering installation as a failed InstallPlan has been detected", deployerCtx.Namespace)
 		deployerCtx.Deployer.Config.DeleteNamespace = false
+		// TODO(tflannag): this is ugly and we should aim for a better implementation,
+		// but in the meantime this will get CI back working again.
+		err = nil
 
 		err = deployerCtx.Deployer.UninstallOLM()
 		assert.NoError(t, err, "failed to uninstall metering after encountering a failed installation")


### PR DESCRIPTION
Update the Setup method for the deployer context structure and ensure
we're zero-ing out the previous failed InstallPlan error we're handling
to avoid failing that particular top-level test metering installation.