### PR TITLE
[release-4.6] Remove operator-courier from the root Dockerfile

### DIFF
--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -1,7 +1,7 @@
 # need helm CLI for final image
-FROM registry.svc.ci.openshift.org/ocp/4.6:metering-helm as helm
+FROM registry.ci.openshift.org/ocp/4.6:metering-helm as helm
 # image needs kubectl, so we copy `oc` from cli image to use as kubectl.
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli as cli
+FROM registry.ci.openshift.org/ocp/4.6:cli as cli
 # need golang for the unit/vendor/verify CI checks
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13
 

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -12,17 +12,11 @@ RUN chmod +x /usr/local/bin/faq
 
 # ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
-RUN INSTALL_PKGS="rh-python36" && \
-    yum clean all && rm -rf /var/cache/yum/* && \
+RUN yum clean all && \
+    rm -rf /var/cache/yum/* && \
     yum -y install centos-release-scl && \
-    yum install --setopt=skip_missing_names_on_install=False -y $INSTALL_PKGS && \
     yum clean all && \
     rm -rf /var/cache/yum
-
-RUN scl enable rh-python36 'pip install operator-courier'
-
-COPY hack/scl-operator-courier.sh /usr/local/bin/operator-courier
-RUN chmod +x /usr/local/bin/operator-courier
 
 COPY --from=cli /usr/bin/oc /usr/bin/
 RUN ln -s /usr/bin/oc /usr/bin/kubectl

--- a/Makefile
+++ b/Makefile
@@ -181,13 +181,6 @@ verify-helm-templates:
 verify-olm-manifests: metering-manifests
 	@echo Generating metering manifests
 	$(MAKE) metering-manifests
-	@echo Verifying metering manifests
-	# # Note: verify is incompatible with the v1 CRDs formatting.
-	# # See: https://github.com/operator-framework/operator-courier/issues/163
-	# # TODO: replace `operator-courier verify` with `operator-sdk bundle validate` once
-	# # there's a pipeline in place for the new bundle format
-	# operator-courier verify --ui_validate_io ./manifests/deploy/openshift/olm/bundle
-	# operator-courier verify --ui_validate_io ./manifests/deploy/upstream/olm/bundle
 
 push-olm-manifests: verify-olm-manifests
 	./hack/push-olm-manifests.sh $(OLM_PACKAGE_ORG) metering-ocp $(OLM_PACKAGE_VERSION)


### PR DESCRIPTION
Remove the `operator-courier` dependency that was previously used to verify the metering manifests. During the 4.6 release cycle, we updated the metering-related CRDs to use the apiextensions.k8s.io/v1 version, which `operator-courier` is unable to process. As a result, we commented out any make targets that attempted to call this dependency but failed to remove that dependency from the root CI build Dockerfile.