### PR TITLE
[release-4.7] Handle failed InstallPlans in metering test installations

### DIFF
--- a/cmd/deploy-metering/main.go
+++ b/cmd/deploy-metering/main.go
@@ -83,7 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&deployManifestsDir, "deploy-manifests-dir", "manifests/deploy", "The absolute/relative path to the metering manifest directory. This can also be specified through the INSTALLER_MANIFESTS_DIR.")
 
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
-	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
+	uninstallCmd.Flags().BoolVar(&cfg.DeleteCRBs, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
 	uninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")
@@ -92,7 +92,7 @@ func init() {
 	// are both using the same flagset. We could switch to an installCmd and uninstallCmd, and
 	// have a --olm sub-command configuration so we could share flags between install/uninstall.
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRDs, "delete-crd", false, "If true, this would delete the metering CRDs during an uninstall. This can also be specified through the METERING_DELETE_CRDS ENV var.")
-	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRB, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
+	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteCRBs, "delete-crb", false, "If true, this would delete the metering cluster role bindings during an uninstall. This can also be specified through METERING_DELETE_CRB ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteNamespace, "delete-namespace", false, "If true, this would delete the namespace during an uninstall. This can also be specified through the METERING_DELETE_NAMESPACE ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeletePVCs, "delete-pvc", true, "If true, this would delete the PVCs used by metering resources during an uninstall. This can also be specified through the METERING_DELETE_PVCS ENV var.")
 	olmUninstallCmd.Flags().BoolVar(&cfg.DeleteAll, "delete-all", false, "If true, this would delete the all metering resources during an uninstall. This can also be specified through the METERING_DELETE_ALL ENV var.")

--- a/pkg/deploy/uninstall.go
+++ b/pkg/deploy/uninstall.go
@@ -10,62 +10,62 @@ import (
 )
 
 func (deploy *Deployer) uninstallNamespace() error {
-	err := deploy.client.CoreV1().Namespaces().Delete(context.TODO(), deploy.config.Namespace, metav1.DeleteOptions{})
+	err := deploy.Client.CoreV1().Namespaces().Delete(context.TODO(), deploy.Config.Namespace, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s namespace doesn't exist", deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s namespace doesn't exist", deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s namespace", deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s namespace", deploy.Config.Namespace)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringConfig() error {
-	err := deploy.meteringClient.MeteringConfigs(deploy.config.Namespace).Delete(context.TODO(), deploy.config.MeteringConfig.Name, metav1.DeleteOptions{})
+	err := deploy.MeteringClient.MeteringConfigs(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.MeteringConfig.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The MeteringConfig resource doesn't exist")
+		deploy.Logger.Warnf("The MeteringConfig resource doesn't exist")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the MeteringConfig resource")
+	deploy.Logger.Infof("Deleted the MeteringConfig resource")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringOperatorGroup() error {
-	err := deploy.olmV1Client.OperatorGroups(deploy.config.Namespace).Delete(context.TODO(), deploy.config.Namespace, metav1.DeleteOptions{})
+	err := deploy.OLMV1Client.OperatorGroups(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.Namespace, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering OperatorGroup resource does not exist")
+		deploy.Logger.Warnf("The metering OperatorGroup resource does not exist")
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to delete the metering OperatorGroup resource: %v", err)
 	}
-	deploy.logger.Infof("Deleted the metering OperatorGroup resource")
+	deploy.Logger.Infof("Deleted the metering OperatorGroup resource")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringSubscription() error {
-	_, err := deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Get(context.TODO(), deploy.config.SubscriptionName, metav1.GetOptions{})
+	_, err := deploy.OLMV1Alpha1Client.Subscriptions(deploy.Config.Namespace).Get(context.TODO(), deploy.Config.SubscriptionName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering Subscription in the %s namespace does not exist", deploy.config.SubscriptionName, deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s metering Subscription in the %s namespace does not exist", deploy.Config.SubscriptionName, deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
 
-	err = deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Delete(context.TODO(), deploy.config.SubscriptionName, metav1.DeleteOptions{})
+	err = deploy.OLMV1Alpha1Client.Subscriptions(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.SubscriptionName, metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete the %s metering Subscription in the %s namespace: %v", deploy.config.SubscriptionName, deploy.config.Namespace, err)
+		return fmt.Errorf("failed to delete the %s metering Subscription in the %s namespace: %v", deploy.Config.SubscriptionName, deploy.Config.Namespace, err)
 	}
-	deploy.logger.Infof("Deleted the %s metering Subscription resource in the %s namespace", deploy.config.SubscriptionName, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering Subscription resource in the %s namespace", deploy.Config.SubscriptionName, deploy.Config.Namespace)
 
 	return nil
 }
@@ -75,9 +75,9 @@ func (deploy *Deployer) uninstallMeteringCSV() error {
 	// what the CSV's name is beforehand without exposing more configurable flags.
 	// in the case where the subscription resource does not already exist, exit early
 	// and hope that the user is re-running the olm-uninstall command.
-	sub, err := deploy.olmV1Alpha1Client.Subscriptions(deploy.config.Namespace).Get(context.TODO(), deploy.config.SubscriptionName, metav1.GetOptions{})
+	sub, err := deploy.OLMV1Alpha1Client.Subscriptions(deploy.Config.Namespace).Get(context.TODO(), deploy.Config.SubscriptionName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering Subscription does not exist")
+		deploy.Logger.Warnf("The metering Subscription does not exist")
 		return nil
 	}
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -85,27 +85,27 @@ func (deploy *Deployer) uninstallMeteringCSV() error {
 	}
 
 	if sub.Status.CurrentCSV == "" {
-		deploy.logger.Warnf("Failed to get the 'status.currentCSV' stored in the %s metering Subscription resource", deploy.config.SubscriptionName)
+		deploy.Logger.Warnf("Failed to get the 'status.currentCSV' stored in the %s metering Subscription resource", deploy.Config.SubscriptionName)
 		return nil
 	}
 
 	csvName := sub.Status.CurrentCSV
-	deploy.logger.Infof("Found an existing metering subscription, attempting to delete the %s CSV", csvName)
+	deploy.Logger.Infof("Found an existing metering subscription, attempting to delete the %s CSV", csvName)
 
-	csv, err := deploy.olmV1Alpha1Client.ClusterServiceVersions(deploy.config.Namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
+	csv, err := deploy.OLMV1Alpha1Client.ClusterServiceVersions(deploy.Config.Namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering CSV resource does not exist", csvName)
+		deploy.Logger.Warnf("The %s metering CSV resource does not exist", csvName)
 		return nil
 	}
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
-	err = deploy.olmV1Alpha1Client.ClusterServiceVersions(deploy.config.Namespace).Delete(context.TODO(), csv.Name, metav1.DeleteOptions{})
+	err = deploy.OLMV1Alpha1Client.ClusterServiceVersions(deploy.Config.Namespace).Delete(context.TODO(), csv.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete the %s metering CSV resource: %v", csvName, err)
 	}
-	deploy.logger.Infof("Deleted the %s metering CSV resource in the %s namespace", csvName, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering CSV resource in the %s namespace", csvName, deploy.Config.Namespace)
 
 	return nil
 }
@@ -131,7 +131,7 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 		return fmt.Errorf("failed to delete the metering role binding: %v", err)
 	}
 
-	if deploy.config.DeleteCRB {
+	if deploy.Config.DeleteCRBs {
 		err = deploy.uninstallMeteringClusterRole()
 		if err != nil {
 			return fmt.Errorf("failed to delete the metering cluster role: %v", err)
@@ -151,16 +151,16 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 			return fmt.Errorf("failed to delete the reporting-operator ClusterRoleBinding resources: %v", err)
 		}
 	} else {
-		deploy.logger.Infof("Skipped deleting the metering cluster role resources")
+		deploy.Logger.Infof("Skipped deleting the metering cluster role resources")
 	}
 
-	if deploy.config.DeletePVCs {
+	if deploy.Config.DeletePVCs {
 		err = deploy.uninstallMeteringPVCs()
 		if err != nil {
 			return fmt.Errorf("failed to delete the metering PVCs: %v", err)
 		}
 	} else {
-		deploy.logger.Infof("Skipped deleting the metering PVCs")
+		deploy.Logger.Infof("Skipped deleting the metering PVCs")
 	}
 
 	return nil
@@ -175,118 +175,118 @@ func (deploy *Deployer) uninstallMeteringResources() error {
 // so we need to explicitly delete them during cleanup.
 func (deploy *Deployer) uninstallMeteringPVCs() error {
 	// Attempt to get a list of PVCs that match the hdfs or hive labels
-	pvcs, err := deploy.client.CoreV1().PersistentVolumeClaims(deploy.config.Namespace).List(context.TODO(), metav1.ListOptions{
+	pvcs, err := deploy.Client.CoreV1().PersistentVolumeClaims(deploy.Config.Namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app=hdfs",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list all the metering PVCs in the %s namespace: %v", deploy.config.Namespace, err)
+		return fmt.Errorf("failed to list all the metering PVCs in the %s namespace: %v", deploy.Config.Namespace, err)
 	}
 	if len(pvcs.Items) == 0 {
-		deploy.logger.Warnf("The HDFS PVCs don't exist")
+		deploy.Logger.Warnf("The HDFS PVCs don't exist")
 		return nil
 	}
 
 	for _, pvc := range pvcs.Items {
-		err = deploy.client.CoreV1().PersistentVolumeClaims(deploy.config.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+		err = deploy.Client.CoreV1().PersistentVolumeClaims(deploy.Config.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
-			deploy.logger.Warnf("The %s PVC does not exist", pvc.Name)
+			deploy.Logger.Warnf("The %s PVC does not exist", pvc.Name)
 			continue
 		}
 		if err != nil {
 			// TODO: we should be returning an array of errors instead of a single err
 			return fmt.Errorf("failed to delete the %s PVC: %v", pvc.Name, err)
 		}
-		deploy.logger.Infof("Deleted the %s PVC in the %s namespace", pvc.Name, deploy.config.Namespace)
+		deploy.Logger.Infof("Deleted the %s PVC in the %s namespace", pvc.Name, deploy.Config.Namespace)
 	}
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringDeployment() error {
-	err := deploy.client.AppsV1().Deployments(deploy.config.Namespace).Delete(context.TODO(), deploy.config.OperatorResources.Deployment.Name, metav1.DeleteOptions{})
+	err := deploy.Client.AppsV1().Deployments(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.OperatorResources.Deployment.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering deployment doesn't exist")
+		deploy.Logger.Warnf("The metering deployment doesn't exist")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the metering deployment")
+	deploy.Logger.Infof("Deleted the metering deployment")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringServiceAccount() error {
-	err := deploy.client.CoreV1().ServiceAccounts(deploy.config.Namespace).Delete(context.TODO(), deploy.config.OperatorResources.ServiceAccount.Name, metav1.DeleteOptions{})
+	err := deploy.Client.CoreV1().ServiceAccounts(deploy.Config.Namespace).Delete(context.TODO(), deploy.Config.OperatorResources.ServiceAccount.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The metering service account doesn't exist")
+		deploy.Logger.Warnf("The metering service account doesn't exist")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the metering serviceaccount")
+	deploy.Logger.Infof("Deleted the metering serviceaccount")
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringRoleBinding() error {
-	res := deploy.config.OperatorResources.RoleBinding
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.RoleBinding
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().RoleBindings(deploy.config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().RoleBindings(deploy.Config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering RoleBinding resource in the %s namespace doesn't exist", res.Name, deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s metering RoleBinding resource in the %s namespace doesn't exist", res.Name, deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering RoleBinding resource in the %s namespace", res.Name, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering RoleBinding resource in the %s namespace", res.Name, deploy.Config.Namespace)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringRole() error {
-	res := deploy.config.OperatorResources.Role
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.Role
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().Roles(deploy.config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().Roles(deploy.Config.Namespace).Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering Role resource in the %s namespace doesn't exist", res.Name, deploy.config.Namespace)
+		deploy.Logger.Warnf("The %s metering Role resource in the %s namespace doesn't exist", res.Name, deploy.Config.Namespace)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering Role resource in the %s namespace", res.Name, deploy.config.Namespace)
+	deploy.Logger.Infof("Deleted the %s metering Role resource in the %s namespace", res.Name, deploy.Config.Namespace)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallMeteringClusterRole() error {
-	res := deploy.config.OperatorResources.ClusterRole
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.ClusterRole
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().ClusterRoles().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().ClusterRoles().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering ClusterRole resource doesn't exist", res.Name)
+		deploy.Logger.Warnf("The %s metering ClusterRole resource doesn't exist", res.Name)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering ClusterRole resource", res.Name)
+	deploy.Logger.Infof("Deleted the %s metering ClusterRole resource", res.Name)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
-	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.Config.Namespace)
 
 	// Attempt to delete all of the ClusterRoles that the metering-ansible-operator
 	// creates for the reporting-operator
-	crs, err := deploy.client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
+	crs, err := deploy.Client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
@@ -294,17 +294,17 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
 	}
 
 	if len(crs.Items) == 0 {
-		deploy.logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRole resources")
+		deploy.Logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRole resources")
 		return nil
 	}
 
 	var errArr []string
 	for _, cr := range crs.Items {
-		err = deploy.client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
+		err = deploy.Client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
 		if err != nil {
 			errArr = append(errArr, fmt.Sprintf("failed to delete the %s ClusterRole resource: %v", cr.Name, err))
 		}
-		deploy.logger.Infof("Deleted the %s ClusterRole resource", cr.Name)
+		deploy.Logger.Infof("Deleted the %s ClusterRole resource", cr.Name)
 	}
 
 	if len(errArr) != 0 {
@@ -315,27 +315,27 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRole() error {
 }
 
 func (deploy *Deployer) uninstallMeteringClusterRoleBinding() error {
-	res := deploy.config.OperatorResources.ClusterRoleBinding
-	res.Name = deploy.config.Namespace + "-" + res.Name
+	res := deploy.Config.OperatorResources.ClusterRoleBinding
+	res.Name = deploy.Config.Namespace + "-" + res.Name
 
-	err := deploy.client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
+	err := deploy.Client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), res.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s metering ClusterRoleBinding resource doesn't exist", res.Name)
+		deploy.Logger.Warnf("The %s metering ClusterRoleBinding resource doesn't exist", res.Name)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	deploy.logger.Infof("Deleted the %s metering ClusterRoleBinding resource", res.Name)
+	deploy.Logger.Infof("Deleted the %s metering ClusterRoleBinding resource", res.Name)
 
 	return nil
 }
 
 func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
-	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.config.Namespace)
+	labelSelector := fmt.Sprintf("app=reporting-operator,metering.openshift.io/ns-prune=%s", deploy.Config.Namespace)
 
 	// attempt to delete any of the clusterroles the reporting-operator creates
-	crbs, err := deploy.client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
+	crbs, err := deploy.Client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
@@ -343,17 +343,17 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
 	}
 
 	if len(crbs.Items) == 0 {
-		deploy.logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRoleBinding resources")
+		deploy.Logger.Warnf("Failed to find any 'app=reporting-operator' ClusterRoleBinding resources")
 		return nil
 	}
 
 	var errArr []string
 	for _, crb := range crbs.Items {
-		err = deploy.client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{})
+		err = deploy.Client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{})
 		if err != nil {
 			errArr = append(errArr, fmt.Sprintf("failed to delete the %s ClusterRoleBinding resource: %v", crb.Name, err))
 		}
-		deploy.logger.Infof("Deleted the %s ClusterRoleBinding resource", crb.Name)
+		deploy.Logger.Infof("Deleted the %s ClusterRoleBinding resource", crb.Name)
 	}
 	if len(errArr) != 0 {
 		return fmt.Errorf(strings.Join(errArr, "\n"))
@@ -363,7 +363,7 @@ func (deploy *Deployer) uninstallReportingOperatorClusterRoleBinding() error {
 }
 
 func (deploy *Deployer) uninstallMeteringCRDs() error {
-	for _, crd := range deploy.config.OperatorResources.CRDs {
+	for _, crd := range deploy.Config.OperatorResources.CRDs {
 		err := deploy.uninstallMeteringCRD(crd)
 		if err != nil {
 			return err
@@ -374,15 +374,15 @@ func (deploy *Deployer) uninstallMeteringCRDs() error {
 }
 
 func (deploy *Deployer) uninstallMeteringCRD(resource CRD) error {
-	err := deploy.apiExtClient.CustomResourceDefinitions().Delete(context.TODO(), resource.Name, metav1.DeleteOptions{})
+	err := deploy.APIExtClient.CustomResourceDefinitions().Delete(context.TODO(), resource.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		deploy.logger.Warnf("The %s CRD doesn't exist", resource.Name)
+		deploy.Logger.Warnf("The %s CRD doesn't exist", resource.Name)
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to remove the %s CRD: %v", resource.Name, err)
 	}
-	deploy.logger.Infof("Deleted the %s CRD", resource.Name)
+	deploy.Logger.Infof("Deleted the %s CRD", resource.Name)
 
 	return nil
 }

--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -187,7 +187,7 @@ func (ctx *DeployerCtx) NewLocalCtx() *LocalCtx {
 func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.ReportingFramework, error) {
 	err := installFunc()
 	if err != nil {
-		installErrMsg = fmt.Sprintf("failed to install metering: %v", err)
+		installErrMsg := fmt.Sprintf("failed to install metering: %v", err)
 		ctx.Logger.Infof(installErrMsg)
 		return nil, fmt.Errorf(installErrMsg)
 	}
@@ -214,16 +214,17 @@ func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.Rep
 		OLMClient:     ctx.OLMV1Alpha1Client,
 		Logger:        ctx.Logger.WithField("component", "podWaiter"),
 	}
-	err := pw.WaitForPods(ctx.Namespace, ctx.TargetPodsCount)
+	err = pw.WaitForPods(ctx.Namespace, ctx.TargetPodsCount)
 	if err != nil {
 		if err == ErrInstallPlanFailed {
 			return nil, ErrInstallPlanFailed
 		}
 		return nil, fmt.Errorf("error waiting for metering pods to become ready: %v", err)
 	}
-	ctx.Logger.Infof("Installing metering took %v", time.Since(start))
 
+	ctx.Logger.Infof("Installing metering took %v", time.Since(start))
 	ctx.Logger.Infof("Getting the service account %s", reportingOperatorServiceAccountName)
+
 	routeBearerToken, err := GetServiceAccountToken(
 		ctx.Client,
 		initialDelay,
@@ -273,10 +274,6 @@ func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.Rep
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct a reportingframework: %v", err)
-	}
-
-	if installErrMsg != "" {
-		return rf, fmt.Errorf(installErrMsg)
 	}
 
 	return rf, nil

--- a/test/deployframework/context.go
+++ b/test/deployframework/context.go
@@ -185,14 +185,6 @@ func (ctx *DeployerCtx) NewLocalCtx() *LocalCtx {
 // resources to become ready in order to proceeed with running the reporting tests.
 // This returns an initialized reportingframework object, or an error if there is any.
 func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.ReportingFramework, error) {
-	var (
-		installErrMsg    string
-		routeBearerToken string
-		installErr       bool
-	)
-
-	// If we expect an install error, and there was an install error, then delay returning
-	// that error message until after the reportingframework has been constructed.
 	err := installFunc()
 	if err != nil {
 		installErrMsg = fmt.Sprintf("failed to install metering: %v", err)
@@ -200,66 +192,63 @@ func (ctx *DeployerCtx) Setup(installFunc func() error) (*reportingframework.Rep
 		return nil, fmt.Errorf(installErrMsg)
 	}
 
-	if !installErr {
-		if ctx.RunTestLocal {
-			ctx.LocalCtx = ctx.NewLocalCtx()
-			err = ctx.LocalCtx.RunMeteringOperatorLocal()
-			if err != nil {
-				return nil, fmt.Errorf("failed to run the metering-operator docker container: %v", err)
-			}
-		}
-
-		ctx.Logger.Infof("Waiting for the metering pods in the %s namespace to be ready", ctx.Namespace)
-		start := time.Now()
-		initialDelay := 10 * time.Second
-		if ctx.RunDevSetup {
-			initialDelay = 1 * time.Second
-		}
-
-		pw := &PodWaiter{
-			InitialDelay:  initialDelay,
-			TimeoutPeriod: waitingForPodsTimeoutPeriod,
-			Client:        ctx.Client,
-			OLMClient:     ctx.OLMV1Alpha1Client,
-			Logger:        ctx.Logger.WithField("component", "podWaiter"),
-		}
-		err := pw.WaitForPods(ctx.Namespace, ctx.TargetPodsCount)
+	if ctx.RunTestLocal {
+		ctx.LocalCtx = ctx.NewLocalCtx()
+		err = ctx.LocalCtx.RunMeteringOperatorLocal()
 		if err != nil {
-			if err == ErrInstallPlanFailed {
-				return nil, ErrInstallPlanFailed
-			}
-			return nil, fmt.Errorf("error waiting for metering pods to become ready: %v", err)
+			return nil, fmt.Errorf("failed to run the metering-operator docker container: %v", err)
 		}
+	}
 
-		ctx.Logger.Infof("Installing metering took %v", time.Since(start))
-		ctx.Logger.Infof("Getting the service account %s", reportingOperatorServiceAccountName)
+	ctx.Logger.Infof("Waiting for the metering pods in the %s namespace to be ready", ctx.Namespace)
+	start := time.Now()
+	initialDelay := 10 * time.Second
+	if ctx.RunDevSetup {
+		initialDelay = 1 * time.Second
+	}
 
-		routeBearerToken, err = GetServiceAccountToken(
-			ctx.Client,
-			initialDelay,
-			waitingForServiceAccountTimePeriod,
-			ctx.Namespace,
-			reportingOperatorServiceAccountName,
-		)
+	pw := &PodWaiter{
+		InitialDelay:  initialDelay,
+		TimeoutPeriod: waitingForPodsTimeoutPeriod,
+		Client:        ctx.Client,
+		OLMClient:     ctx.OLMV1Alpha1Client,
+		Logger:        ctx.Logger.WithField("component", "podWaiter"),
+	}
+	err := pw.WaitForPods(ctx.Namespace, ctx.TargetPodsCount)
+	if err != nil {
+		if err == ErrInstallPlanFailed {
+			return nil, ErrInstallPlanFailed
+		}
+		return nil, fmt.Errorf("error waiting for metering pods to become ready: %v", err)
+	}
+	ctx.Logger.Infof("Installing metering took %v", time.Since(start))
+
+	ctx.Logger.Infof("Getting the service account %s", reportingOperatorServiceAccountName)
+	routeBearerToken, err := GetServiceAccountToken(
+		ctx.Client,
+		initialDelay,
+		waitingForServiceAccountTimePeriod,
+		ctx.Namespace,
+		reportingOperatorServiceAccountName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the route bearer token: %v", err)
+	}
+
+	if ctx.RunTestLocal {
+		useHTTPSAPI = false
+		useRouteForReportingAPI = false
+		useKubeProxyForReportingAPI = false
+		reportingAPIURL = fmt.Sprintf("%s://%s:%d", httpScheme, localAddr, apiPort)
+
+		err = ctx.LocalCtx.RunReportingOperatorLocal(apiPort, metricsPort, pprofPort, routeBearerToken)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get the route bearer token: %v", err)
+			return nil, fmt.Errorf("failed to run the reporting-operator locally: %v", err)
 		}
-
-		if ctx.RunTestLocal {
-			useHTTPSAPI = false
-			useRouteForReportingAPI = false
-			useKubeProxyForReportingAPI = false
-			reportingAPIURL = fmt.Sprintf("%s://%s:%d", httpScheme, localAddr, apiPort)
-
-			err = ctx.LocalCtx.RunReportingOperatorLocal(apiPort, metricsPort, pprofPort, routeBearerToken)
-			if err != nil {
-				return nil, fmt.Errorf("failed to run the reporting-operator locally: %v", err)
-			}
-			reportingAPIHealthCheckURL := fmt.Sprintf("%s/%s", reportingAPIURL, healthCheckEndpoint)
-			err := waitForURLToReportStatusOK(ctx.Logger, reportingAPIHealthCheckURL, healthCheckTimeoutPeriod)
-			if err != nil {
-				return nil, fmt.Errorf("failed to wait for the reporting-operator to become healthy: %v", err)
-			}
+		reportingAPIHealthCheckURL := fmt.Sprintf("%s/%s", reportingAPIURL, healthCheckEndpoint)
+		err := waitForURLToReportStatusOK(ctx.Logger, reportingAPIHealthCheckURL, healthCheckTimeoutPeriod)
+		if err != nil {
+			return nil, fmt.Errorf("failed to wait for the reporting-operator to become healthy: %v", err)
 		}
 	}
 

--- a/test/deployframework/framework.go
+++ b/test/deployframework/framework.go
@@ -34,13 +34,16 @@ const (
 	meteringconfigMetadataName          = "operator-metering"
 	reportingOperatorServiceAccountName = "reporting-operator"
 
-	defaultTargetPods        = 7
-	defaultPlatform          = "openshift"
-	defaultDeleteNamespace   = true
-	defaultDeleteCRB         = true
-	defaultSubscriptionName  = "metering-ocp"
-	defaultCatalogSourceName = "metering-dev-catalogsource"
-	defaultPackageName       = "metering-ocp"
+	DefaultTargetPods        = 7
+	DefaultPlatform          = "openshift"
+	DefaultSubscriptionName  = "metering-ocp"
+	DefaultCatalogSourceName = "metering-dev-catalogsource"
+	DefaultPackageName       = "metering-ocp"
+
+	DefaultDeleteNamespace = true
+	DefaultDeleteCRB       = true
+	DefaultDeletePVC       = true
+	DefaultDeleteCRD       = false
 
 	manifestsDeployDir = "manifests/deploy"
 	olmManifestsDir    = "olm_deploy/manifests/"
@@ -113,7 +116,7 @@ func New(logger logrus.FieldLogger, runLocal, runDevSetup bool, nsPrefix, repoDi
 		return nil, fmt.Errorf("failed to stat the %s path to the manifest/deploy directory: %v", manifestsDir, err)
 	}
 
-	operatorResources, err := deploy.ReadMeteringAnsibleOperatorManifests(manifestsDir, defaultPlatform)
+	operatorResources, err := deploy.ReadMeteringAnsibleOperatorManifests(manifestsDir, DefaultPlatform)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize objects from manifests: %v", err)
 	}
@@ -149,6 +152,10 @@ func (df *DeployFramework) NewDeployerConfig(
 	catalogSourceName,
 	catalogSourceNamespace,
 	subscriptionChannel string,
+	deleteNamespace,
+	deleteCRDs,
+	deleteCRBs,
+	deletePVCs bool,
 	spec metering.MeteringConfigSpec,
 ) (*deploy.Config, error) {
 	meteringConfig := &metering.MeteringConfig{
@@ -195,11 +202,13 @@ func (df *DeployFramework) NewDeployerConfig(
 		Namespace:              namespace,
 		Repo:                   meteringOperatorImageRepo,
 		Tag:                    meteringOperatorImageTag,
-		Platform:               defaultPlatform,
-		DeleteNamespace:        defaultDeleteNamespace,
-		DeleteCRB:              defaultDeleteCRB,
-		SubscriptionName:       defaultSubscriptionName,
-		PackageName:            defaultPackageName,
+		Platform:               DefaultPlatform,
+		DeleteNamespace:        deleteNamespace,
+		DeleteCRDs:             deleteCRDs,
+		DeleteCRBs:             deleteCRBs,
+		DeletePVCs:             deletePVCs,
+		SubscriptionName:       DefaultSubscriptionName,
+		PackageName:            DefaultPackageName,
 		CatalogSourceName:      catalogSourceName,
 		CatalogSourceNamespace: catalogSourceNamespace,
 		Channel:                subscriptionChannel,

--- a/test/deployframework/framework_test.go
+++ b/test/deployframework/framework_test.go
@@ -26,21 +26,36 @@ func TestNewDeployerConfig(t *testing.T) {
 	testCatalogSourceNamespace := "marketplace"
 	testSubscriptionChannel := "v0.0.1"
 
-	cfg, err := df.NewDeployerConfig(testNamespace, testMeteringOpRepo, testMeteringOpTag, testReportingOpRepo, testReportingOpTag, testCatalogSourceName, testCatalogSourceNamespace, testSubscriptionChannel, spec)
+	cfg, err := df.NewDeployerConfig(
+		testNamespace,
+		testMeteringOpRepo,
+		testMeteringOpTag,
+		testReportingOpRepo,
+		testReportingOpTag,
+		testCatalogSourceName,
+		testCatalogSourceNamespace,
+		testSubscriptionChannel,
+		DefaultDeleteNamespace,
+		DefaultDeleteCRD,
+		DefaultDeleteCRB,
+		DefaultDeletePVC,
+		spec)
 	require.NoError(t, err)
 
 	expectedCfg := &deploy.Config{
 		Namespace:              testNamespace,
 		Repo:                   testMeteringOpRepo,
 		Tag:                    testMeteringOpTag,
-		Platform:               defaultPlatform,
-		SubscriptionName:       defaultSubscriptionName,
-		PackageName:            defaultPackageName,
+		Platform:               DefaultPlatform,
+		SubscriptionName:       DefaultSubscriptionName,
+		PackageName:            DefaultPackageName,
 		CatalogSourceName:      testCatalogSourceName,
 		CatalogSourceNamespace: testCatalogSourceNamespace,
 		Channel:                testSubscriptionChannel,
-		DeleteCRB:              defaultDeleteCRB,
-		DeleteNamespace:        defaultDeleteNamespace,
+		DeleteNamespace:        DefaultDeleteNamespace,
+		DeleteCRDs:             DefaultDeleteCRD,
+		DeleteCRBs:             DefaultDeleteCRB,
+		DeletePVCs:             DefaultDeletePVC,
 		ExtraNamespaceLabels: map[string]string{
 			"name": fmt.Sprintf("%s-%s", df.NamespacePrefix, testNamespaceLabel),
 		},

--- a/test/deployframework/registry.go
+++ b/test/deployframework/registry.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (df *DeployFramework) CreateCatalogSourceFromIndex(indexImage string) (string, string, error) {
-	catalogSourceName := df.NamespacePrefix + "-" + defaultCatalogSourceName
+	catalogSourceName := df.NamespacePrefix + "-" + DefaultCatalogSourceName
 
 	catalogSource, err := df.OLMV1Alpha1Client.CatalogSources(registryDeployNamespace).Get(context.TODO(), catalogSourceName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -76,7 +76,7 @@ func (df *DeployFramework) CreateRegistryResources(registryImage, meteringOperat
 	}
 
 	var catalogSource *olmv1alpha1.CatalogSource
-	catalogSourceName := df.NamespacePrefix + "-" + defaultCatalogSourceName
+	catalogSourceName := df.NamespacePrefix + "-" + DefaultCatalogSourceName
 
 	catalogSource, err = df.OLMV1Alpha1Client.CatalogSources(registryDeployNamespace).Get(context.TODO(), catalogSourceName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -190,6 +190,9 @@ func (df *DeployFramework) WaitForPackageManifest(name, namespace, subscriptionC
 					ready = true
 				}
 			}
+		}
+		if !ready {
+			df.Logger.Warnf("The metering-ocp packagemanifest is present but the %s channel is not present", subscriptionChannel)
 		}
 
 		return ready, nil

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -491,8 +491,6 @@ func TestMeteringUpgrades(t *testing.T) {
 				upgradeFromSubscriptionChannel,
 				subscriptionChannel,
 				testOutputPath,
-				testCase.ExpectInstallErrMsg,
-				testCase.ExpectInstallErr,
 				testCase.PurgeReports,
 				testCase.PurgeReportDataSources,
 				testCase.InstallSubTest,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"github.com/kube-reporting/metering-operator/test/deployframework"
@@ -172,14 +175,55 @@ type InstallTestCase struct {
 
 type PreInstallFunc func(ctx *deployframework.DeployerCtx) error
 
+func TestInvalidMeteringConfigs(t *testing.T) {
+	namespace := fmt.Sprintf("%s-invalid-meteringconfigs", namespacePrefix)
+	ns, err := createTestingNamespace(df.Client, namespace)
+	require.NoError(t, err, "failed to successfully create the %s testing namespace", namespace)
+	require.NotEmpty(t, ns.Name, "expected the testing namespace would not be nil")
+
+	tt := []struct {
+		Name                           string
+		ExpectInstallErrMsg            []string
+		MeteringConfigManifestFileName string
+	}{
+		{
+			Name: "missing-storage-spec",
+			ExpectInstallErrMsg: []string{
+				"spec.storage in body is required|spec.storage: Required value",
+			},
+			MeteringConfigManifestFileName: "missing-storage.yaml",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t := t
+
+		mc, err := testhelpers.DecodeMeteringConfigManifest(repoPath, testMeteringConfigManifestsPath, tc.MeteringConfigManifestFileName)
+		require.NoError(t, err, "failed to successfully decode the YAML MeteringConfig manifest")
+
+		_, err = df.MeteringClient.MeteringConfigs(ns.Name).Create(context.Background(), mc, metav1.CreateOptions{})
+		testhelpers.AssertErrorContainsErrorMsgs(t, err, tc.ExpectInstallErrMsg)
+	}
+
+	// In the case that `make e2e-dev` has been specified, avoid
+	// deleting the testing namespace used to validate the MC's.
+	if runDevSetup {
+		return
+	}
+
+	// May need to account for apierrors.IsNotFound(err) just to reduce
+	// any potential e2e flakes and return w/o an error
+	err = df.Client.CoreV1().Namespaces().Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "failed to delete the %s testing namespace", ns.Name)
+}
+
 func TestManualMeteringInstall(t *testing.T) {
 	testInstallConfigs := []struct {
 		Name                           string
 		MeteringOperatorImageRepo      string
 		MeteringOperatorImageTag       string
 		Skip                           bool
-		ExpectInstallErr               bool
-		ExpectInstallErrMsg            []string
 		InstallSubTests                []InstallTestCase
 		PreInstallFunc                 PreInstallFunc
 		MeteringConfigManifestFilename string
@@ -196,7 +240,7 @@ func TestManualMeteringInstall(t *testing.T) {
 			// any new machine. The result is the new machines that get
 			// provisioned, don't have this custom node label we added in
 			// the preInstallFunc closure.
-			Skip:           true,
+			Skip:           !testing.Short(),
 			PreInstallFunc: customNodeSelectorFunc,
 			InstallSubTests: []InstallTestCase{
 				{
@@ -213,10 +257,6 @@ func TestManualMeteringInstall(t *testing.T) {
 				{
 					Name:     "testMeteringAnsibleOperatorMetricsWork",
 					TestFunc: testMeteringAnsibleOperatorMetricsWork,
-				},
-				{
-					Name:     "testPrometheusConnectorWorks",
-					TestFunc: testPrometheusConnectorWorks,
 				},
 				{
 					Name:     "testReportingOperatorServiceCABundleExists",
@@ -388,8 +428,6 @@ func TestManualMeteringInstall(t *testing.T) {
 				catalogSourceNamespace,
 				subscriptionChannel,
 				testOutputPath,
-				testCase.ExpectInstallErrMsg,
-				testCase.ExpectInstallErr,
 				testCase.PreInstallFunc,
 				testCase.InstallSubTests,
 			)
@@ -417,7 +455,6 @@ func TestMeteringUpgrades(t *testing.T) {
 			PurgeReports:              true,
 			PurgeReportDataSources:    true,
 			Skip:                      false,
-			ExpectInstallErrMsg:       []string{},
 			InstallSubTest: InstallTestCase{
 				Name:     "testReportingProducesData",
 				TestFunc: testReportingProducesData,

--- a/test/e2e/metering_upgrade_test.go
+++ b/test/e2e/metering_upgrade_test.go
@@ -23,6 +23,35 @@ const (
 	upgradeFromImage                  = "quay.io/tflannag/metering-index:4.5"
 )
 
+type InstallConfig struct {
+	CatalogSourceName      string
+	CatalogSourceNamespace string
+	PackageName            string
+	SubscriptionChannel    string
+}
+
+func NewInstallConfig(name, namespace, packageName, channel string) *InstallConfig {
+	if name == "" {
+		name = "redhat-operators"
+	}
+	if namespace == "" {
+		namespace = "openshift-marketplace"
+	}
+	if packageName == "" {
+		packageName = "metering-ocp"
+	}
+	if channel == "" {
+		channel = "4.8"
+	}
+
+	return &InstallConfig{
+		CatalogSourceName:      name,
+		CatalogSourceNamespace: namespace,
+		PackageName:            packageName,
+		SubscriptionChannel:    channel,
+	}
+}
+
 func testManualOLMUpgradeInstall(
 	t *testing.T,
 	testCaseName,
@@ -50,9 +79,7 @@ func testManualOLMUpgradeInstall(
 	require.NoError(t, err, "creating the test case output directory should produce no error")
 
 	testFuncNamespace := fmt.Sprintf("%s-%s", namespacePrefix, strings.ToLower(testCaseName))
-	if len(testFuncNamespace) > kubeNamespaceCharLimit {
-		require.Fail(t, "The length of the test function namespace exceeded the kube namespace limit of %d characters", kubeNamespaceCharLimit)
-	}
+	require.LessOrEqual(t, len(testFuncNamespace), kubeNamespaceCharLimit)
 
 	mc, err := testhelpers.DecodeMeteringConfigManifest(repoPath, testMeteringConfigManifestsPath, manifestFilename)
 	require.NoError(t, err, "failed to successfully decode the YAML MeteringConfig manifest")
@@ -98,7 +125,11 @@ func testManualOLMUpgradeInstall(
 
 	deployerCtx.TestCaseOutputPath = postUpgradeTestOutputDir
 	rf, err = deployerCtx.Upgrade(catalogSourceName, catalogSourceNamespace, subscriptionChannel, purgeReports, purgeReportDataSources)
-	require.NoError(t, err, "upgrading metering should produce no error")
+	if err != nil {
+		gatherErr := deployerCtx.MustGatherMeteringResources(gatherTestArtifactsScript)
+		assert.NoError(t, gatherErr, "gathering metering resources should produce no error")
+		require.NoError(t, err, "upgrading metering should produce no error")
+	}
 
 	// run tests against the upgraded installation
 	postUpgradeTestName := fmt.Sprintf("post-upgrade-%s", testInstallFunction.Name)

--- a/test/e2e/metering_upgrade_test.go
+++ b/test/e2e/metering_upgrade_test.go
@@ -74,6 +74,10 @@ func testManualOLMUpgradeInstall(
 		upgradeFromSubscriptionChannel,
 		preUpgradeTestOutputDir,
 		testInstallFunction.ExtraEnvVars,
+		deployframework.DefaultDeleteNamespace,
+		deployframework.DefaultDeleteCRD,
+		deployframework.DefaultDeleteCRB,
+		deployframework.DefaultDeletePVC,
 		mc.Spec,
 	)
 	require.NoError(t, err, "creating a new deployer context should produce no error")
@@ -83,14 +87,8 @@ func testManualOLMUpgradeInstall(
 		canSafelyRunTest bool
 		rf               *reportingframework.ReportingFramework
 	)
-	rf, err = deployerCtx.Setup(deployerCtx.Deployer.InstallOLM, expectInstallErr)
-	if canSafelyRunTest = testhelpers.AssertCanSafelyRunReportingTests(t, err, expectInstallErr, expectInstallErrMsg); !canSafelyRunTest {
-		// if we encounter an unexpected Setup error, fail this test case
-		// early and gather the metering and OLM resource logs we care about.
-		err = deployerCtx.MustGatherMeteringResources(gatherTestArtifactsScript)
-		assert.NoError(t, err, "gathering metering resources should produce no error")
-		t.Fatal("Exiting test case early as the pre-upgrade tests failed")
-	}
+	rf, err = deployerCtx.Setup(deployerCtx.Deployer.InstallOLM)
+	require.NoError(t, err, "failed to successfully the pre-upgrade metering installation")
 
 	preUpgradeTestName := fmt.Sprintf("pre-upgrade-%s", testInstallFunction.Name)
 	t.Run(preUpgradeTestName, func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of all of the e2e and deploy package changes needed to fix how we handle failed InstallPlan custom resources in the various metering test installations we created.