### PR TITLE
test/e2e: Cleanup install and upgrade test helper functions

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -491,8 +491,6 @@ func TestMeteringUpgrades(t *testing.T) {
 				upgradeFromSubscriptionChannel,
 				subscriptionChannel,
 				testOutputPath,
-				testCase.ExpectInstallErrMsg,
-				testCase.ExpectInstallErr,
 				testCase.PurgeReports,
 				testCase.PurgeReportDataSources,
 				testCase.InstallSubTest,


### PR DESCRIPTION
Update the e2e package and remove all installErr and installErrMsgs
parameter handling.