### PR TITLE
test/e2e: Disable ClusterAutoscaler scaling down testing nodes

### DIFF
--- a/test/e2e/manifests/machines/clusterautoscaler.yaml
+++ b/test/e2e/manifests/machines/clusterautoscaler.yaml
@@ -13,8 +13,4 @@ spec:
       max: 256
       min: 16
   scaleDown:
-    delayAfterAdd: 2m
-    delayAfterDelete: 2m
-    delayAfterFailure: 30s
-    enabled: true
-    unneededTime: 60s
+    enabled: false


### PR DESCRIPTION
Update the clusterautoscaler.yaml YAML manifest that is used to create
a `ClusterAutoscaler` instance in our testing clusters, and disable node
scaling down mechanisms.

We're seeing more and more e2e flakes centered around the
reporting-operator being scaled down at inopportune times, namely when
attempting to get Report results. In the context of our e2e suite, these
additional nodes should be swept up when uninstalling the OCP cluster.

Note: Another way to ensure we're not evicting the reporting-operator
container from a particular node is to add the following label to that
deployment definition:

```yaml
metadata:
  labels:
    cluster-autoscaler.kubernetes.io/safe-to-evict=false
```

Adding this label doesn't make much sense given the reporting-operator
container isn't a workload that we typically care about being evicted,
but in the context of the e2e suite and reducing e2e flakes adding this
label may make sense in the future. Other alternatives include creating
a PodDisruptionBudget resource for the reporting-operator workloads, but
this is an extreme case and like that eviction label, doesn't make much
sense for a non-important workload.