### PR TITLE
Makefile: Add .PHONY target for vendor check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ fmt:
 	@echo path: $(shell pwd)
 	find . -name '*.go' -not -path "./vendor/*" | xargs gofmt -w
 
-# Update dependencies
+.PHONY: vendor
 vendor:
 	go mod tidy
 	go mod vendor


### PR DESCRIPTION
Specify a .PHONY target for the make vendor target. This ensure that
running `make vendor` will always be considered "out-of-date" and all
the modules will commands be run.