### PR TITLE
Bug 1939121: Add deprecation notice to the Metering CSV YAML manifests

### DIFF
--- a/bundle/manifests/meteringoperator.v4.8.0.clusterserviceversion.yaml
+++ b/bundle/manifests/meteringoperator.v4.8.0.clusterserviceversion.yaml
@@ -208,16 +208,24 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.8
     createdAt: "2019-01-01T11:59:59Z"
-    description: Chargeback and reporting tool to provide accountability for how resources
-      are used across a cluster
+    description: The Metering Operator is deprecated and will be removed in a future release.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'
     repository: https://github.com/kube-reporting/metering-operator
     support: Red Hat, Inc.
 spec:
-  displayName: Metering
+  displayName: Metering (Deprecated)
   description: |
+    # Deprecation Notice
+
+    The Metering Operator was **deprecated** in the [OpenShift 4.6 release](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-metering-operator-deprecated).
+
+    In the future, this version of the Metering package may be removed, so please
+    plan accordingly.
+
+    ## Summary
+
     The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).
 
     Read the user guide for more details on [running and viewing your first report](https://docs.openshift.com/container-platform/4.8/metering/metering-using-metering.html).
@@ -257,7 +265,7 @@ spec:
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.8.0"
   minKubeVersion: "1.18.3"
-  maturity: stable
+  maturity: deprecated
   maintainers:
     - email: metering-team@redhat.com
       name: Red Hat

--- a/charts/metering-ansible-operator/values.yaml
+++ b/charts/metering-ansible-operator/values.yaml
@@ -226,8 +226,17 @@ olm:
     version: "4.8.0"
     skipRange: ">=4.5.0 <4.8.0"
     minKubeVersion: 1.18.3
-    displayName: Metering
+    displayName: Metering (Deprecated)
     description: |
+      # Deprecation Notice
+
+      The Metering Operator was **deprecated** in the [OpenShift 4.6 release](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-metering-operator-deprecated).
+
+      In the future, this version of the Metering package may be removed, so please
+      plan accordingly.
+
+      ## Summary
+
       The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).
 
       Read the user guide for more details on [running and viewing your first report](https://docs.openshift.com/container-platform/4.8/metering/metering-using-metering.html).
@@ -268,7 +277,7 @@ olm:
     icon:
       - base64data: PHN2ZyBpZD0iYmI5OWY3NGMtM2VkOS00OWU2LWE0OWQtNDI3ODA5NWU5ZWI4IiBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDcyMS4xNSA3MjEuMTUiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuYjdmMDIwYzgtMjFkMS00NWVmLWE0NTktNzJhNWE0MmE5MjJlIHsKICAgICAgICBmaWxsOiAjZGIzOTI3OwogICAgICB9CgogICAgICAuZjM0NTNmYmYtODk1My00NjE3LWJlNTEtMWZkZDJiOTdiMDBlIHsKICAgICAgICBmaWxsOiAjY2IzNjI4OwogICAgICB9CgogICAgICAuYjFhNGZjNTMtYWFlNS00ZWI5LTliN2ItYTAxYmMxYTU0ZmFjIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICB9CgogICAgICAuYTc4NTliZDQtYjA1My00YzVmLTk5MGQtYzRmNzFkNDgwZTM4IHsKICAgICAgICBmaWxsOiAjZTNlM2UyOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8dGl0bGU+UHJvZHVjdF9JY29uLVJlZF9IYXQtTWV0ZXJpbmctUkdCPC90aXRsZT4KICA8Y2lyY2xlIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIGN4PSIzNjAuNTc1IiBjeT0iMzYwLjU3NSIgcj0iMzU4LjU3NiIvPgogIDxwYXRoIGNsYXNzPSJmMzQ1M2ZiZi04OTUzLTQ2MTctYmU1MS0xZmRkMmI5N2IwMGUiIGQ9Ik02MTUuNTMsMTA4LjkxNiwxMDguNDY0LDYxNS45ODNjMTQwLjE0MywxMzguNjE3LDM2Ni4xMTEsMTM4LjE2NCw1MDUuNjcxLTEuNFM3NTQuMTQ5LDI0OS4wNTksNjE1LjUzLDEwOC45MTZaIi8+CiAgPHBhdGggY2xhc3M9ImIxYTRmYzUzLWFhZTUtNGViOS05YjdiLWEwMWJjMWE1NGZhYyIgZD0iTTM3MC4xMzEsMTYzLjkzMmwxNzAuMyw5OC4zMjFWNDU4LjlsLTE3MC4zLDk4LjMyMUwxOTkuODMzLDQ1OC45VjI2Mi4yNTNsMTcwLjMtOTguMzIxbTAtMjMuMDk0LTEwLDUuNzczLTE3MC4zLDk4LjMyMi0xMCw1Ljc3M1Y0NzAuNDQ0bDEwLDUuNzczLDE3MC4zLDk4LjMyMiwxMCw1Ljc3MywxMC01Ljc3MywxNzAuMy05OC4zMjIsMTAtNS43NzNWMjUwLjcwNmwtMTAtNS43NzMtMTcwLjMtOTguMzIyLTEwLTUuNzczWiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiMWE0ZmM1My1hYWU1LTRlYjktOWI3Yi1hMDFiYzFhNTRmYWMiIHBvaW50cz0iMzU0LjE2NyA1MTMuMjQyIDIyNi43NjggNDM5LjY4OCAyMjYuNzY4IDI5NS4yMjQgMzU0LjE2NyAzNjguNzc4IDM1NC4xNjcgNTEzLjI0MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJhNzg1OWJkNC1iMDUzLTRjNWYtOTkwZC1jNGY3MWQ0ODBlMzgiIHBvaW50cz0iMzg2LjAxNyA1MTMuMjQyIDUxMy40MTYgNDM5LjY4OCA1MTMuNDE2IDI5NS4yMjQgMzg2LjAxNyAzNjguNzc4IDM4Ni4wMTcgNTEzLjI0MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiMWE0ZmM1My1hYWU1LTRlYjktOWI3Yi1hMDFiYzFhNTRmYWMiIHBvaW50cz0iMjQyLjY5MyAyNjcuOTcyIDM3MC4wOTIgMTk0LjQxOCA0OTcuNDkxIDI2Ny45NzIgMzcwLjA5MiAzNDEuNTI2IDI0Mi42OTMgMjY3Ljk3MiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMjg2LjQ4OCAyNjkuMTM0IDI5My4zMDQgMjY0LjczMiAzNzMuOTAxIDMxMS4yNjUgMzY3LjA4NSAzMTUuNjY3IDI4Ni40ODggMjY5LjEzNCIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzAwLjIyNSAyNjkuMTM0IDM0NS43OTIgMjQyLjA3NCAzNjAuNTgxIDI1MC42OTkgMzE1LjAxNCAyNzcuNzU4IDMwMC4yMjUgMjY5LjEzNCIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzIzLjAwOCAyODIuMTYgMzk4LjU2MyAyMzUuODY2IDQxMy4zNTIgMjQ0LjQ5IDMzNy43OTggMjkwLjc4NSAzMjMuMDA4IDI4Mi4xNiIvPgogIDxwb2x5Z29uIGNsYXNzPSJiN2YwMjBjOC0yMWQxLTQ1ZWYtYTQ1OS03MmE1YTQyYTkyMmUiIHBvaW50cz0iMzQ1Ljc5MiAyOTUuMTg3IDQwNi44NCAyNTkuMzQ3IDQyMS42MyAyNjcuOTcyIDM2MC41ODEgMzAzLjgxMSAzNDUuNzkyIDI5NS4xODciLz4KPC9zdmc+Cg==
         mediatype: image/svg+xml
-    maturity: stable
+    maturity: deprecated
     maintainers:
     - name: Red Hat
       email: metering-team@redhat.com
@@ -344,7 +353,7 @@ olm:
       support: Red Hat, Inc.
       createdAt: "2019-01-01T11:59:59Z"
       containerImage: "quay.io/openshift/origin-metering-ansible-operator:4.8"
-      description: 'Chargeback and reporting tool to provide accountability for how resources are used across a cluster'
+      description: 'The Metering Operator is deprecated and will be removed in a future release.'
       repository: https://github.com/kube-reporting/metering-operator
       alm-examples: |-
         [

--- a/manifests/deploy/openshift/olm/bundle/4.8/meteringoperator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/deploy/openshift/olm/bundle/4.8/meteringoperator.v4.8.0.clusterserviceversion.yaml
@@ -208,16 +208,24 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-ansible-operator:4.8
     createdAt: "2019-01-01T11:59:59Z"
-    description: Chargeback and reporting tool to provide accountability for how resources
-      are used across a cluster
+    description: The Metering Operator is deprecated and will be removed in a future release.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'
     repository: https://github.com/kube-reporting/metering-operator
     support: Red Hat, Inc.
 spec:
-  displayName: Metering
+  displayName: Metering (Deprecated)
   description: |
+    # Deprecation Notice
+
+    The Metering Operator was **deprecated** in the [OpenShift 4.6 release](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-metering-operator-deprecated).
+
+    In the future, this version of the Metering package may be removed, so please
+    plan accordingly.
+
+    ## Summary
+
     The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).
 
     Read the user guide for more details on [running and viewing your first report](https://docs.openshift.com/container-platform/4.8/metering/metering-using-metering.html).
@@ -257,7 +265,7 @@ spec:
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.8.0"
   minKubeVersion: "1.18.3"
-  maturity: stable
+  maturity: deprecated
   maintainers:
     - email: metering-team@redhat.com
       name: Red Hat

--- a/manifests/deploy/upstream/olm/bundle/4.8/meteringoperator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/deploy/upstream/olm/bundle/4.8/meteringoperator.v4.8.0.clusterserviceversion.yaml
@@ -208,15 +208,14 @@ metadata:
     certified: "false"
     containerImage: quay.io/coreos/metering-ansible-operator:release-4.8
     createdAt: "2019-01-01T11:59:59Z"
-    description: Chargeback and reporting tool to provide accountability for how resources
-      are used across a cluster
+    description: The Metering Operator is deprecated and will be removed in a future release.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-metering
     operators.openshift.io/capability: '["fips", "cluster-proxy"]'
     repository: https://github.com/kube-reporting/metering-operator
     support: Red Hat, Inc.
 spec:
-  displayName: Metering
+  displayName: Metering (Deprecated)
   description: |
     The Metering Operator is a generic reporting tool to provide accountability for how resources are used across a cluster cherry-picking and storing information from different sources. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster for storage. The Metering Operator is a part of the [Kubernetes Reporting organization](https://github.com/kube-reporting).
 
@@ -257,7 +256,7 @@ spec:
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.8.0"
   minKubeVersion: "1.18.3"
-  maturity: stable
+  maturity: deprecated
   maintainers:
     - email: metering-team@redhat.com
       name: Red Hat


### PR DESCRIPTION
Add deprecation notice to the Metering CSV YAML manifests
  
- Update the name from `Metering` to `Metering (Deprecated)`
- Add deprecation notice to the long description. Link to the 4.6 OpenShift release notes.
- Add deprecation notice to the short description.

![Screenshot from 2021-03-15 14-35-09](https://user-images.githubusercontent.com/9899409/111205076-3629c980-859d-11eb-816e-a473ac093763.png)

Needs to be backported to the release-4.6 branch.